### PR TITLE
Update dot env files

### DIFF
--- a/.env
+++ b/.env
@@ -1,18 +1,5 @@
-KEYCLOAK_ISSUER=https://bbpauth.epfl.ch/auth/realms/BBP
-KEYCLOAK_CLIENT_ID=bbp-sbo-application
-
-NEXT_PUBLIC_NEXUS_URL=https://bbp.epfl.ch/nexus/v1
-
 NEXT_PUBLIC_NEXUS_DEFAULT_ORG=bbp
 NEXT_PUBLIC_NEXUS_DEFAULT_PROJECT=mmb-point-neuron-framework-model
-
-NEXT_PUBLIC_BLUE_NAAS_URL=https://openbluebrain.com/api/bluenaas
-NEXT_PUBLIC_CELL_SVC_BASE_URL=https://cells.sbo.kcp.bbp.epfl.ch
-NEXT_PUBLIC_FEEDBACK_URL=https://bbp.epfl.ch/mmb-beta/api/jira
-NEXT_PUBLIC_KG_INFERENCE_BASE_URL=https://openbluebrain.com/api/kg-inference
-NEXT_PUBLIC_THUMBNAIL_GENERATION_BASE_URL=https://thumbnail-generation-api.kcp.bbp.epfl.ch
-NEXT_PUBLIC_SYNTHESIS_URL=https://synthesis.sbo.kcp.bbp.epfl.ch/synthesis-with-resources
-NEXT_PUBLIC_ME_MODEL_ANALYSIS_WS_URL=wss://yyuu69y9fk.execute-api.us-east-1.amazonaws.com/prod/
 
 NEXT_PUBLIC_DEFAULT_MODEL_RELEASE_NAME=Release 24.1
 NEXT_PUBLIC_DEFAULT_MODEL_RELEASE_DESCRIPTION=AtlasRelease v1.1.0 configuration
@@ -44,14 +31,11 @@ NEXT_PUBLIC_CELL_COMPOSITION_ID=https://bbp.epfl.ch/neurosciencegraph/data/cellc
 NEXT_PUBLIC_CELL_COMPOSITION_TAG=v1.1.0
 
 NEXT_PUBLIC_SYN_PARAM_ASSIGNMENT_RESOURCE_ID=https://bbp.epfl.ch/neurosciencegraph/data/synapticassignment/d57536aa-d576-4b3b-a89b-b7888f24eb21
-
 NEXT_PUBLIC_SYN_PARAM_RESOURCE_ID=https://bbp.epfl.ch/neurosciencegraph/data/synapticparameters/cf25c2bf-e6e4-4367-acd8-94004bfcfe49
 
 NEXT_PUBLIC_ETYPE_MECHANISM_MAP_ID=https://bbp.epfl.ch/data/bbp/mmb-point-neuron-framework-model/27d6009b-7a78-4af3-82c7-2c9f3c0758d2
 
 NEXT_PUBLIC_CONN_INITIAL_RULES_FILE_ID=https://bbp.epfl.ch/neurosciencegraph/data/7e2f41a0-3d84-4142-a38e-734117acb33d
-
 NEXT_PUBLIC_CONN_INITIAL_PARAMS_FILE_ID=https://bbp.epfl.ch/neurosciencegraph/data/2924ab22-086e-42d5-96ee-f9ce46ccf4b4
 
-NEXT_PUBLIC_VIRTUAL_LAB_API_URL=http://localhost:8000
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51P6uAFFE4Bi50cLlatJIc0fUPsP0jQkaCCJ8TTkIYOOLIrLzxX1M9p1kVD11drNqsF9p7yiaumWJ8UHb3ptJJRXB00y3qjYReV

--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,16 @@
-KEYCLOAK_CLIENT_ID=bbp-sbo-application-dev
+KEYCLOAK_ISSUER=https://staging.openbluebrain.com/auth/realms/SBO
+KEYCLOAK_CLIENT_ID=obp-core-web-app-dev
 KEYCLOAK_CLIENT_SECRET=dummy-secret
 
-NEXTAUTH_SECRET=dummy-secret
+NEXTAUTH_SECRET=dummy-secret-for-dev
 
-NEXT_PUBLIC_BBS_ML_BASE_URL=https://openbluebrain.com/api/literature
+NEXT_PUBLIC_NEXUS_URL=https://staging.openbluebrain.com/api/nexus/v1
+
+NEXT_PUBLIC_BLUE_NAAS_URL=https://staging.openbluebrain.com/api/bluenaas
+NEXT_PUBLIC_CELL_SVC_BASE_URL=https://staging.openbluebrain.com/api/circuit
+NEXT_PUBLIC_KG_INFERENCE_BASE_URL=https://staging.openbluebrain.com/api/kg-inference
+NEXT_PUBLIC_THUMBNAIL_GENERATION_BASE_URL=https://staging.openbluebrain.com/api/thumbnail-generation
+NEXT_PUBLIC_SYNTHESIS_URL=https://synthesis.sbo.kcp.bbp.epfl.ch/synthesis-with-resources # TODO: change to staging
+NEXT_PUBLIC_ME_MODEL_ANALYSIS_WS_URL=wss://yyuu69y9fk.execute-api.us-east-1.amazonaws.com/prod/ # TODO: check if correct
+NEXT_PUBLIC_VIRTUAL_LAB_API_URL=https://staging.openbluebrain.com/api/virtual-lab-manager
+NEXT_PUBLIC_BBS_ML_BASE_URL=https://staging.openbluebrain.com/api/literature

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,0 @@
-NEXT_PUBLIC_BBS_ML_BASE_URL=https://openbluebrain.com/api/literature

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -42,7 +42,7 @@ export const env = createEnv({
     NEXT_PUBLIC_BLUE_NAAS_URL: z.string().url(),
     NEXT_PUBLIC_ME_MODEL_ANALYSIS_WS_URL: z.string().url(),
     NEXT_PUBLIC_CELL_SVC_BASE_URL: z.string().url(),
-    NEXT_PUBLIC_FEEDBACK_URL: z.string().url(),
+    NEXT_PUBLIC_FEEDBACK_URL: z.string().url().optional(),
     NEXT_PUBLIC_KG_INFERENCE_BASE_URL: z.string().url(),
     NEXT_PUBLIC_THUMBNAIL_GENERATION_BASE_URL: z.string().url(),
     NEXT_PUBLIC_SYNTHESIS_URL: z.string().url(),


### PR DESCRIPTION
Now local dev server points to the staging environment.

Also, entries which are not common for all environments were moved out of .env, so that in deployments they have to be explicitly provided (otherwise the server will throw an error). This will prevent the leakage of wrong defaults.