### PR TITLE
Ephys viewer: correct reference to global styles

### DIFF
--- a/src/features/ephys-viewer/styles/ephys-plugin-styles.css
+++ b/src/features/ephys-viewer/styles/ephys-plugin-styles.css
@@ -1,4 +1,4 @@
-@reference '../../../../styles/globals.css';
+@reference '../../../styles/globals.css';
 
 .trace-selector-group.ant-checkbox-wrapper {
   padding-right: 4px;


### PR DESCRIPTION
I hope there is a better way to reference global styles, will look into that a bit later.