### PR TITLE
Rate limit is also applied on suggestions, now

### DIFF
--- a/src/services/ai-agent/api/suggestion.ts
+++ b/src/services/ai-agent/api/suggestion.ts
@@ -3,12 +3,21 @@ import { userJourneyTracker } from '@/components/explore-section/Literature/user
 import { isType } from '@/util/type-guards';
 
 export async function serviceAiAgentSuggestionFromUserJourney(
-  accessToken: string
+  accessToken: string,
+  options?: {
+    virtualLabId?: string | null;
+    projectId?: string | null;
+  }
 ): Promise<string[]> {
+  const { virtualLabId = null, projectId = null } = options ?? {};
   const journey = await userJourneyTracker.getLastTuples();
   const data = await fetchJSON({
     accessToken,
     path: 'qa/question_suggestions',
+    params: {
+      vlab_id: virtualLabId,
+      project_id: projectId,
+    },
     query: {
       click_history: journey,
     },

--- a/src/services/ai-agent/api/url.ts
+++ b/src/services/ai-agent/api/url.ts
@@ -1,14 +1,28 @@
+import { isString } from '@/util/type-guards';
+
 const AGENT_URL = process.env.NEXT_PUBLIC_AI_AGENT_URL ?? '(Missing NEXT_PUBLIC_AI_AGENT_URL)';
 
 /**
  * This function can be used to set the `api` property
  * of `useChat`.
  */
-export function serviceAiAgentUrl(...items: string[]) {
-  return [AGENT_URL, ...items]
+export function serviceAiAgentUrl(
+  entrypoint: string | string[],
+  params?: Record<string, string | null>
+) {
+  const items = Array.isArray(entrypoint) ? entrypoint : [entrypoint];
+  const url = [AGENT_URL, ...items]
     .map((item) => {
       if (item.endsWith('/')) return item.slice(0, -1);
       return item;
     })
     .join('/');
+  if (!params) return url;
+
+  const urlParams = Object.keys(params)
+    .filter((key) => isString(params[key]))
+    .map((key) => `${key}=${encodeURIComponent(params[key] as string)}`);
+  if (urlParams.length === 0) return url;
+
+  return `${url}?${urlParams.join('&')}`;
 }

--- a/src/services/ai-agent/api/util.ts
+++ b/src/services/ai-agent/api/util.ts
@@ -7,6 +7,7 @@ interface QueryOptions<T> {
   method?: 'POST' | 'DELETE' | 'GET';
   path: string;
   query?: unknown;
+  params?: Record<string, string | null>;
   typeGuard: (data: unknown) => data is T;
 }
 
@@ -14,10 +15,11 @@ export async function fetchJSON<T>({
   accessToken = 'token-is-missing',
   method = 'POST',
   path,
+  params = {},
   query = {},
   typeGuard,
 }: QueryOptions<T>): Promise<T> {
-  const url = serviceAiAgentUrl(path);
+  const url = serviceAiAgentUrl(path, params);
   try {
     const resp = await fetch(url, {
       method,

--- a/src/services/ai-agent/hooks/chat.ts
+++ b/src/services/ai-agent/hooks/chat.ts
@@ -5,7 +5,7 @@ import { serviceAiAgentUrl } from '../api';
 export function useServiceAiAgentChat(threadId: string) {
   const session = useSession();
   const chat = useChat({
-    api: serviceAiAgentUrl('qa/chat_streamed', threadId),
+    api: serviceAiAgentUrl(['qa/chat_streamed', threadId]),
     id: threadId,
     headers: {
       Authorization: `Bearer ${session.data?.accessToken}`,

--- a/src/services/ai-agent/hooks/suggestion.ts
+++ b/src/services/ai-agent/hooks/suggestion.ts
@@ -4,18 +4,25 @@ import { serviceAiAgentSuggestionFromUserJourney } from '../api/suggestion';
 import { useAccessToken } from '@/hooks/useAccessToken';
 import { userJourneyTracker } from '@/components/explore-section/Literature/user-journey';
 import { useGenericEventListener } from '@/util/generic-event';
+import { useParamProjectId, useParamVirtualLabId } from '@/util/params';
 
 export function useServiceAiAgentSuggestionFromUserJourney(): [
   suggestions: string[],
   clearSuggestions: () => void,
 ] {
+  const virtualLabId = useParamVirtualLabId();
+  const projectId = useParamProjectId();
   const accessToken = useAccessToken();
   const [suggestions, setSuggestions] = React.useState<string[]>([]);
   const fetchSuggestions = React.useCallback(() => {
     const action = async () => {
       try {
         const data = await serviceAiAgentSuggestionFromUserJourney(
-          accessToken ?? 'no-access-token'
+          accessToken ?? 'no-access-token',
+          {
+            virtualLabId,
+            projectId,
+          }
         );
         setSuggestions(data);
       } catch {
@@ -23,7 +30,7 @@ export function useServiceAiAgentSuggestionFromUserJourney(): [
       }
     };
     action();
-  }, [accessToken]);
+  }, [accessToken, projectId, virtualLabId]);
   React.useEffect(fetchSuggestions, [fetchSuggestions]);
   useGenericEventListener(userJourneyTracker.eventChange, fetchSuggestions);
   return [suggestions, () => setSuggestions([])];


### PR DESCRIPTION
If the user ask for too many suggestions, we internally get a 429 HTTP error that we silently ignore.
This way, the user won't spend AI money, but they will still see the hard-coded suggestions.