### PR TITLE
Add button to run a notebook, for now only enabled in staging, and only for the regular (not uploaded by a user) notebooks

### DIFF
--- a/.deployment-envs/.env.staging
+++ b/.deployment-envs/.env.staging
@@ -26,4 +26,4 @@ NEXT_PUBLIC_SANITY_DATASET="staging"
 # AI Agent service from Machine Learning team
 NEXT_PUBLIC_AI_AGENT_URL="https://staging.openbraininstitute.org/api/agent/"
 
-
+NEXT_PUBLIC_ENABLE_RUN_NOTEBOOK=True

--- a/.env.development
+++ b/.env.development
@@ -22,4 +22,4 @@ MAILCHIMP_API_SERVER='dummy'
 # AI Agent service from Machine Learning team
 NEXT_PUBLIC_AI_AGENT_URL="https://staging.openbraininstitute.org/api/agent/"
 
-
+NEXT_PUBLIC_ENABLE_RUN_NOTEBOOK=True

--- a/src/app/app/virtual-lab/lab/[virtualLabId]/project/[projectId]/(pages)/notebooks/NotebookTable.tsx
+++ b/src/app/app/virtual-lab/lab/[virtualLabId]/project/[projectId]/(pages)/notebooks/NotebookTable.tsx
@@ -4,7 +4,13 @@ import { ConfigProvider, DatePicker, Input, Select } from 'antd';
 
 import { useMemo, useState } from 'react';
 
-import { DeleteOutlined, LoadingOutlined, PlusOutlined, UndoOutlined } from '@ant-design/icons';
+import {
+  DeleteOutlined,
+  LoadingOutlined,
+  PlusOutlined,
+  UndoOutlined,
+  PlayCircleOutlined,
+} from '@ant-design/icons';
 import Table from 'antd/es/table';
 import { Popover } from 'antd/lib';
 import { compareAsc, format } from 'date-fns';
@@ -36,6 +42,7 @@ function NotebookTable({
   vlabId,
   projectId,
   serverError,
+  enableRunNotebook = false,
 }: {
   vlabId: string;
   projectId: string;
@@ -43,6 +50,7 @@ function NotebookTable({
   failed?: string[];
   onDelete?: (id: string) => void;
   serverError?: string;
+  enableRunNotebook?: boolean;
 }) {
   const [loadingZip, setLoadingZip] = useState(false);
   const [currentNotebook, setCurrentNotebook] = useState<Notebook | null>(null);
@@ -95,6 +103,10 @@ function NotebookTable({
       return false;
     });
   }, [notebooks, search]);
+
+  const runNotebook = async (notebook: Notebook) => {
+    notification.info(`Request received to run notebook: ${notebook.name}`);
+  };
 
   const handleDownloadClick = async (notebook: Notebook) => {
     setLoadingZip(true);
@@ -172,6 +184,19 @@ function NotebookTable({
                     onClick={() => onDelete(notebook.id)}
                   >
                     Delete
+                  </button>
+                </div>
+              )}
+              {enableRunNotebook && (
+                <div className="flex gap-4">
+                  <PlayCircleOutlined style={{ fontSize: '12px' }} />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      runNotebook(notebook);
+                    }}
+                  >
+                    Run
                   </button>
                 </div>
               )}

--- a/src/app/app/virtual-lab/lab/[virtualLabId]/project/[projectId]/(pages)/notebooks/page.tsx
+++ b/src/app/app/virtual-lab/lab/[virtualLabId]/project/[projectId]/(pages)/notebooks/page.tsx
@@ -2,6 +2,7 @@ import NotebookTable from './NotebookTable';
 import { notebookRepoUrl } from '@/config';
 import { ServerSideComponentProp } from '@/types/common';
 import fetchNotebooks from '@/util/virtual-lab/fetchNotebooks';
+import { env } from '@/env.mjs';
 
 export default async function Notebooks({
   params,
@@ -16,6 +17,7 @@ export default async function Notebooks({
       projectId={projectId}
       vlabId={virtualLabId}
       serverError={error}
+      enableRunNotebook={env.NEXT_PUBLIC_ENABLE_RUN_NOTEBOOK}
     />
   );
 }

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -97,6 +97,7 @@ export const env = createEnv({
     NEXT_PUBLIC_MATOMO_SITE_ID: z.string().optional(),
     // There is only one Sanity server, but with two datasets.
     NEXT_PUBLIC_SANITY_DATASET: z.enum(["staging", "production"]).optional(),
+    NEXT_PUBLIC_ENABLE_RUN_NOTEBOOK: z.string().transform((val) => val === 'true').default('false'),
   },
 
   experimental__runtimeEnv: {
@@ -176,5 +177,6 @@ export const env = createEnv({
     NEXT_PUBLIC_MATOMO_CDN_URL: process.env.NEXT_PUBLIC_MATOMO_CDN_URL,
     NEXT_PUBLIC_MATOMO_SITE_ID: process.env.NEXT_PUBLIC_MATOMO_SITE_ID,
     NEXT_PUBLIC_SANITY_DATASET: process.env.NEXT_PUBLIC_SANITY_DATASET,
+    NEXT_PUBLIC_ENABLE_RUN_NOTEBOOK: process.env.NEXT_PUBLIC_ENABLE_RUN_NOTEBOOK,
   },
 });


### PR DESCRIPTION
This PR adds a 'Run' button in the popup of the table of notebooks. The button is currently only added in the staging environment, it's only added to the list of OBI-managed notebooks (so not the notebooks owned by a user) and at the moment it doesn't do anything yet: it just shows a notification that a request to run a notebook was received.

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/04b18278-982e-4793-bee8-a376dd689ada" />
