### PR TITLE
Fix some linting issues by renaming variables

### DIFF
--- a/src/components/entities-type-stats/panel.tsx
+++ b/src/components/entities-type-stats/panel.tsx
@@ -66,10 +66,12 @@ export function EntityTypeStats(props: StatsPanelProps) {
           let isError = false;
 
           if (!isLoading) {
-            const _result = get(data?.experimental, `${value.legacyType}`, '');
+            const tmpResult = get(data?.experimental, `${value.legacyType}`, '');
             records =
-              typeof _result === 'number' ? `${_result} record${_result > 0 ? 's' : ''}` : 'error';
-            isError = !!error || typeof _result === 'string';
+              typeof tmpResult === 'number'
+                ? `${tmpResult} record${tmpResult > 0 ? 's' : ''}`
+                : 'error';
+            isError = !!error || typeof tmpResult === 'string';
           }
 
           return (
@@ -93,10 +95,12 @@ export function EntityTypeStats(props: StatsPanelProps) {
           let records = '';
           let isError = false;
           if (!isLoading) {
-            const _result = get(data?.model, `${value.legacyType}`, '');
+            const tmpResult = get(data?.model, `${value.legacyType}`, '');
             records =
-              typeof _result === 'number' ? `${_result} record${_result > 0 ? 's' : ''}` : 'error';
-            isError = !!error || typeof _result === 'string';
+              typeof tmpResult === 'number'
+                ? `${tmpResult} record${tmpResult > 0 ? 's' : ''}`
+                : 'error';
+            isError = !!error || typeof tmpResult === 'string';
           }
           return (
             <EntityTypeCount

--- a/src/features/entities/me-model/detail-view/card-viewers/emodel-overview-card.tsx
+++ b/src/features/entities/me-model/detail-view/card-viewers/emodel-overview-card.tsx
@@ -36,9 +36,9 @@ function EModelOverviewCard({ mode = 'summary', data, reselectLink = false }: Pr
   }>();
 
   const getSelectUrlQueryParams = () => {
-    const _params = new URLSearchParams(searchParams?.toString());
-    _params.delete('e');
-    return _params.toString();
+    const urlSearchParams = new URLSearchParams(searchParams?.toString());
+    urlSearchParams.delete('e');
+    return urlSearchParams.toString();
   };
 
   if (data) {

--- a/src/features/entities/me-model/detail-view/card-viewers/morphology-overview-card.tsx
+++ b/src/features/entities/me-model/detail-view/card-viewers/morphology-overview-card.tsx
@@ -34,9 +34,9 @@ function MorphologyOverviewCard({ mode = 'summary', data, reselectLink = false }
   }>();
 
   const getSelectUrlQueryParams = () => {
-    const _params = new URLSearchParams(searchParams?.toString());
-    _params.delete('m');
-    return _params.toString();
+    const urlSearchParams = new URLSearchParams(searchParams?.toString());
+    urlSearchParams.delete('m');
+    return urlSearchParams.toString();
   };
 
   if (data) {

--- a/src/page-wrappers/build/me-model/morphology.selection.tsx
+++ b/src/page-wrappers/build/me-model/morphology.selection.tsx
@@ -47,9 +47,11 @@ export default function MorphologySelection({ params, searchParams }: Props) {
     setSessionValue({ ...sessionValue, mmodel: morphology, brainRegion: morphology?.brain_region });
 
     const upOneLevel = pathname?.split('/').slice(0, -1).join('/');
-    const _params = new URLSearchParams(searchParams);
-    _params.set('m', morphology!.id);
-    const newHref = _params ? `${upOneLevel}?${_params.toString()}` : (upOneLevel ?? '');
+    const urlSearchParams = new URLSearchParams(searchParams);
+    urlSearchParams.set('m', morphology!.id);
+    const newHref = urlSearchParams
+      ? `${upOneLevel}?${urlSearchParams.toString()}`
+      : (upOneLevel ?? '');
 
     navigate(newHref);
   };


### PR DESCRIPTION
This PR fixes some of the linting issues in core-web-app entitycore-migration: it's just renaming some variables.