### PR TITLE
Fix fonts

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,7 @@ export default async function RootLayout({ children }: RootLayoutProps) {
   return (
     <html
       lang="en"
-      className={`${titilliumWeb.variable} font-sans, ${gabarito.variable} font-geometric, ${DMSerifText.variable} font-serif`}
+      className={`${titilliumWeb.variable} ${gabarito.variable} ${DMSerifText.variable}`}
     >
       <body>
         <Providers session={session}>


### PR DESCRIPTION
These "font-sans, font-serif, font-geometric" are conflicting with each other, basically only the last one is applied for the whole platform. At the same time corresponding css variables are not available in the same level of DOM/CSSOM tree - so at the end some not-that-good-looking default font was applied (as Times in my case).

Now, according to tailwind configuration we have:

```
fontFamily: {
        sans: ['var(--font-titillium-web)', ...fontFamily.sans],
        title: ['var(--font-gabarito)', ...fontFamily.sans],
        serif: ['var(--DMSerifText)', ...fontFamily.serif],
      },
```

Which means we can use `font-sans`, `font-title` and `font-serif` classes inside pages/component to apply corresponding fonts.

By default, sans family is used, in particular - Titillium web. This is defined in `tailwind-preflight.css`:

```
font-family: theme(
    'fontFamily.sans',
    ui-sans-serif,
    ...
```