### PR TITLE
Return back id token permissions for staging GitHub Action

### DIFF
--- a/.github/workflows/publish-staging-image.yml
+++ b/.github/workflows/publish-staging-image.yml
@@ -1,9 +1,14 @@
 name: Deploy to STAGING
 
+permissions:
+  id-token: write # Required for OIDC authentication
+  contents: read # Standard permission for GitHub Actions
+
 on:
   push:
     branches:
       - develop
+      - fix/staging-gh-action
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-staging-image.yml
+++ b/.github/workflows/publish-staging-image.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - develop
-      - fix/staging-gh-action
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
It turns out by accident I've removed id token permissions necessary to do aws auth.