### PR TITLE
Make me-model validation more reliable

### DIFF
--- a/.deployment-envs/.env.staging
+++ b/.deployment-envs/.env.staging
@@ -5,7 +5,7 @@ NEXT_PUBLIC_CELL_SVC_BASE_URL=https://staging.openbraininstitute.org/api/circuit
 NEXT_PUBLIC_KG_INFERENCE_BASE_URL=https://staging.openbraininstitute.org/api/kg-inference
 NEXT_PUBLIC_THUMBNAIL_GENERATION_BASE_URL=https://staging.openbraininstitute.org/api/thumbnail-generation
 NEXT_PUBLIC_SYNTHESIS_URL=https://synthesis.sbo.kcp.bbp.epfl.ch/synthesis-with-resources # TODO: change to staging
-NEXT_PUBLIC_ME_MODEL_ANALYSIS_WS_URL=wss://yyuu69y9fk.execute-api.us-east-1.amazonaws.com/prod/ # TODO: check if correct
+NEXT_PUBLIC_ME_MODEL_ANALYSIS_WS_URL=wss://kjyo1qi5af.execute-api.us-east-1.amazonaws.com/prod/
 NEXT_PUBLIC_VIRTUAL_LAB_API_URL=https://staging.openbraininstitute.org/api/virtual-lab-manager
 NEXT_PUBLIC_BBS_ML_BASE_URL=https://staging.openbraininstitute.org/api/literature
 

--- a/src/app/api/auth/new-access-token/route.ts
+++ b/src/app/api/auth/new-access-token/route.ts
@@ -1,0 +1,32 @@
+import { getToken } from 'next-auth/jwt';
+import { NextRequest } from 'next/server';
+import { refreshAccessToken } from '@/auth';
+
+export const POST = async (request: NextRequest) => {
+  const token = await getToken({
+    req: request,
+    secret: process.env.NEXTAUTH_SECRET,
+  });
+
+  if (!token) {
+    return new Response('Unauthorized', {
+      status: 401,
+      statusText: 'The supplied authentication is not authorized for this action',
+    });
+  }
+
+  try {
+    const newToken = await refreshAccessToken(token);
+
+    return new Response(JSON.stringify({ accessToken: (newToken as any)?.accessToken }), {
+      status: 200,
+      statusText: 'OK',
+    });
+  } catch (ex) {
+    // captureException(ex);
+    return new Response('Server Error', {
+      status: 500,
+      statusText: `${ex}`,
+    });
+  }
+};

--- a/src/app/app/virtual-lab/lab/[virtualLabId]/project/[projectId]/(secondary)/build/me-model/new/configure/page.tsx
+++ b/src/app/app/virtual-lab/lab/[virtualLabId]/project/[projectId]/(secondary)/build/me-model/new/configure/page.tsx
@@ -132,10 +132,18 @@ export default function NewMEModelPage({ params: { projectId, virtualLabId } }: 
     });
   };
 
+  const fetchFreshAccessToken = async () => {
+    const res = await fetch('/api/auth/new-access-token', { method: 'POST' });
+    const token = await res.json();
+    return token.accessToken;
+  };
+
   const onClickWithValidation = () => {
     setMeModelCreating(true);
+
     createMEModel({ virtualLabId, projectId })
-      .then(() => createValidationModal({ virtualLabId, projectId }))
+      .then(fetchFreshAccessToken)
+      .then((accessToken) => createValidationModal({ virtualLabId, projectId }, accessToken))
       .catch((err) => showErrorNotification(err))
       .finally(() => setMeModelCreating(false));
   };

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -12,7 +12,7 @@ const clientSecret = env.KEYCLOAK_CLIENT_SECRET;
  * `accessToken` and `accessTokenExpires`. If an error occurs,
  * returns the old token and an error property
  */
-async function refreshAccessToken(token: TokenSet) {
+export async function refreshAccessToken(token: TokenSet) {
   try {
     const tokenUrl = `${issuer}/protocol/openid-connect/token`;
 

--- a/src/components/build-section/virtual-lab/me-model/BluePyEModelContainer.tsx
+++ b/src/components/build-section/virtual-lab/me-model/BluePyEModelContainer.tsx
@@ -6,7 +6,6 @@ import { format } from 'date-fns';
 
 import BluePyEModelCls from '@/services/virtual-lab/build/me-model/bluepy-emodel';
 import { meModelSelfUrlAtom, selectedMEModelIdAtom } from '@/state/virtual-lab/build/me-model';
-import { useSessionAtomValue } from '@/hooks/hooks';
 import CentralLoadingWheel from '@/components/CentralLoadingWheel';
 import { VirtualLabInfo } from '@/types/virtual-lab/common';
 import { generateVlProjectUrl } from '@/util/virtual-lab/urls';
@@ -174,9 +173,11 @@ function ValidationError({
 
 export default function BluePyEModelContainer({
   virtualLabInfo,
+  accessToken,
   onClose,
 }: {
   virtualLabInfo: VirtualLabInfo;
+  accessToken: string;
   onClose: () => void;
 }) {
   const router = useRouter();
@@ -184,14 +185,12 @@ export default function BluePyEModelContainer({
   const meModelSelfUrl = useAtomValue(meModelSelfUrlAtom);
   const meModelId = useAtomValue(selectedMEModelIdAtom);
 
-  const session = useSessionAtomValue();
-
   const bluePyEModelInstance = useRef<BluePyEModelCls | null>(null);
 
   const [analysisState, setAnalysisState] = useState<AnalisysState>('initializing');
 
   useEffect(() => {
-    if (bluePyEModelInstance.current || !meModelSelfUrl || !session?.accessToken) return;
+    if (bluePyEModelInstance.current || !meModelSelfUrl || !accessToken) return;
 
     const onInit = () => {
       bluePyEModelInstance.current?.runAnalysis();
@@ -206,7 +205,7 @@ export default function BluePyEModelContainer({
       setAnalysisState('error');
     };
 
-    bluePyEModelInstance.current = new BluePyEModelCls(meModelSelfUrl, session.accessToken, {
+    bluePyEModelInstance.current = new BluePyEModelCls(meModelSelfUrl, accessToken, {
       onInit,
       onAnalysisDone,
       onAnalysisError,
@@ -217,7 +216,7 @@ export default function BluePyEModelContainer({
       bluePyEModelInstance.current.destroy();
       bluePyEModelInstance.current = null;
     };
-  }, [meModelSelfUrl, router, session, virtualLabInfo.projectId, virtualLabInfo.virtualLabId]);
+  }, [meModelSelfUrl, router, accessToken, virtualLabInfo.projectId, virtualLabInfo.virtualLabId]);
 
   if (analysisState === 'initializing') {
     return <ValidationInit virtualLabInfo={virtualLabInfo} meModelId={meModelId as string} />;

--- a/src/components/build-section/virtual-lab/me-model/pending-validation-modal-hook.tsx
+++ b/src/components/build-section/virtual-lab/me-model/pending-validation-modal-hook.tsx
@@ -12,7 +12,7 @@ export function usePendingValidationModal() {
   const destroyRef = useRef<() => void>();
   const onClose = () => destroyRef?.current?.();
 
-  function createModal(virtualLabInfo: VirtualLabInfo) {
+  function createModal(virtualLabInfo: VirtualLabInfo, accessToken: string) {
     const { destroy } = modal.confirm({
       title: null,
       icon: null,
@@ -28,7 +28,13 @@ export function usePendingValidationModal() {
       },
       closeIcon: <CloseOutlined className="text-2xl text-primary-8" />,
       className: '![&>.ant-modal-content]:bg-red-500',
-      content: <BluePyEModelContainer onClose={onClose} virtualLabInfo={virtualLabInfo} />,
+      content: (
+        <BluePyEModelContainer
+          onClose={onClose}
+          virtualLabInfo={virtualLabInfo}
+          accessToken={accessToken}
+        />
+      ),
     });
     destroyRef.current = destroy;
     return destroy;

--- a/src/services/virtual-lab/build/me-model/bluepy-emodel.ts
+++ b/src/services/virtual-lab/build/me-model/bluepy-emodel.ts
@@ -1,4 +1,4 @@
-import Ws, { BluePyEModelCmd, WSResponses } from './websocket';
+import Ws, { BluePyEModelCmd, Cmd } from './websocket';
 
 import { meModelAnalysisSvc } from '@/config';
 
@@ -15,7 +15,7 @@ export default class BluePyEModelCls {
 
   constructor(modelSelfUrl: string, token: string, config: BluePyEModelConfig = {}) {
     this.config = config;
-    this.ws = new Ws(meModelAnalysisSvc.wsUrl, token, this.onMessage);
+    this.ws = new Ws(meModelAnalysisSvc.wsUrl, token, { onMessage: this.onMessage });
     this.ws.send(BluePyEModelCmd.SET_MODEL, { model_self_url: modelSelfUrl });
   }
 
@@ -23,7 +23,7 @@ export default class BluePyEModelCls {
     this.ws.send(BluePyEModelCmd.RUN_ANALYSIS, {});
   }
 
-  private onMessage = (cmd: WSResponses) => {
+  private onMessage = (cmd: Cmd) => {
     switch (cmd) {
       case 'set_model_done':
         this.config.onInit?.();

--- a/src/services/virtual-lab/build/me-model/websocket.ts
+++ b/src/services/virtual-lab/build/me-model/websocket.ts
@@ -1,13 +1,43 @@
-import WsCommon from '@/services/ws-common';
+import WsCommon, { OnMessageHandler } from '@/services/ws-common';
 
 export const BluePyEModelCmd = {
   // Cmd target: backend
   SET_MODEL: 'set_model',
   RUN_ANALYSIS: 'run_analysis',
+  PING: 'ping',
 };
+
+const PING_INTERVAL = 60_000;
 
 type BluePyEModelCmdKeys = Lowercase<keyof typeof BluePyEModelCmd>;
 
-export type WSResponses = `${BluePyEModelCmdKeys}_done` | `${BluePyEModelCmdKeys}_error`;
+export type Cmd = `${BluePyEModelCmdKeys}_done` | `${BluePyEModelCmdKeys}_error`;
 
-export default class Ws extends WsCommon<WSResponses> {}
+export default class Ws extends WsCommon<Cmd> {
+  private pingIntervalTimerId?: number;
+
+  constructor(
+    webSocketUrl: string,
+    token: string,
+    {
+      onMessage,
+      onClose,
+      onOpen,
+    }: { onMessage: OnMessageHandler<Cmd>; onOpen?: () => void; onClose?: () => void }
+  ) {
+    const params = {
+      onMessage,
+      onOpen: () => {
+        onOpen?.();
+        this.pingIntervalTimerId = window.setInterval(() => {
+          this.send(BluePyEModelCmd.PING, {});
+        }, PING_INTERVAL);
+      },
+      onClose: () => {
+        onClose?.();
+        window.clearInterval(this.pingIntervalTimerId);
+      },
+    };
+    super(webSocketUrl, token, params);
+  }
+}

--- a/src/services/ws-common.ts
+++ b/src/services/ws-common.ts
@@ -17,9 +17,9 @@ type Message = string;
 type Data = any;
 type CmdId = number;
 type MessageQueueEntry = [Message, Data, CmdId | undefined];
-type OnMessageHandler<WSResponses> = (cmd: WSResponses, data: any) => void;
+export type OnMessageHandler<Cmd> = (cmd: Cmd, data: any) => void;
 
-export default class WsCommon<WSResponses> {
+export default class WsCommon<Cmd> {
   private cmdId: number = 0;
 
   private closing: boolean = false;
@@ -28,7 +28,11 @@ export default class WsCommon<WSResponses> {
 
   private messageContext?: any;
 
-  private onMessage: OnMessageHandler<WSResponses>;
+  private onMessage: OnMessageHandler<Cmd>;
+
+  private onOpen?: () => void;
+
+  private onClose?: () => void;
 
   private requestResolvers = new Map<number, (data: Data) => void>();
 
@@ -40,10 +44,20 @@ export default class WsCommon<WSResponses> {
 
   private token?: string;
 
-  constructor(webSocketUrl: string, token: string, onMessage: OnMessageHandler<WSResponses>) {
+  constructor(
+    webSocketUrl: string,
+    token: string,
+    {
+      onMessage,
+      onOpen,
+      onClose,
+    }: { onMessage: OnMessageHandler<Cmd>; onOpen: () => void; onClose: () => void }
+  ) {
     this.webSocketUrl = webSocketUrl;
 
     this.onMessage = onMessage;
+    this.onOpen = onOpen;
+    this.onClose = onClose;
 
     this.token = token;
 
@@ -120,8 +134,15 @@ export default class WsCommon<WSResponses> {
     this.socket = socket;
 
     // send message to check until the service is up
-    socket.addEventListener('open', () => this.sendCheckUpMsg());
-    socket.addEventListener('close', this.reconnect);
+    socket.addEventListener('open', () => {
+      this.sendCheckUpMsg();
+      this.onOpen?.();
+    });
+
+    socket.addEventListener('close', () => {
+      this.onClose?.();
+      this.reconnect();
+    });
 
     socket.addEventListener('message', (e) => {
       const message = JSON.parse(e.data);


### PR DESCRIPTION
These are mostly workarounds to make me-model validation work:
* Add websocket ping messages so that AWS ALB do not close the connection due to reaching inactivity threshold.
* Refresh access token before starting the validation - eventually this will have to be replaced by access token management in the service itself (separate KC client with token exchange capability and longer access token TTL).
* Set current API Gateway URL.