### PR TITLE
Fix circuit layout

### DIFF
--- a/src/app/app/virtual-lab/(free)/explore/(interactive)/interactive/(data)/model/circuit/[id]/page.tsx
+++ b/src/app/app/virtual-lab/(free)/explore/(interactive)/interactive/(data)/model/circuit/[id]/page.tsx
@@ -1,21 +1,25 @@
 'use client';
 
+import { useSetAtom } from 'jotai';
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import MainDetailViewCore from '@/components/explore-section/Circuit/DetailView/MainDetailViewCore';
 import { CircuitSchemaProps } from '@/components/explore-section/Circuit/type';
 import { buildCircuitMap } from '@/components/explore-section/Circuit/utils/circuits-map';
+import { brainRegionSidebarIsCollapsedAtom } from '@/state/brain-regions';
 
 export default function CircuitDetailPage() {
+  const setBrainRegionSidebarIsCollapsed = useSetAtom(brainRegionSidebarIsCollapsedAtom);
+  const params = useParams();
+
   const [circuitData, setCircuitData] = useState<CircuitSchemaProps | null>(null);
   const [parentCircuitData, setParentCircuitData] = useState<CircuitSchemaProps | null>(null);
   const [derivedCircuitsData, setDerivedCircuitsData] = useState<CircuitSchemaProps[] | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  const params = useParams();
-  const circuitKey = params.key as string | undefined;
+  const circuitKey = params.id as string | undefined;
 
   useEffect(() => {
     const fetchCircuit = async () => {
@@ -24,6 +28,8 @@ export default function CircuitDetailPage() {
         setLoading(false);
         return;
       }
+
+      setBrainRegionSidebarIsCollapsed(true);
 
       try {
         setLoading(true);

--- a/src/components/explore-section/Circuit/global/Columns.tsx
+++ b/src/components/explore-section/Circuit/global/Columns.tsx
@@ -25,10 +25,7 @@ const columns = (
     key: 'name',
     width: 150,
     render: (_value: any, record: CircuitSchemaProps, _index: number) => (
-      <Link
-        href={`/app/virtual-lab/explore/interactive/model/circuit/${record.key}`}
-        className="whitespace-nowrap"
-      >
+      <Link href={`./circuit/${record.key}`} className="whitespace-nowrap">
         {record.name}
       </Link>
     ),

--- a/src/components/explore-section/ExploreListingLayout/index.tsx
+++ b/src/components/explore-section/ExploreListingLayout/index.tsx
@@ -97,9 +97,6 @@ export default function ExploreListingLayout({
   const nMenuItems = Object.keys(config).length + (showCircuitMenu ? 1 : 0);
   const menuItemWidth = `${Math.floor(100 / nMenuItems) - 0.04}%`;
 
-  // eslint-disable-next-line
-  const isCircuitPage = /\/model\/circuit\/[^\/]+$/.test(pathname);
-
   const items: {
     key: string;
     title: string;
@@ -172,13 +169,14 @@ export default function ExploreListingLayout({
     });
   }
 
+  // ! The menu is not rendered for details pages (where the route contains `id` segment)
   if (params?.id)
     return <ErrorBoundary FallbackComponent={SimpleErrorComponent}>{children}</ErrorBoundary>;
 
   return (
     <div className="flex h-screen w-full overflow-x-auto bg-primary-9" id="interactive-data-layout">
       <ErrorBoundary FallbackComponent={SimpleErrorComponent}>
-        {!isCircuitPage && <BackToInteractiveExplorationBtn href={interactivePageHref} />}
+        <BackToInteractiveExplorationBtn href={interactivePageHref} />
 
         <div className="flex grow flex-col overflow-x-hidden">
           <Menu


### PR DESCRIPTION
* Use relative links so that when navigating to circuit details page in a context of vlab/project explore - we stay in the same context.
* Use `id` param instead of `key` for circuit details pages as the former one is what controls the presence of the menu.
* Hide brain region nav bar when opening circuit details - behaviour similar to the rest of entities.