### PR TITLE
fix search results in listing page

### DIFF
--- a/src/components/explore-section/ExploreSectionListingView/ExploreSectionNameSearch.tsx
+++ b/src/components/explore-section/ExploreSectionListingView/ExploreSectionNameSearch.tsx
@@ -1,23 +1,40 @@
 import { ChangeEvent, RefObject, useEffect, useRef, useState } from 'react';
-import { useAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 import { SearchOutlined } from '@ant-design/icons';
 
-import { searchStringAtom } from '@/state/explore-section/list-view-atoms';
-
+import {
+  pageNumberAtom,
+  previousDataAtom,
+  searchStringAtom,
+} from '@/state/explore-section/list-view-atoms';
+import { DataType, PAGE_NUMBER } from '@/constants/explore-section/list-views';
 import { useDebouncedCallback } from '@/hooks/hooks';
 
 type SearchProps = {
-  dataKey?: string;
+  dataKey: string;
+  dataType: DataType;
 };
 
-export default function ExploreSectionNameSearch({ dataKey }: SearchProps) {
+export default function ExploreSectionNameSearch({ dataType, dataKey }: SearchProps) {
   const [searchString, setSearchString] = useAtom(searchStringAtom(dataKey ?? ''));
 
   const searchInputRef: RefObject<HTMLInputElement | null> = useRef(null);
   useEffect(() => searchInputRef?.current?.focus(), []); // Auto-focus on render
+  const setPageNumber = useSetAtom(pageNumberAtom(dataKey));
+
+  const setPrevData = useSetAtom(
+    previousDataAtom({
+      key: dataKey,
+      dataType,
+    })
+  );
 
   const debouncedUpdateAtom = useDebouncedCallback(
-    (searchStr: string) => setSearchString(searchStr),
+    (searchStr: string) => {
+      setPrevData([]);
+      setPageNumber(PAGE_NUMBER);
+      setSearchString(searchStr);
+    },
     [setSearchString],
     600
   );

--- a/src/components/explore-section/ExploreSectionListingView/FilterControls.tsx
+++ b/src/components/explore-section/ExploreSectionListingView/FilterControls.tsx
@@ -92,7 +92,7 @@ export default function FilterControls({
       )}
     >
       <div className="w-max">{children}</div>
-      {!resourceId && <ExploreSectionNameSearch dataKey={dataKey} />}
+      {!resourceId && <ExploreSectionNameSearch dataType={dataType} dataKey={dataKey} />}
       <div className="inline-flex w-full place-content-end gap-2">
         {/* only show search input on listing views. resource id is present on detail views. */}
         <FilterBtn disabled={disabled} onClick={() => setDisplayControlPanel(!displayControlPanel)}>


### PR DESCRIPTION
when you search in listing page, the history of paginated entities kept so on search the atom that keep the previous results should be reseted 