### PR TITLE
Fix the heder title that was wrapping

### DIFF
--- a/src/components/ai-assistant/ai-assistant.module.css
+++ b/src/components/ai-assistant/ai-assistant.module.css
@@ -67,6 +67,7 @@
   order: 9;
   transform: rotate(180deg);
   writing-mode: vertical-lr;
+  white-space: nowrap;
 }
 
 .overlay {


### PR DESCRIPTION
The header of the AI Assistant was wrapping and going outside of the container, when in collapsed mode.