### PR TITLE
extend filter panel options to display/hide columns

### DIFF
--- a/src/app/app/virtual-lab/lab/[virtualLabId]/project/[projectId]/(pages)/library/page.tsx
+++ b/src/app/app/virtual-lab/lab/[virtualLabId]/project/[projectId]/(pages)/library/page.tsx
@@ -36,8 +36,6 @@ export default async function Page(props: Props) {
   );
   const { list } = groupBookmarksByCategory(result?.data);
 
-  console.log('ᦨ #  page.tsx:41 #  Page #  list:', list);
-
   const { activeCategory, tabs, availableTypeKeysPerCategory } = getAvailableTabs(category, list);
   const activeType = tabs.at(0)?.key!;
 

--- a/src/components/explore-section/CardView/Card.tsx
+++ b/src/components/explore-section/CardView/Card.tsx
@@ -36,8 +36,6 @@ export default function Card({ resource, dataType, activeKeys, metrics, score }:
   const basePath = path.split('/').slice(0, -1).join('/');
   const resourceUrl = detailUrlBuilder(basePath, resource);
 
-  console.log('ᦨ #  Card.tsx:39 #  Card #  resource:', resource);
-
   const { groupedCardFields, renderMetric } = useMorphometrics(dataType, metrics);
 
   return (

--- a/src/entity-configuration/definitions/fields-defs/common.ts
+++ b/src/entity-configuration/definitions/fields-defs/common.ts
@@ -28,6 +28,8 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
       singular: 'preview',
     },
     style: { width: 184 },
+    isFilterable: false,
+    isDisplayable: true,
   },
   [EntityCoreFields.Name]: {
     title: 'Name',
@@ -43,6 +45,8 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
       property: 'order_by',
       value: 'name',
     },
+    isFilterable: true,
+    isDisplayable: true,
   },
   [EntityCoreFields.CreationDate]: {
     title: 'Creation date',
@@ -61,6 +65,8 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
       property: 'order_by',
       value: 'creation_date',
     },
+    isFilterable: true,
+    isDisplayable: true,
   },
   [EntityCoreFields.RegistrationDate]: {
     title: 'Registration date',
@@ -79,6 +85,8 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
       property: 'order_by',
       value: 'creation_date',
     },
+    isFilterable: true,
+    isDisplayable: true,
   },
   [EntityCoreFields.UpdateDate]: {
     title: 'Update date',
@@ -97,6 +105,8 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
       property: 'order_by',
       value: 'updated_at',
     },
+    isFilterable: false,
+    isDisplayable: false,
   },
   [EntityCoreFields.Description]: {
     title: 'Description',
@@ -106,27 +116,8 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
       plural: 'Descriptions',
       singular: 'Description',
     },
-  },
-  [EntityCoreFields.Contributions]: {
-    title: 'Contributors',
-    filter: CoreFieldFilterTypeEnum.CheckList,
-    render: (r) =>
-      renderEmptyOrValue(
-        transformAgentToNames(
-          (r as EntityCoreObjectTypes & { contributions?: Array<IContributor> | null })
-            .contributions
-        )
-      ),
-    vocabulary: {
-      plural: 'Contributors',
-      singular: 'Contributor',
-    },
-    constraint: 'contribution__pref_label__in',
-    isSortable: false,
-    order: {
-      property: 'contribution__order_by',
-      value: 'pref_label',
-    },
+    isFilterable: false,
+    isDisplayable: false,
   },
   [EntityCoreFields.Contribution]: {
     title: 'Contributors',
@@ -143,11 +134,13 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
       singular: 'Contributor',
     },
     constraint: 'contribution__pref_label__in',
-    isSortable: false,
     order: {
       property: 'contribution__order_by',
       value: 'pref_label',
     },
+    isSortable: false,
+    isFilterable: true,
+    isDisplayable: true,
   },
   [EntityCoreFields.BrainRegion]: {
     title: 'Brain Region',
@@ -158,5 +151,7 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
       singular: 'Brain Region',
     },
     constraint: 'brain_region_id',
+    isFilterable: false,
+    isDisplayable: true,
   },
 };

--- a/src/entity-configuration/definitions/fields-defs/experimental.tsx
+++ b/src/entity-configuration/definitions/fields-defs/experimental.tsx
@@ -33,6 +33,7 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
       singular: 'License',
     },
     isFilterable: false,
+    isDisplayable: true,
   },
   [EntityCoreFields.Species]: {
     title: 'Species',
@@ -56,6 +57,7 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
     },
     isSortable: false,
     isFilterable: true,
+    isDisplayable: true,
   },
   [EntityCoreFields.MType]: {
     fieldType: CoreFieldType.CellType,
@@ -80,6 +82,7 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
     },
     isSortable: false,
     isFilterable: true,
+    isDisplayable: true,
   },
   [EntityCoreFields.EType]: {
     fieldType: CoreFieldType.CellType,
@@ -104,6 +107,7 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
     },
     isSortable: false,
     isFilterable: true,
+    isDisplayable: true,
   },
   [EntityCoreFields.NumberOfMeasurements]: {
     title: 'N° of Measurements',
@@ -121,6 +125,7 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
     },
     isSortable: false,
     isFilterable: false,
+    isDisplayable: false,
   },
   [EntityCoreFields.SubjectAge]: {
     title: 'Age',
@@ -131,6 +136,7 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
       singular: 'Age',
     },
     isFilterable: false,
+    isDisplayable: false,
   },
   [EntityCoreFields.MeanSTD]: {
     title: 'Mean ± STD',
@@ -150,6 +156,7 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
     },
     isFilterable: false,
     isSortable: false,
+    isDisplayable: true,
   },
   [EntityCoreFields.Sem]: {
     title: 'SEM',
@@ -163,8 +170,9 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
       plural: 'Values',
       singular: 'Value',
     },
-    isFilterable: false,
     isSortable: false,
+    isFilterable: false,
+    isDisplayable: false,
   },
   [EntityCoreFields.PreSynapticBrainRegion]: {
     title: 'Brain Region [From]',
@@ -179,6 +187,8 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
     },
     filter: CoreFieldFilterTypeEnum.CheckList,
     constraint: 'synaptic_pathway__pre_region',
+    isFilterable: true,
+    isDisplayable: true,
   },
   [EntityCoreFields.PostSynapticBrainRegion]: {
     title: 'Brain Region [To]',
@@ -193,6 +203,8 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
     },
     filter: CoreFieldFilterTypeEnum.CheckList,
     constraint: 'synaptic_pathway__post_region',
+    isFilterable: true,
+    isDisplayable: true,
   },
   [EntityCoreFields.PreSynapticCellType]: {
     title: 'Cell Type [From]',
@@ -206,6 +218,8 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
       plural: 'Cell Type [From]',
       singular: 'Cell Type [From]',
     },
+    isFilterable: true,
+    isDisplayable: true,
   },
   [EntityCoreFields.PostSynapticCellType]: {
     title: 'Cell Type [To]',
@@ -219,6 +233,8 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
       plural: 'Cell Type [To]',
       singular: 'Cell Type [To]',
     },
+    isFilterable: true,
+    isDisplayable: true,
   },
   [EntityCoreFields.Weight]: {
     title: 'Weight',
@@ -231,8 +247,9 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
       plural: 'Values',
       singular: 'Value',
     },
-    isFilterable: false,
     isSortable: false,
+    isFilterable: false,
+    isDisplayable: false,
   },
   [EntityCoreFields.NeuronDensity]: {
     title: 'Density',
@@ -246,7 +263,8 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
       plural: 'Densities',
       singular: 'Density',
     },
-    isFilterable: false,
     isSortable: false,
+    isFilterable: false,
+    isDisplayable: false,
   },
 };

--- a/src/entity-configuration/definitions/fields-defs/model.tsx
+++ b/src/entity-configuration/definitions/fields-defs/model.tsx
@@ -18,7 +18,8 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
       singular: 'Morphology',
     },
     constraint: 'exemplar_morphology__label__in',
-    isFilterable: true,
+    isFilterable: false,
+    isDisplayable: true,
   },
   [EntityCoreFields.EModelScore]: {
     title: 'Model cumulated score',
@@ -29,6 +30,7 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
       singular: 'Model cumulated scores',
     },
     isFilterable: false,
+    isDisplayable: true,
     // constraint: 'brain_region_id',
   },
   [EntityCoreFields.EModelResponse]: {
@@ -47,6 +49,7 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
     // },
     isSortable: false,
     isFilterable: false,
+    isDisplayable: true,
   },
   [EntityCoreFields.MEModelMorphologyPreview]: {
     className: 'text-center',
@@ -65,6 +68,7 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
     },
     style: { width: 184 },
     isFilterable: false,
+    isDisplayable: true,
   },
   [EntityCoreFields.MEModelTracePreview]: {
     className: 'text-center',
@@ -81,5 +85,6 @@ export const FieldsDefinition: FieldsDefinitionRegistry<EntityCoreObjectTypes> =
     },
     style: { width: 184 },
     isFilterable: false,
+    isDisplayable: true,
   },
 };

--- a/src/entity-configuration/definitions/types.ts
+++ b/src/entity-configuration/definitions/types.ts
@@ -82,6 +82,7 @@ export type FieldDefinition<T extends EntityCoreIdentifiable> = {
   constraint?: string | Record<string, string>;
   isSortable?: boolean;
   isFilterable?: boolean;
+  isDisplayable?: boolean;
   order?: {
     property: string;
     value: string;
@@ -99,3 +100,6 @@ export type FieldDefinition<T extends EntityCoreIdentifiable> = {
 export type FieldsDefinitionRegistry<T extends EntityCoreIdentifiable> = {
   [key: string]: FieldDefinition<T>;
 };
+
+export type FieldsDefinitionItem<T extends EntityCoreIdentifiable> =
+  FieldsDefinitionRegistry<T>[keyof FieldsDefinitionRegistry<T>];

--- a/src/features/listing-filter-panel/index.tsx
+++ b/src/features/listing-filter-panel/index.tsx
@@ -10,15 +10,18 @@ import {
   useState,
 } from 'react';
 import { CloseOutlined } from '@ant-design/icons';
-import { Input } from 'antd';
-import { useAtom, useSetAtom } from 'jotai';
 import { unwrap, useResetAtom } from 'jotai/utils';
-import map from 'lodash/map';
+import { useAtom, useSetAtom } from 'jotai';
+import { Input } from 'antd';
 
+import orderBy from 'lodash/orderBy';
+import map from 'lodash/map';
+import get from 'lodash/get';
+
+import ValueOrRange from '@/features/listing-filter-panel/value-or-range';
 import ClearFilters from '@/features/listing-filter-panel/clear-filters';
 import DateRange from '@/features/listing-filter-panel/date-range';
 import CheckList from '@/features/listing-filter-panel/checklist';
-import ValueOrRange from '@/features/listing-filter-panel/value-or-range';
 
 import {
   activeColumnsAtom,
@@ -26,17 +29,19 @@ import {
   searchStringAtom,
 } from '@/state/explore-section/list-view-atoms';
 import { Filter, GteLteValue, ValueOrRangeFilter } from '@/features/listing-filter-panel/types';
+import { getFieldDefinition, getFieldsDefinition } from '@/entity-configuration/definitions';
 import { ExploreDataScope, FilterValues } from '@/types/explore-section/application';
 import { FilterGroup } from '@/features/listing-filter-panel/filter-group';
 import { DataType } from '@/constants/explore-section/list-views';
-import { FilterTypeEnum } from '@/types/explore-section/filters';
 import { Facets } from '@/api/entitycore/types/shared/response';
-import { getFieldLabel } from '@/api/explore-section/fields';
 import { defaultList } from './checklist/default-checklist';
 import { fieldTitleSentenceCase } from '@/util/utils';
-import { getFieldDefinition } from '@/entity-configuration/definitions';
-import type { CoreFilter } from '@/entity-configuration/definitions/types';
-import { CoreFieldFilterTypeEnum } from '@/entity-configuration/definitions/fields-defs/enums';
+import {
+  CoreFieldFilterTypeEnum,
+  EntityCoreFields,
+} from '@/entity-configuration/definitions/fields-defs/enums';
+
+import type { CoreFilter, FieldsDefinitionItem } from '@/entity-configuration/definitions/types';
 
 export type ListingFilterPanelProps = {
   children?: ReactNode;
@@ -179,6 +184,7 @@ export default function ListingFilterPanel({
       [dataType, dataScope, dataKey]
     )
   );
+  const fields = activeColumns ? getFieldsDefinition(activeColumns as EntityCoreFields[]) : [];
 
   const onToggleActive = (key: string) => {
     if (!activeColumns) return;
@@ -217,21 +223,26 @@ export default function ListingFilterPanel({
 
   const filterItems = useMemo(
     () =>
-      filters
-        ?.map((filter) => {
-          return {
-            content: filter.type
-              ? createFilterItemComponent(filter, facets, filterValues, setFilterValues)
-              : undefined,
-            display: activeColumns?.includes(filter.field),
-            label: fieldTitleSentenceCase(getFieldDefinition(filter.field)?.title ?? ''),
-            type: filter.type,
-            toggleFunc: showDisplayTrigger
-              ? () => onToggleActive && onToggleActive(filter.field)
-              : undefined, // There are cases where we don't want to show the display trigger. Undefined toggleFunc achieves this.
-          };
-        })
-        .filter((item) => showDisplayTrigger || item.content !== undefined), // If showDisplayTrigger is false and content is undefined that filter is not needed.
+      orderBy(
+        filters
+          ?.map((filter) => {
+            const item = get(fields, filter.field, {}) as FieldsDefinitionItem<any>;
+            return {
+              content:
+                filter.type && item.isFilterable
+                  ? createFilterItemComponent(filter, facets, filterValues, setFilterValues)
+                  : undefined,
+              display: item.isDisplayable,
+              label: fieldTitleSentenceCase(getFieldDefinition(filter.field)?.title ?? ''),
+              type: filter.type,
+              toggleFunc: showDisplayTrigger
+                ? () => onToggleActive && onToggleActive(filter.field)
+                : undefined, // There are cases where we don't want to show the display trigger. Undefined toggleFunc achieves this.
+            };
+          })
+          .filter((item) => showDisplayTrigger || item.content !== undefined), // If showDisplayTrigger is false and content is undefined that filter is not needed.
+        ['display', 'desc']
+      ),
     [
       filters,
       facets,

--- a/src/state/explore-section/list-view-atoms.ts
+++ b/src/state/explore-section/list-view-atoms.ts
@@ -44,6 +44,7 @@ import {
 import { CoreFieldFilterTypeEnum } from '@/entity-configuration/definitions/fields-defs/enums';
 import { CoreFilter } from '@/entity-configuration/definitions/types';
 import { getFieldsDefinition } from '@/entity-configuration/definitions';
+import filter from 'lodash/filter';
 
 type DataAtomFamilyScopeType = {
   key: string;
@@ -82,12 +83,7 @@ export const activeColumnsAtom = atomFamily(
       const dimensionColumns = await get(dimensionColumnsAtom(scope));
       const { columns } = { ...ViewsDefinitionRegistry[scope.dataType] };
 
-      return [
-        'index',
-        ...(dimensionColumns || []),
-        ...columns,
-        // isExperimentalData(scope.dataType) ? Field.RegistrationDate : Field.CreationDate,
-      ];
+      return ['index', ...(dimensionColumns || []), ...columns];
     }),
   isListAtomEqual
 );
@@ -115,14 +111,14 @@ export const filtersAtom = atomFamily(
     atomWithDefault<Promise<Array<CoreFilter>>>(async (get) => {
       const columns = getViewDefinitionByLegacyType(scope.dataType)?.columns;
       const fields = columns ? getFieldsDefinition(columns) : [];
-
       const dimensionsColumns = await get(dimensionColumnsAtom(scope));
+
       return [
         ...(columns
           ?.filter(
             (o) =>
-              _get(fields, o)?.isFilterable === true ||
-              typeof _get(fields, o)?.isFilterable === 'undefined' // TODO: should be changed in the next commit
+              _get(fields, o, { isFilterable: false })?.isFilterable === true ||
+              _get(fields, o, { isDisplayable: false })?.isDisplayable === true
           )
           ?.map((colKey) => columnKeyToFilter(colKey)) ?? []),
         ...(dimensionsColumns || []).map(


### PR DESCRIPTION
- entitycore will not support all the fields in the filter panel (after discussion with JDC), so we need a way to specify which legacy fields should continue to be supported and flag the others as not filterable, so we can enable them at any point of time when they are ready, 
- another field `isDisplayable` for allowing the user to `hide/show` specific fields in the table 