### PR TITLE
Remove blue highlight for headers with additional properties

### DIFF
--- a/src/features/small-microcircuit/_components/components.module.css
+++ b/src/features/small-microcircuit/_components/components.module.css
@@ -13,12 +13,13 @@
   position: absolute;
   left: 0;
   right: 0;
-  bottom: -20px;
+  bottom: 0;
   width: 100%;
   pointer-events: none;
   z-index: 9;
   transition: all 0.2s;
   opacity: 0;
+  transform: translateY(calc(100% + 8px));
 }
 
 .input:hover .tooltip {

--- a/src/features/small-microcircuit/_components/section.tsx
+++ b/src/features/small-microcircuit/_components/section.tsx
@@ -38,11 +38,19 @@ export function useSectionRenderer(
   const renderSection = ([k, v]: [string, JSONSchema]) => {
     if (!schema || !schema?.properties) return;
 
+    const handleHeaderClick = (subkey: string, subValue: unknown) => {
+      if (isPlainObject(subValue)) {
+        setSelectedCategory(typeof subValue.type === 'string' ? subValue.type : '');
+        setSelectedItemIdx(parseInt(subkey.split('_')[1], 10));
+      }
+      setEditing(true);
+    };
+
     return (
       <Fragment key={k}>
         <Tab
           tab={k}
-          selectedTab={configTab}
+          selectedTab={!v.additionalProperties ? configTab : 'NO SELECTION FOR THIS SECTION'}
           onClick={() => {
             if (configTab === k && !isRootCategory(schema, k)) {
               setEditing(false);
@@ -81,18 +89,18 @@ export function useSectionRenderer(
 
               return (
                 <Fragment key={subkey}>
-                  {/* eslint-disable-next-line */}
                   <div
                     className={classNames(
                       'text-primary-8 flex h-[50px] min-h-[50px] w-[90%] min-w-[150px] items-center justify-between rounded-full bg-gray-100 px-5 py-2 text-sm drop-shadow hover:bg-gradient-to-r hover:from-[#003A8C] hover:to-[#001026] hover:text-white',
                       isSelected ? 'bg-gradient-to-r from-[#003A8C] to-[#001026] text-white' : ''
                     )}
-                    onClick={() => {
-                      if (isPlainObject(subValue)) {
-                        setSelectedCategory(typeof subValue.type === 'string' ? subValue.type : '');
-                        setSelectedItemIdx(parseInt(subkey.split('_')[1], 10));
+                    tabIndex={0}
+                    role="button"
+                    onClick={() => handleHeaderClick(subkey, subValue)}
+                    onKeyDown={(evt) => {
+                      if (evt.key === ' ' || evt.key === 'Enter') {
+                        handleHeaderClick(subkey, subValue);
                       }
-                      setEditing(true);
                     }}
                   >
                     {subkey}

--- a/src/features/small-microcircuit/index.tsx
+++ b/src/features/small-microcircuit/index.tsx
@@ -13,9 +13,9 @@ import { useSectionRenderer } from './_components/section';
 import TabsSelector from './_components/tabs-selector';
 import { CATEGORIES, isAtom, ORDERING } from './_components/utils';
 import { AtomsMap, JSONSchema, TabType } from './types';
-
 import CircuitName from './_components/circuit-name';
 import CircuitPreview from './_components/circuit-preview';
+
 import { getCircuitSimulations } from '@/api/entitycore/queries/simulation/circuit-simulation';
 import { getCircuitSimulationExecutions } from '@/api/entitycore/queries/simulation/circuit-simulation-execution';
 import { getCircuitSimulationResult } from '@/api/entitycore/queries/simulation/circuit-simulation-result';


### PR DESCRIPTION
When a header is selected, it appeared blue (with a gradient). Otherwise, it is white.

James wants this behavior only for the first two headers. The other, have (+) buttons to add extra properties.
He we wants them to stay white.

We also fixed a misalignment of the tooltips when the inputs have an error message displayed.