### PR TITLE
Correctly parse nexus self urls

### DIFF
--- a/src/util/nexus.ts
+++ b/src/util/nexus.ts
@@ -152,13 +152,11 @@ export function getIdFromSelfUrl(selfUrl: string | null) {
 }
 
 export function getOrgFromSelfUrl(selfUrl: string | null) {
-  if (!selfUrl) return null;
-  return selfUrl.replace(`${nexus.url}/resources/`, '').split('/')[0];
+  return selfUrl ? selfUrl.split('/').at(-4) : null;
 }
 
 export function getProjectFromSelfUrl(selfUrl: string | null) {
-  if (!selfUrl) return null;
-  return selfUrl.replace(`${nexus.url}/resources/`, '').split('/')[1];
+  return selfUrl ? selfUrl.split('/').at(-3) : null;
 }
 
 export function getOrgAndProjectFromProjectId(projectId: string): { org: string; project: string } {


### PR DESCRIPTION
The assumption that current nexus deployment domain will be always in the _self is not correct.
It turns out we have some entities with bbp.epfl.ch domain in our current staging nexus.

Current solution parses the url backwards, so the result doesn't depend on the domain.