### PR TITLE
110/change user journey format 3

### DIFF
--- a/src/components/explore-section/Literature/user-journey/index.ts
+++ b/src/components/explore-section/Literature/user-journey/index.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { defaultExploreRegion } from '@/constants/explore-section/default-brain-region';
 import GenericEvent from '@/util/generic-event';
 import { logError } from '@/util/logger';
 import { getLocalStorageHelper } from '@/util/storage';
@@ -48,7 +49,17 @@ class UserJourneyTracker {
 
   constructor() {
     try {
-      this.history = getLocalStorageHelper().get(this.KEY, [], isUserJourney);
+      this.history = getLocalStorageHelper().get(
+        this.KEY,
+        [
+          {
+            timestamp: Date.now(),
+            region: defaultExploreRegion.title,
+            artifact: null,
+          },
+        ],
+        isUserJourney
+      );
       if (this.trim()) this.save();
     } catch (ex) {
       logError('Bad format for UserJourney in local storage:', ex);

--- a/src/components/literature-suggestions/literature-suggestions.tsx
+++ b/src/components/literature-suggestions/literature-suggestions.tsx
@@ -13,6 +13,7 @@ import { classNames } from '@/util/utils';
 import { useServiceAiAgentChat, useServiceAiAgentThread } from '@/services/ai-agent';
 
 import styles from './literature-suggestions.module.css';
+import { useCollapsedPanel } from './hooks';
 
 export interface LiteratureSuggestionsProps {
   className?: string;

--- a/src/components/literature-suggestions/literature-suggestions.tsx
+++ b/src/components/literature-suggestions/literature-suggestions.tsx
@@ -13,7 +13,6 @@ import { classNames } from '@/util/utils';
 import { useServiceAiAgentChat, useServiceAiAgentThread } from '@/services/ai-agent';
 
 import styles from './literature-suggestions.module.css';
-import { useCollapsedPanel } from './hooks';
 
 export interface LiteratureSuggestionsProps {
   className?: string;


### PR DESCRIPTION
When a new user goes to explore section for the first time, their history is empty. And since they haven't clicked any brain region yet, the AI agent does not know what suggestion to produce.

This PR is to add an initial history with the default brain region. Today, it's Cerebrum.