### PR TITLE
Use current session to determine a state when refresh fails

### DIFF
--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -9,7 +9,7 @@ import sessionAtom from '@/state/session';
 
 export type SessionOrNull = Session | null;
 
-/* 
+/*
    Waits for useSessionState to set the session.
    useSessionState updates it to always have the latest token available.
 */
@@ -73,9 +73,9 @@ export default function useSessionState() {
   }, [session?.accessToken, currentSession, session, setSessionState]);
 
   useEffect(() => {
-    if (session?.error !== 'RefreshAccessTokenError') return;
+    if (currentSession?.data?.error !== 'RefreshAccessTokenError') return;
 
     // automatically signIn when a refresh token expires
     signIn('keycloak');
-  }, [session]);
+  }, [currentSession]);
 }


### PR DESCRIPTION
Due to [some optimisations](https://github.com/openbraininstitute/core-web-app/blob/develop/src/hooks/session.ts#L71) to avoid unnecessary re-renders on session change, in order to detect token refresh failures we should rely on the session directly from the next-auth lib, unlike it is currently implemented.

Addresses https://github.com/openbraininstitute/prod-build-emodel/issues/4.