### PR TITLE
Reset page and previous results on filter apply

### DIFF
--- a/src/components/explore-section/ControlPanel/index.tsx
+++ b/src/components/explore-section/ControlPanel/index.tsx
@@ -25,13 +25,16 @@ import { ExploreDataScope, FilterValues } from '@/types/explore-section/applicat
 import {
   activeColumnsAtom,
   filtersAtom,
+  pageNumberAtom,
+  previousDataAtom,
   searchStringAtom,
 } from '@/state/explore-section/list-view-atoms';
 import { getFieldEsConfig, getFieldLabel } from '@/api/explore-section/fields';
 import { FilterTypeEnum } from '@/types/explore-section/filters';
-import { DataType } from '@/constants/explore-section/list-views';
+import { DataType, PAGE_NUMBER } from '@/constants/explore-section/list-views';
 import ClearFilters from '@/components/explore-section/ExploreSectionListingView/ClearFilters';
 import { fieldTitleSentenceCase } from '@/util/utils';
+import { VirtualLabInfo } from '@/types/virtual-lab/common';
 
 export type ControlPanelProps = {
   children?: ReactNode;
@@ -44,6 +47,7 @@ export type ControlPanelProps = {
   setFilters: any;
   showDisplayTrigger?: boolean;
   resourceId?: string;
+  virtualLabInfo?: VirtualLabInfo;
 };
 
 function createFilterItemComponent(
@@ -166,6 +170,7 @@ export default function ControlPanel({
   setFilters,
   showDisplayTrigger = true,
   resourceId,
+  virtualLabInfo,
 }: ControlPanelProps) {
   const [activeColumns, setActiveColumns] = useAtom(
     useMemo(
@@ -176,6 +181,11 @@ export default function ControlPanel({
 
   const [filterValues, setFilterValues] = useState<FilterValues>({});
   const resetFilters = useResetAtom(filtersAtom({ dataType, dataScope, resourceId, key: dataKey }));
+  const setPrevData = useSetAtom(
+    previousDataAtom({ virtualLabInfo, dataType, dataScope, key: dataKey })
+  );
+  const setPageNumber = useSetAtom(pageNumberAtom(dataKey));
+
   const setSearchString = useSetAtom(searchStringAtom(dataKey));
 
   const onToggleActive = (key: string) => {
@@ -203,6 +213,8 @@ export default function ControlPanel({
   }, [filters]);
 
   const submitValues = () => {
+    setPageNumber(PAGE_NUMBER);
+    setPrevData([]);
     setFilters(filters?.map((fil: Filter) => ({ ...fil, value: filterValues[fil.field] })));
   };
 

--- a/src/components/explore-section/ExploreSectionListingView/LoadMoreButton.tsx
+++ b/src/components/explore-section/ExploreSectionListingView/LoadMoreButton.tsx
@@ -1,5 +1,5 @@
 import { HTMLProps, useCallback } from 'react';
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import {
   dataAtom,
   pageNumberAtom,
@@ -33,7 +33,7 @@ export function useData(
   },
   key: string
 ) {
-  const [prevData] = useAtom(previousDataAtom({ ...dataContext, key }));
+  const prevData = useAtomValue(previousDataAtom({ ...dataContext, key }));
 
   const data = useUnwrappedValue(
     dataAtom({

--- a/src/components/explore-section/ExploreSectionListingView/WithControlPanel.tsx
+++ b/src/components/explore-section/ExploreSectionListingView/WithControlPanel.tsx
@@ -70,6 +70,7 @@ export default function WithControlPanel({
           dataType={dataType}
           dataScope={dataScope}
           dataKey={dataKey}
+          virtualLabInfo={virtualLabInfo}
         />
       )}
     </>


### PR DESCRIPTION
When the user applies a filter in the list view the current page and already cached "previous" (from previous pages) results have to be reset.

Relates to https://github.com/openbraininstitute/prod-build-emodel/issues/35.