### PR TITLE
remove entitycore migration without suffix image tag

### DIFF
--- a/.github/workflows/publish-staging-next.yml
+++ b/.github/workflows/publish-staging-next.yml
@@ -45,8 +45,6 @@ jobs:
       - name: Publish the image for AWS To AWS ECR
         run: |
           docker push ${{ vars.PUBLICECR_URI }}:entitycore-migration-aws
-          docker tag ${{ vars.PUBLICECR_URI }}:entitycore-migration-aws ${{ vars.PUBLICECR_URI }}:entitycore-migration
-          docker push ${{ vars.PUBLICECR_URI }}:entitycore-migration
 
       - name: Build a Docker image for Azure
         run: |


### PR DESCRIPTION
No longer push the entitycore-migration image tag: use either entitycore-migration-aws or entitycore-migration-azure
