### PR TITLE
89/3d morph is dimmed

### DIFF
--- a/src/services/bluenaas-single-cell/renderer.ts
+++ b/src/services/bluenaas-single-cell/renderer.ts
@@ -198,7 +198,7 @@ export default class NeuronViewerRenderer {
     this.scene = new Scene();
     this.scene.background = new Color(BACKGROUND_COLOR);
     this.scene.fog = new Fog(FOG_COLOR, FOG_NEAR, FOG_FAR);
-    this.scene.add(new AmbientLight(AMBIENT_LIGHT_COLOR));
+    this.scene.add(new AmbientLight(AMBIENT_LIGHT_COLOR, 20));
     this.scene.add(this.morphObj);
     this.scene.add(this.secMarkerObj);
 


### PR DESCRIPTION
The view was like this because of a new version of ThreeJS:
![image](https://github.com/user-attachments/assets/6383854b-e146-458a-b56d-f7721da3ff59)

Now, it's like this:
![image](https://github.com/user-attachments/assets/6dd8283d-3efd-4a53-8c7a-4fa32e23021c)
