### PR TITLE
Reflect domain migration in .env.development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,16 +1,16 @@
-KEYCLOAK_ISSUER=https://staging.openbluebrain.com/auth/realms/SBO
+KEYCLOAK_ISSUER=https://staging.openbraininstitute.org/auth/realms/SBO
 KEYCLOAK_CLIENT_ID=obp-core-web-app-dev
 KEYCLOAK_CLIENT_SECRET=dummy-secret
 
 NEXTAUTH_SECRET=dummy-secret-for-dev
 
-NEXT_PUBLIC_NEXUS_URL=https://staging.openbluebrain.com/api/nexus/v1
+NEXT_PUBLIC_NEXUS_URL=https://staging.openbraininstitute.org/api/nexus/v1
 
-NEXT_PUBLIC_BLUE_NAAS_URL=https://staging.openbluebrain.com/api/bluenaas
-NEXT_PUBLIC_CELL_SVC_BASE_URL=https://staging.openbluebrain.com/api/circuit
-NEXT_PUBLIC_KG_INFERENCE_BASE_URL=https://staging.openbluebrain.com/api/kg-inference
-NEXT_PUBLIC_THUMBNAIL_GENERATION_BASE_URL=https://staging.openbluebrain.com/api/thumbnail-generation
+NEXT_PUBLIC_BLUE_NAAS_URL=https://staging.openbraininstitute.org/api/bluenaas
+NEXT_PUBLIC_CELL_SVC_BASE_URL=https://staging.openbraininstitute.org/api/circuit
+NEXT_PUBLIC_KG_INFERENCE_BASE_URL=https://staging.openbraininstitute.org/api/kg-inference
+NEXT_PUBLIC_THUMBNAIL_GENERATION_BASE_URL=https://staging.openbraininstitute.org/api/thumbnail-generation
 NEXT_PUBLIC_SYNTHESIS_URL=https://synthesis.sbo.kcp.bbp.epfl.ch/synthesis-with-resources # TODO: change to staging
 NEXT_PUBLIC_ME_MODEL_ANALYSIS_WS_URL=wss://yyuu69y9fk.execute-api.us-east-1.amazonaws.com/prod/ # TODO: check if correct
-NEXT_PUBLIC_VIRTUAL_LAB_API_URL=https://staging.openbluebrain.com/api/virtual-lab-manager
-NEXT_PUBLIC_BBS_ML_BASE_URL=https://staging.openbluebrain.com/api/literature
+NEXT_PUBLIC_VIRTUAL_LAB_API_URL=https://staging.openbraininstitute.org/api/virtual-lab-manager
+NEXT_PUBLIC_BBS_ML_BASE_URL=https://staging.openbraininstitute.org/api/literature


### PR DESCRIPTION
Most of the services are available under `staging.openbraininstitute.org` domain except of nexus which is still available from `staging.openbluebrain.com`.