### PR TITLE
Fix M-model query by id

### DIFF
--- a/src/state/virtual-lab/build/me-model.ts
+++ b/src/state/virtual-lab/build/me-model.ts
@@ -25,7 +25,12 @@ import { Experiment } from '@/types/explore-section/es-experiment';
 const retrieveESResourceByID = async (id: string) => {
   const query = esb
     .requestBodySearch()
-    .query(esb.boolQuery().must(esb.termQuery('@id', id)))
+    .query(
+      esb
+        .boolQuery()
+        .should([esb.termQuery('@id', id), esb.termQuery('@id.keyword', id)])
+        .minimumShouldMatch(1)
+    )
     .size(1);
 
   return authFetch(API_SEARCH, {


### PR DESCRIPTION
It seems that data from `bbp/mouselight` project can not be queried by using `@id` field for a term query against global search endpoint for `suite/sbo`.

In the past I've seen `@id.keyword` fields present in nexus - tried that and it did work.

I've checked some of the ESView configs in the project and the mapping configurations seem to be correct (type for `@id` field set as `keyword`), so it must be somewhere in the global reach configuration to which I do not have access. (And I'm not sure it's worth to spend time on that now).

As a workaround I've updated the query that is used to fetch morphology by id from the global search to match both `@id` and `@id.keyword` fields.

Relates to https://github.com/openbraininstitute/prod-build-emodel/issues/29.

P.S. With a quick search in the codebase found that that's the only place where such query is used, so this should be enough to address the issue. Hopefully other services are not affected - if the opposite is confirmed - probably then we should start looking to fix the index instead.