### PR TITLE
Circuit detail view fix z index position of sections tabs

### DIFF
--- a/src/components/explore-section/Circuit/DetailView/main-detail-view-core.tsx
+++ b/src/components/explore-section/Circuit/DetailView/main-detail-view-core.tsx
@@ -13,10 +13,6 @@ import { CircuitSchemaProps } from '@/components/explore-section/Circuit/type';
 import { buildCircuitMap } from '@/components/explore-section/Circuit/utils/circuits-map';
 import { brainRegionSidebarIsCollapsedAtom } from '@/state/brain-regions';
 
-import { CircuitSchemaProps } from '@/components/explore-section/Circuit/type';
-import { buildCircuitMap } from '@/components/explore-section/Circuit/utils/circuits-map';
-import { brainRegionSidebarIsCollapsedAtom } from '@/state/brain-regions';
-
 function MainDetailViewCore({
   content,
   parentCircuit,
@@ -27,7 +23,7 @@ function MainDetailViewCore({
   derivedCircuits: CircuitSchemaProps[] | null;
 }) {
   return (
-    <div className="py-10 pl-20 pr-10 text-primary-9">
+    <div className="relative py-10 pl-20 pr-10 text-primary-9">
       <HeaderDetailView content={content} />
       <Visualiser content={content} />
       <SectionMainContainer

--- a/src/components/explore-section/Circuit/DetailView/main-detail-view-core.tsx
+++ b/src/components/explore-section/Circuit/DetailView/main-detail-view-core.tsx
@@ -13,6 +13,10 @@ import { CircuitSchemaProps } from '@/components/explore-section/Circuit/type';
 import { buildCircuitMap } from '@/components/explore-section/Circuit/utils/circuits-map';
 import { brainRegionSidebarIsCollapsedAtom } from '@/state/brain-regions';
 
+import { CircuitSchemaProps } from '@/components/explore-section/Circuit/type';
+import { buildCircuitMap } from '@/components/explore-section/Circuit/utils/circuits-map';
+import { brainRegionSidebarIsCollapsedAtom } from '@/state/brain-regions';
+
 function MainDetailViewCore({
   content,
   parentCircuit,

--- a/src/components/explore-section/Circuit/DetailView/sections/section-content-bloc.tsx
+++ b/src/components/explore-section/Circuit/DetailView/sections/section-content-bloc.tsx
@@ -40,5 +40,5 @@ export default function SectionContentBlock({
       currentSection = null;
   }
 
-  return <div className="relative z-10 flex w-full flex-col bg-white p-12">{currentSection}</div>;
+  return <div className="relative flex w-full flex-col bg-white p-12">{currentSection}</div>;
 }

--- a/src/components/explore-section/Circuit/DetailView/sections/section-tabs.tsx
+++ b/src/components/explore-section/Circuit/DetailView/sections/section-tabs.tsx
@@ -38,7 +38,7 @@ export default function SectionTabs({
   ];
 
   return (
-    <div className="sticky top-0 z-50 grid h-16 w-full grid-cols-4 bg-[#F3F3F3]">
+    <div className="relative top-0 grid h-16 w-full grid-cols-4 bg-[#F3F3F3]">
       {sections.map((section: SectionProps) => {
         return (
           <button

--- a/src/components/explore-section/Circuit/global/circuit-table.tsx
+++ b/src/components/explore-section/Circuit/global/circuit-table.tsx
@@ -268,7 +268,7 @@ export default function CircuitTable({
         <>
           <div
             className={classNames(
-              'out-expo fixed bottom-3 z-[999999] h-screen w-[44vw] overflow-y-scroll bg-primary-9 p-8 transition-right duration-500',
+              'out-expo fixed bottom-3 z-100 h-screen w-[44vw] overflow-y-scroll bg-primary-9 p-8 transition-right duration-500',
               downloadModalOpen ? 'right-0' : '-right-full'
             )}
           >
@@ -281,7 +281,7 @@ export default function CircuitTable({
           </div>
           <div
             className={classNames(
-              'fixed left-0 top-0 z-[999998] h-screen w-screen bg-black transition-opacity duration-500 ease-out-back',
+              'fixed left-0 top-0 z-80 h-screen w-screen bg-black transition-opacity duration-500 ease-out-back',
               downloadModalOpen ? 'opacity-50' : 'pointer-events-none opacity-0'
             )}
           />

--- a/src/components/explore-section/Circuit/global/download/download-container.tsx
+++ b/src/components/explore-section/Circuit/global/download/download-container.tsx
@@ -62,7 +62,7 @@ export default function DownloadContainer({
   );
 
   return (
-    <div className="w-full">
+    <div className="relative w-full">
       <HeaderDownloadModal
         handleCloseDownloadModal={handleCloseDownloadModal}
         content={content.files}

--- a/src/components/explore-section/Circuit/type/index.tsx
+++ b/src/components/explore-section/Circuit/type/index.tsx
@@ -142,3 +142,9 @@ export type FileTypeHeaderProps = {
 export interface FilteredCircuit extends CircuitSchemaProps {
   isNonMatchingParent?: boolean;
 }
+
+export type CollaboratingInstitution = {
+  name: string;
+  url: string;
+  location: string;
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -109,6 +109,13 @@ module.exports = {
         '20vh': '20vh',
         '25vh': '25vh',
       },
+      zIndex: {
+        60: '60',
+        70: '70',
+        80: '80',
+        90: '90',
+        100: '100',
+      },
       listStyleType: {
         square: 'square',
       },


### PR DESCRIPTION
Fixed the problem of z-index between the circuit detail view section tab header which was sticky. Apparently, the sticky position mess with the z-index even if you have explicitly define a value. 
Now it's fixed