### PR TITLE
Preventing from downloading directories

### DIFF
--- a/src/components/explore-section/Circuit/global/download/download-item.module.css
+++ b/src/components/explore-section/Circuit/global/download/download-item.module.css
@@ -1,0 +1,3 @@
+div.comingSoon {
+  color: #fff9;
+}

--- a/src/components/explore-section/Circuit/global/download/download-item.tsx
+++ b/src/components/explore-section/Circuit/global/download/download-item.tsx
@@ -8,11 +8,19 @@ import {
 import { DownloadIcon } from '@/components/icons';
 import { classNames } from '@/util/utils';
 
+import styles from './download-item.module.css';
+
 export function DownloadChildrenItem({
   childrenItem,
 }: {
   childrenItem: SingleSelectedDownloadableItemProps;
 }) {
+  const disabled = childrenItem.extension === 'directory';
+
+  if (disabled) {
+    return <div className={styles.comingSoon}>Coming soon...</div>;
+  }
+
   return (
     <div className="flex w-full flex-row justify-between">
       <div className="w-3/4 hyphens-auto">


### PR DESCRIPTION
Downloading directories is not yet possible on the platform. But the button was still here and clickable.
We replaced it with a "Coming soon..." label.

<img width="427" alt="image" src="https://github.com/user-attachments/assets/b425eeab-e61f-4248-b244-b372378ff227" />
