### PR TITLE
Adapt ME-model validation calls to the new API (with entitycore support)

### DIFF
--- a/src/services/virtual-lab/build/me-model/bluepy-emodel.ts
+++ b/src/services/virtual-lab/build/me-model/bluepy-emodel.ts
@@ -1,4 +1,4 @@
-import Ws, { BluePyEModelCmd, Cmd } from './websocket';
+import Ws, { BluePyEModelCmd, Cmd, ModelOrigin } from './websocket';
 
 import { meModelAnalysisSvc } from '@/config';
 
@@ -9,25 +9,47 @@ interface BluePyEModelConfig {
 }
 
 export default class BluePyEModelCls {
+  private modelSelfUrl: string;
+
+  private access_token: string;
+
   private config: BluePyEModelConfig;
 
   private ws: Ws;
 
   constructor(modelSelfUrl: string, token: string, config: BluePyEModelConfig = {}) {
+    this.modelSelfUrl = modelSelfUrl;
+    this.access_token = token;
     this.config = config;
+
     this.ws = new Ws(meModelAnalysisSvc.wsUrl, token, { onMessage: this.onMessage });
-    this.ws.send(BluePyEModelCmd.SET_MODEL, { model_self_url: modelSelfUrl });
+
+    // TODO call runAnalysis directly not via the parents onInit which in turn calls runAnalysis
+    this.config.onInit?.();
   }
 
   runAnalysis() {
-    this.ws.send(BluePyEModelCmd.RUN_ANALYSIS, {});
+    this.ws.send(BluePyEModelCmd.RUN_ANALYSIS, {
+      access_token: this.access_token,
+      config: {
+        model_origin: ModelOrigin.NEXUS,
+        self_url: this.modelSelfUrl,
+      },
+      // For Entitycore required params are:
+      // access_token: this.access_token,
+      // config: {
+      // model_origin: ModelOrigin.ENTITYCORE,
+      // model_id: '<model_id>',
+      // project_context: {
+      //   project_id: '<project_id>'
+      //   virtual_lab_id: '<virtual_lab_id>',
+      // }
+      // },
+    });
   }
 
   private onMessage = (cmd: Cmd) => {
     switch (cmd) {
-      case 'set_model_done':
-        this.config.onInit?.();
-        break;
       case 'run_analysis_done':
         this.config.onAnalysisDone?.();
         break;

--- a/src/services/virtual-lab/build/me-model/websocket.ts
+++ b/src/services/virtual-lab/build/me-model/websocket.ts
@@ -2,10 +2,14 @@ import WsCommon, { OnMessageHandler } from '@/services/ws-common';
 
 export const BluePyEModelCmd = {
   // Cmd target: backend
-  SET_MODEL: 'set_model',
   RUN_ANALYSIS: 'run_analysis',
   PING: 'ping',
 };
+
+export enum ModelOrigin {
+  NEXUS = 'nexus',
+  ENTITYCORE = 'entitycore',
+}
 
 const PING_INTERVAL = 60_000;
 


### PR DESCRIPTION
This PR updates the logic to call ME-model validation service, according to changes introduced in [Integrate entitycore helper](https://github.com/openbraininstitute/me-model-analysis/pull/4).

Relates to [https://github.com/openbraininstitute/prod-singlecell-simulation/issues/126](https://github.com/openbraininstitute/prod-singlecell-simulation/issues/126).