### PR TITLE
Show real balances from API

### DIFF
--- a/src/components/VirtualLab/VirtualLabBanner/VirtualLabMainStatistics.tsx
+++ b/src/components/VirtualLab/VirtualLabBanner/VirtualLabMainStatistics.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CalendarOutlined, UserOutlined } from '@ant-design/icons';
+import { CalendarOutlined, CreditCardOutlined, UserOutlined } from '@ant-design/icons';
 
 import VirtualLabStatistic from '../VirtualLabStatistic';
 import { MembersGroupIcon } from '@/components/icons';
@@ -10,9 +10,10 @@ type Props = {
   admin?: string;
   createdAt?: string;
   userCount?: number | string;
+  balance?: number | string;
 };
 
-export default function VirtualLabMainStatistics({ admin, createdAt, userCount }: Props) {
+export default function VirtualLabMainStatistics({ admin, createdAt, userCount, balance }: Props) {
   const iconStyle = { color: '#69C0FF' };
 
   return (
@@ -37,6 +38,13 @@ export default function VirtualLabMainStatistics({ admin, createdAt, userCount }
           icon={<CalendarOutlined style={iconStyle} />}
           title="Creation date"
           detail={createdAt && formatDate(createdAt)}
+        />
+      )}
+      {balance && (
+        <VirtualLabStatistic
+          icon={<CreditCardOutlined style={iconStyle} />}
+          title="Credit balance"
+          detail={balance}
         />
       )}
     </div>

--- a/src/components/VirtualLab/VirtualLabBanner/index.tsx
+++ b/src/components/VirtualLab/VirtualLabBanner/index.tsx
@@ -3,7 +3,7 @@
 import { ChangeEvent, CSSProperties, ReactNode, useState } from 'react';
 import { useAtomValue } from 'jotai';
 import { unwrap } from 'jotai/utils';
-import { Button, ConfigProvider, Input, Progress } from 'antd';
+import { Button, ConfigProvider, Input } from 'antd';
 import { EditOutlined, UnlockOutlined } from '@ant-design/icons';
 import Link from 'next/link';
 
@@ -12,9 +12,12 @@ import VirtualLabMainStatistics from './VirtualLabMainStatistics';
 import { basePath } from '@/config';
 import { VirtualLab } from '@/types/virtual-lab/lab';
 import useUpdateProject from '@/hooks/useUpdateVirtualLabProject';
-import { useDebouncedCallback, useUnwrappedValue } from '@/hooks/hooks';
-import { virtualLabMembersAtomFamily } from '@/state/virtual-lab/lab';
-import { virtualLabProjectUsersAtomFamily } from '@/state/virtual-lab/projects';
+import { useDebouncedCallback, useLastTruthyValue, useUnwrappedValue } from '@/hooks/hooks';
+import { virtualLabBalanceAtomFamily, virtualLabMembersAtomFamily } from '@/state/virtual-lab/lab';
+import {
+  projectBalanceAtomFamily,
+  virtualLabProjectUsersAtomFamily,
+} from '@/state/virtual-lab/projects';
 import { classNames } from '@/util/utils';
 import { generateLabUrl } from '@/util/virtual-lab/urls';
 import { notification as notify } from '@/api/notifications';
@@ -150,12 +153,14 @@ function BannerWrapper({
   createdAt,
   label,
   userCount,
+  balance,
 }: {
   admin?: string;
   children?: ReactNode;
   createdAt?: string;
   label?: string;
   userCount?: number;
+  balance?: number | string;
 }) {
   return (
     <div className="flex w-full flex-col gap-2">
@@ -164,7 +169,12 @@ function BannerWrapper({
         {children}
       </div>
       <div className="mt-auto">
-        <VirtualLabMainStatistics admin={admin} createdAt={createdAt} userCount={userCount} />
+        <VirtualLabMainStatistics
+          admin={admin}
+          createdAt={createdAt}
+          userCount={userCount}
+          balance={balance}
+        />
       </div>
     </div>
   );
@@ -177,7 +187,8 @@ const linkClassName = 'absolute left-0 top-0 flex h-full w-full justify-between 
 type Props = { createdAt?: string; description?: string; name?: string };
 
 export function DashboardBanner({ createdAt, description, id, name }: Props & { id: string }) {
-  const users = useAtomValue(unwrap(virtualLabMembersAtomFamily(id)));
+  const users = useLastTruthyValue(virtualLabMembersAtomFamily(id));
+  const balance = useLastTruthyValue(virtualLabBalanceAtomFamily({ virtualLabId: id }));
 
   const labUrl = id && generateLabUrl(id);
   const href = `${labUrl}/overview`;
@@ -191,12 +202,12 @@ export function DashboardBanner({ createdAt, description, id, name }: Props & { 
             createdAt={createdAt}
             label="Virtual lab Name"
             userCount={users?.length || 0}
+            balance={balance?.data.balance}
           >
             <StaticValues description={description} name={name} dataTestid="dashboard-banner" />
           </BannerWrapper>
         </Link>
       </BackgroundImg>
-      <BudgetStatus />
     </>
   );
 }
@@ -215,6 +226,7 @@ export function SandboxBanner({ description, name }: Omit<Props, 'createdAt'>) {
 
 export function LabDetailBanner({ vlab }: { vlab?: VirtualLab }) {
   const users = useUnwrappedValue(virtualLabMembersAtomFamily(vlab?.id));
+  const balance = useUnwrappedValue(virtualLabBalanceAtomFamily({ virtualLabId: vlab?.id }));
 
   const updateVlab = useUpdateVirtualLab(vlab?.id);
   const updateDebounced = useDebouncedCallback(updateVlab, [updateVlab], 600);
@@ -242,6 +254,7 @@ export function LabDetailBanner({ vlab }: { vlab?: VirtualLab }) {
             createdAt={vlab?.created_at}
             label="Virtual lab Name"
             userCount={users?.length || 0}
+            balance={balance?.data.balance}
           >
             {isEditable ? (
               <EditableInputs
@@ -257,38 +270,7 @@ export function LabDetailBanner({ vlab }: { vlab?: VirtualLab }) {
           {editBtn}
         </div>
       </BackgroundImg>
-      <BudgetStatus />
     </>
-  );
-}
-
-export function BudgetStatus() {
-  const totalSpent = 100;
-  const totalBudget = 300;
-  const remaining = totalBudget - totalSpent;
-
-  return (
-    <div className="mt-1 flex w-full flex-col items-start bg-primary-8 p-4 text-white">
-      <div className="mb-2 flex w-full justify-between text-primary-1">
-        <p className="font-bold text-white">Budget</p>
-        <p>Total budget: ${totalBudget}</p>
-      </div>
-      <Progress
-        showInfo={false}
-        percent={(totalSpent / totalBudget) * 100}
-        strokeColor="white"
-        trailColor="#91D5FF"
-        className="w-full"
-      />
-      <div className="flex w-full justify-between text-primary-1">
-        <p className="text-neutral-2">
-          Total spent: <span className="font-bold text-white">${totalSpent}</span>
-        </p>
-        <p>
-          Remaining: <span className="font-bold ">${remaining}</span>
-        </p>
-      </div>
-    </div>
   );
 }
 
@@ -310,6 +292,7 @@ export function ProjectDetailBanner({
   virtualLabId,
 }: Props & { projectId: string; virtualLabId: string }) {
   const users = useAtomValue(unwrap(virtualLabProjectUsersAtomFamily({ virtualLabId, projectId })));
+  const balance = useUnwrappedValue(projectBalanceAtomFamily({ virtualLabId, projectId }));
 
   const updateProject = useUpdateProject(virtualLabId, projectId);
 
@@ -354,7 +337,8 @@ export function ProjectDetailBanner({
           admin={users?.find((user) => user.role === 'admin')?.name || '-'}
           createdAt={createdAt}
           label="Project Name"
-          userCount={users?.length || 0}
+          userCount={users?.length ?? 0}
+          balance={balance?.balance ?? ''}
         >
           {isEditable ? (
             <EditableInputs

--- a/src/components/VirtualLab/projects/VirtualLabProjectHomePage/index.tsx
+++ b/src/components/VirtualLab/projects/VirtualLabProjectHomePage/index.tsx
@@ -5,7 +5,7 @@ import { Spin } from 'antd';
 import sortBy from 'lodash/sortBy';
 
 import Member from '@/components/VirtualLab/VirtualLabHomePage/Member';
-import { ProjectDetailBanner, BudgetStatus } from '@/components/VirtualLab/VirtualLabBanner';
+import { ProjectDetailBanner } from '@/components/VirtualLab/VirtualLabBanner';
 import WelcomeUserBanner from '@/components/VirtualLab/VirtualLabHomePage/WelcomeUserBanner';
 import {
   virtualLabProjectDetailsAtomFamily,
@@ -77,7 +77,6 @@ export default function VirtualLabProjectHomePage({
           projectId={projectId!}
           virtualLabId={virtualLabId}
         />
-        <BudgetStatus />
         <div>
           <div className="my-10 text-lg font-bold uppercase">Members</div>
           <UsersHorizontalList virtualLabId={virtualLabId} projectId={projectId} />

--- a/src/components/VirtualLab/projects/VirtualLabProjectList/VirtualLabProjectItem.tsx
+++ b/src/components/VirtualLab/projects/VirtualLabProjectList/VirtualLabProjectItem.tsx
@@ -1,6 +1,11 @@
-import { CalendarOutlined, LoadingOutlined, UserOutlined } from '@ant-design/icons';
+import {
+  CalendarOutlined,
+  CreditCardOutlined,
+  LoadingOutlined,
+  UserOutlined,
+} from '@ant-design/icons';
 import Link from 'next/link';
-import { loadable, unwrap } from 'jotai/utils';
+import { loadable } from 'jotai/utils';
 import { useAtomValue } from 'jotai';
 import { Spin } from 'antd';
 
@@ -10,6 +15,8 @@ import { Project } from '@/types/virtual-lab/projects';
 import { formatDate } from '@/util/utils';
 import { generateVlProjectUrl } from '@/util/virtual-lab/urls';
 import { virtualLabProjectUsersAtomFamily } from '@/state/virtual-lab/projects';
+import { useLastTruthyValue } from '@/hooks/hooks';
+import { virtualLabBalanceAtomFamily } from '@/state/virtual-lab/lab';
 
 function MemberAmount({ virtualLabId, projectId }: { virtualLabId: string; projectId: string }) {
   const users = useAtomValue(
@@ -28,14 +35,18 @@ function MemberAmount({ virtualLabId, projectId }: { virtualLabId: string; proje
 function ProjectStats({ project }: { project: Project }) {
   const { created_at: createdAt, id: projectId, virtual_lab_id: virtualLabId } = project;
 
-  const projectUsers = useAtomValue(
-    unwrap(
-      virtualLabProjectUsersAtomFamily({
-        virtualLabId,
-        projectId,
-      })
-    )
+  const projectUsers = useLastTruthyValue(
+    virtualLabProjectUsersAtomFamily({
+      virtualLabId,
+      projectId,
+    })
   );
+
+  const virtualLabBalance = useLastTruthyValue(virtualLabBalanceAtomFamily({ virtualLabId }));
+
+  const projectBalance = virtualLabBalance?.data.projects?.find(
+    (pr) => pr.proj_id === projectId
+  )?.balance;
 
   const iconStyle = { color: '#69C0FF' };
 
@@ -78,6 +89,12 @@ function ProjectStats({ project }: { project: Project }) {
           icon: <CalendarOutlined style={iconStyle} />,
           key: 'creation-date',
           title: 'Creation date',
+        },
+        {
+          detail: projectBalance ?? 0,
+          icon: <CreditCardOutlined style={iconStyle} />,
+          key: 'credit-balance',
+          title: 'Credit balance',
         },
       ].map(({ detail, icon, key, title }) => (
         <VirtualLabStatistic detail={detail} icon={icon} key={key} title={title} />

--- a/src/state/virtual-lab/lab.ts
+++ b/src/state/virtual-lab/lab.ts
@@ -118,8 +118,10 @@ export const refreshBalanceAtom = atom(null, (get, set) =>
 );
 
 export const virtualLabBalanceAtomFamily = readAtomFamilyWithExpiration(
-  ({ virtualLabId }: { virtualLabId: string }) =>
+  ({ virtualLabId }: { virtualLabId?: string }) =>
     atom(async (get) => {
+      if (!virtualLabId) return;
+
       get(virtualLabBalanceRefreshTriggerAtom);
 
       return getVirtualLabAccountBalance({ virtualLabId, includeProjects: true });


### PR DESCRIPTION
The current change:
* Removes current balance component which has number of usability issues.
* Adds rendering of the balance to VLab/Project details banner.

Before:
<img width="1488" alt="before" src="https://github.com/user-attachments/assets/8ade76c8-7aba-4f84-93df-567aae060271" />

After:
<img width="1483" alt="after" src="https://github.com/user-attachments/assets/79cd01c4-73cc-4b49-9aaa-8085d2cff3f9" />


Removed content is highlighted in red, added - in green.