### PR TITLE
Mailchimp subscribe route integration

### DIFF
--- a/src/app/api/newsletter/route.ts
+++ b/src/app/api/newsletter/route.ts
@@ -42,10 +42,16 @@ export async function POST(req: Request) {
   }
 
   const url = `https://${API_SERVER}.api.mailchimp.com/3.0/lists/${AUDIENCE_ID}/members`;
+  const tags = ['newsletter', 'website'];
+
+  if (env.NEXT_PUBLIC_DEPLOYMENT_ENV === 'staging') {
+    tags.push('test');
+  }
+
   const data = {
     email_address: emailValidation.data,
     status: 'subscribed',
-    tags: ['newsletter'],
+    tags,
   };
 
   try {
@@ -77,6 +83,7 @@ export async function POST(req: Request) {
       { status: result.status ?? 400 }
     );
   } catch (error) {
+    console.error('error sending newsletter email', error);
     captureException(error, {
       tags: { section: 'landing-page', feature: 'newsletter' },
       extra: {

--- a/src/app/api/newsletter/route.ts
+++ b/src/app/api/newsletter/route.ts
@@ -1,0 +1,95 @@
+import { captureException } from '@sentry/nextjs';
+import { z } from 'zod';
+import { env } from '@/env.mjs';
+
+const API_KEY = env.MAILCHIMP_API_KEY;
+const API_SERVER = env.MAILCHIMP_API_SERVER;
+const AUDIENCE_ID = env.MAILCHIMP_AUDIENCE_ID;
+
+const EmailSchema = z.string().email({ message: 'Please enter a valid email address' });
+
+const ErrorMessageMap = {
+  'Member Exists': "Uh oh, it looks like this email's already subscribed 🧐.",
+  'Invalid Resource': 'Please provide a valid email address.',
+  default: 'Adding new email to newsletter audience failed',
+};
+
+type ErrorMessageMapType = keyof typeof ErrorMessageMap;
+type MailchimpErrorResponse = {
+  type: string;
+  title: ErrorMessageMapType;
+  status: number;
+  detail: string;
+  instance: string;
+};
+type RequestBody = {
+  email: string;
+};
+
+function getErrorMessage(key: ErrorMessageMapType) {
+  return ErrorMessageMap[key] || ErrorMessageMap.default;
+}
+
+export async function POST(req: Request) {
+  const { email } = (await req.json()) as RequestBody;
+  const emailValidation = EmailSchema.safeParse(email);
+
+  if (!emailValidation.success) {
+    return new Response('ValidationError: Please enter a valid email address', {
+      status: 402,
+      statusText: 'Validation error',
+    });
+  }
+
+  const url = `https://${API_SERVER}.api.mailchimp.com/3.0/lists/${AUDIENCE_ID}/members`;
+  const data = {
+    email_address: emailValidation.data,
+    status: 'subscribed',
+    tags: ['newsletter'],
+  };
+
+  try {
+    const response = await fetch(url, {
+      method: 'post',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `api_key ${API_KEY}`,
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (response.ok) {
+      return Response.json(
+        {
+          message: 'Awesome! You have successfully subscribed!',
+        },
+        { status: 200 }
+      );
+    }
+
+    const result = (await response.json()) as MailchimpErrorResponse;
+
+    return Response.json(
+      {
+        message: getErrorMessage(result.title ?? 'default'),
+        reason: result.title ?? 'unknown',
+      },
+      { status: result.status ?? 400 }
+    );
+  } catch (error) {
+    captureException(error, {
+      tags: { section: 'landing-page', feature: 'newsletter' },
+      extra: {
+        email: emailValidation.data,
+      },
+    });
+    return Response.json(
+      {
+        message: 'Oops! There was an error subscribing you to the newsletter',
+        reason:
+          'message' in (error as { message: string }) ? (error as { message: string }).message : '',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -89,7 +89,8 @@ export const env = createEnv({
 
     NEXT_PUBLIC_VIRTUAL_LAB_API_URL: z.string().url(),
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().startsWith("pk_"),
-    NEXT_PUBLIC_BBS_ML_PRIVATE_BASE_URL: z.string().url().optional()
+    NEXT_PUBLIC_BBS_ML_PRIVATE_BASE_URL: z.string().url().optional(),
+    NEXT_PUBLIC_DEPLOYMENT_ENV: z.enum(["staging", "production"]).optional(),
   },
 
   experimental__runtimeEnv: {
@@ -164,5 +165,6 @@ export const env = createEnv({
 
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
     NEXT_PUBLIC_BBS_ML_PRIVATE_BASE_URL: process.env.NEXT_PUBLIC_BBS_ML_PRIVATE_BASE_URL,
+    NEXT_PUBLIC_DEPLOYMENT_ENV: process.env.NEXT_PUBLIC_DEPLOYMENT_ENV
   },
 });

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -15,8 +15,9 @@ export const env = createEnv({
 
     NEXTAUTH_SECRET: z.string().min(5),
 
-    // MAILCHIMP_API_KEY: z.string().min(1),
-    // MAILCHIMP_AUDIENCE_ID: z.string().min(1),
+    MAILCHIMP_API_KEY: z.string().min(1),
+    MAILCHIMP_AUDIENCE_ID: z.string().min(1),
+    MAILCHIMP_API_SERVER: z.string().min(1),
 
     CI_COMMIT_SHORT_SHA: z.string().optional(),
     npm_package_version: z.string().optional(),

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import nextAuthMiddleware, { NextRequestWithAuth } from 'next-auth/middleware';
 import { NextRequest, NextResponse } from 'next/server';
 
-const FREE_ACCESS_PAGES = ['/', '/log-in', '/getting-started', '/about*'];
+const FREE_ACCESS_PAGES = ['/', '/log-in', '/getting-started', '/about*', '/api/newsletter'];
 const ASSETS = [
   '/static*',
   '/images*',


### PR DESCRIPTION
1. Add route to subscribe to newsletter
2. `${basePath}/api/newsletter` will be used in the subscribe form:
```
const options = {
  method: 'POST',
  headers: {'Content-Type': 'application/json'},
  body: '{"email":"xxx@gmail.com"}'
};

fetch('http://localhost:3000/api/newsletter', options)
  .then(response => response.json())
  .then(response => console.log(response))
  .catch(err => console.error(err));
```
**Possible responses:**
```
200: {
          message: 'Awesome! You have successfully subscribed!',
        },
4xx: {
        message: // please look ErrorMessageMap messages
        reason: ""
      },
500:{
        message: 'Oops! There was an error subscribing you to the newsletter',
        reason: ""
      }
```