### PR TITLE
fix user journey order and unwanted reset of current session

### DIFF
--- a/src/components/explore-section/ExploreInteractive/StatItem.tsx
+++ b/src/components/explore-section/ExploreInteractive/StatItem.tsx
@@ -23,10 +23,13 @@ export default function StatItem({
   const [, setCurrentExplorerArtifact] = useCurrentExplorerArtifact();
   const selectedBrainRegion = useAtomValue(selectedBrainRegionAtom);
   const onClick = async () => {
-    if (!(await userJourneyTracker.getCurrentTuple())) {
+    const current = await userJourneyTracker.getCurrentTuple();
+
+    if (!current) {
       await userJourneyTracker.handleBrainRegionClick(selectedBrainRegion?.title!);
     }
     const artifact = ensureString(title, 'Morphology');
+
     setCurrentExplorerArtifact(artifact);
     await userJourneyTracker.handleClick('artifact', artifact);
   };

--- a/src/components/explore-section/Literature/user-journey/index.ts
+++ b/src/components/explore-section/Literature/user-journey/index.ts
@@ -8,10 +8,16 @@ class ClickContextTracker {
 
   async saveTuple(): Promise<void> {
     const currentTuple = await this.getCurrentTuple();
+
     if (!currentTuple) return;
 
-    await this.dbInstance.clickTuples.add(currentTuple);
-    await this.dbInstance.activeSession.delete('current');
+    try {
+      await this.dbInstance.clickTuples.add(currentTuple);
+      await this.dbInstance.activeSession.delete('current');
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error in save use journey tuple:', error);
+    }
   }
 
   async getCurrentTuple(): Promise<ClickTuple | null> {
@@ -30,12 +36,12 @@ class ClickContextTracker {
     const newTuple: ClickTuple = {
       clicks: [{ type: 'brain_region', data, timestamp: Date.now() }],
     };
-
     await this.updateCurrentTuple(newTuple);
   }
 
   async handleClick(type: ClickType, data: string): Promise<void> {
     const currentTuple = await this.getCurrentTuple();
+
     if (!currentTuple) {
       // eslint-disable-next-line no-console
       console.warn(`${type} clicked without a starting brain region.`);
@@ -43,12 +49,23 @@ class ClickContextTracker {
     }
 
     currentTuple.clicks.push({ type, data, timestamp: Date.now() });
+
     await this.updateCurrentTuple(currentTuple);
   }
 
   async getLastTuples(count: number = 10): Promise<Array<Array<[ClickType, string]>>> {
-    const tuples = await this.dbInstance.clickTuples.orderBy('id').reverse().limit(count).toArray();
-    return tuples.map((tuple) => tuple.clicks.map((click) => [click.type, click.data]));
+    const tuples = await this.dbInstance.clickTuples.orderBy('id').toArray();
+    const currentActiveTuple = await this.getCurrentTuple();
+    const sortedClicks = [...tuples, ...(currentActiveTuple ? [currentActiveTuple] : [])]
+      .sort((a, b) => {
+        const aTimestamp = a.clicks.find((c) => c.type === 'brain_region')?.timestamp || 0;
+        const bTimestamp = b.clicks.find((c) => c.type === 'brain_region')?.timestamp || 0;
+        return bTimestamp - aTimestamp;
+      })
+      .slice(0, count)
+      .reverse();
+
+    return sortedClicks.map((tuple) => tuple.clicks.map((click) => [click.type, click.data]));
   }
 }
 

--- a/src/services/ai-agent/api/suggestion.ts
+++ b/src/services/ai-agent/api/suggestion.ts
@@ -12,8 +12,8 @@ export const serviceAiAgentSuggestionFromUserJourney = asyncCreateSquash(
     }
   ): Promise<string[]> => {
     const { threadId = null, virtualLabId = null, projectId = null } = options ?? {};
-    await userJourneyTracker.saveTuple();
     const journey = await userJourneyTracker.getLastTuples();
+
     const data = await fetchJSON({
       accessToken,
       path: 'qa/question_suggestions',

--- a/src/services/ai-agent/hooks/suggestion.ts
+++ b/src/services/ai-agent/hooks/suggestion.ts
@@ -26,12 +26,13 @@ export function useServiceAiAgentSuggestionFromUserJourney(
           }
         );
         setSuggestions(data.slice(0, count));
-      } catch {
+      } catch (ex) {
         setSuggestions([]);
       }
     };
     action();
   }, [threadId, count, accessToken, projectId, virtualLabId]);
+
   React.useEffect(fetchSuggestions, [fetchSuggestions]);
   useGenericEventListener(userJourneyTracker.eventChange, fetchSuggestions);
   return [suggestions, () => setSuggestions([])];


### PR DESCRIPTION
1. basically the issue was more that the order, the service `src/services/ai-agent/api/suggestion.ts` was saving the latest active session and in the same time this service called in a hook that run in first render and each change of the history so it was always reseting the state was send wrongly.
2. the order now is using the `timestamp` of the brain region descendant + the current session, reversed to have it in the order that the backend use