### PR TITLE
245/fix tooltip alignement

### DIFF
--- a/src/features/small-microcircuit/_components/circuit-details/circuit-details.module.css
+++ b/src/features/small-microcircuit/_components/circuit-details/circuit-details.module.css
@@ -1,0 +1,3 @@
+.circuitDetails {
+    
+}

--- a/src/features/small-microcircuit/_components/circuit-details/circuit-details.tsx
+++ b/src/features/small-microcircuit/_components/circuit-details/circuit-details.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Input } from 'antd';
 
+import Tooltip from '../tooltip';
+
 import { classNames } from '@/util/utils';
 import { ICircuit } from '@/api/entitycore/types/entities/circuit';
 
@@ -14,8 +16,10 @@ export interface CircuitDetailsProps {
 export default function CircuitDetails({ className, circuit }: CircuitDetailsProps) {
   return (
     <div className={classNames(className, styles.circuitDetails)}>
-      <Input value={circuit.id} disabled />
-      <Input value={circuit.name} disabled />
+      <Tooltip value={circuit.description}>
+        <Input value={circuit.id} disabled />
+        <Input value={circuit.name} disabled />
+      </Tooltip>
     </div>
   );
 }

--- a/src/features/small-microcircuit/_components/circuit-details/circuit-details.tsx
+++ b/src/features/small-microcircuit/_components/circuit-details/circuit-details.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Input } from 'antd';
+
+import { classNames } from '@/util/utils';
+import { ICircuit } from '@/api/entitycore/types/entities/circuit';
+
+import styles from './circuit-details.module.css';
+
+export interface CircuitDetailsProps {
+  className?: string;
+  circuit: ICircuit;
+}
+
+export default function CircuitDetails({ className, circuit }: CircuitDetailsProps) {
+  return (
+    <div className={classNames(className, styles.circuitDetails)}>
+      <Input value={circuit.id} disabled />
+      <Input value={circuit.name} disabled />
+    </div>
+  );
+}

--- a/src/features/small-microcircuit/_components/circuit-details/index.ts
+++ b/src/features/small-microcircuit/_components/circuit-details/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./circuit-details"

--- a/src/features/small-microcircuit/_components/circuit-name/circuit-name.tsx
+++ b/src/features/small-microcircuit/_components/circuit-name/circuit-name.tsx
@@ -1,19 +1,18 @@
 import React from 'react';
 import { InfoCircleFilled } from '@ant-design/icons';
 
-import { useCircuit } from '../hooks/circuit';
-
+import { ICircuit } from '@/api/entitycore/types/entities/circuit';
 import { classNames } from '@/util/utils';
 
 import styles from './circuit-name.module.css';
 
 export interface CircuitNameProps {
   className?: string;
-  circuitId: string;
+  circuit: ICircuit | undefined | null;
 }
 
-export default function CircuitName({ className, circuitId }: CircuitNameProps) {
-  const { name, description } = useCircuitNameAndDescription(circuitId);
+export default function CircuitName({ className, circuit }: CircuitNameProps) {
+  const { name, description } = useCircuitNameAndDescription(circuit);
 
   return (
     <div className={classNames(className, styles.circuitName)}>
@@ -25,11 +24,12 @@ export default function CircuitName({ className, circuitId }: CircuitNameProps) 
   );
 }
 
-function useCircuitNameAndDescription(circuitId: string) {
-  const [name, setName] = React.useState(circuitId);
+function useCircuitNameAndDescription(circuit: ICircuit | undefined | null) {
+  const [name, setName] = React.useState(circuit?.id ?? '');
   const [description, setDescription] = React.useState('');
-  const circuit = useCircuit(circuitId);
   React.useEffect(() => {
+    if (!circuit) return;
+
     const action = async () => {
       if (circuit) {
         setName(circuit.name);

--- a/src/features/small-microcircuit/_components/circuit-preview/circuit-preview.tsx
+++ b/src/features/small-microcircuit/_components/circuit-preview/circuit-preview.tsx
@@ -3,16 +3,17 @@ import React from 'react';
 
 import { useCircuitImageURL } from '../hooks/circuit';
 import { classNames } from '@/util/utils';
+import { ICircuit } from '@/api/entitycore/types/entities/circuit';
 
 import styles from './circuit-preview.module.css';
 
 export interface CircuitPreviewProps {
   className?: string;
-  circuitId: string;
+  circuit: ICircuit | undefined | null;
 }
 
-export default function CircuitPreview({ className, circuitId }: CircuitPreviewProps) {
-  const url = useCircuitImageURL(circuitId);
+export default function CircuitPreview({ className, circuit }: CircuitPreviewProps) {
+  const url = useCircuitImageURL(circuit?.id);
 
   return (
     <div className={classNames(className, styles.circuitPreview, url && styles.show)}>

--- a/src/features/small-microcircuit/_components/components.tsx
+++ b/src/features/small-microcircuit/_components/components.tsx
@@ -2,13 +2,14 @@ import { useEffect, useState } from 'react';
 import { atom, useAtom } from 'jotai';
 import { InputNumber, Input, Select, Button } from 'antd';
 import { CheckCircleOutlined, CloseCircleOutlined, PlusCircleOutlined } from '@ant-design/icons';
+
 import { JSONSchema } from '../types';
-
 import { isPlainObject } from './utils';
+import CircuitDetails from './circuit-details';
+import Tooltip from './tooltip';
 
+import { ICircuit } from '@/api/entitycore/types/entities/circuit';
 import { classNames } from '@/util/utils';
-
-import styles from './components.module.css';
 
 type Primitive = null | boolean | number | string;
 export interface Object {
@@ -24,15 +25,17 @@ export function JSONSchemaForm({
   schema,
   stateAtom,
   config,
+  circuit,
   onAddReferenceClick,
 }: {
   disabled: boolean;
   config: Config;
   schema: JSONSchema;
+  circuit: ICircuit | undefined | null;
   stateAtom: ReturnType<typeof atom<{ [key: string]: ConfigValue }>>;
   onAddReferenceClick: (reference: string) => void;
 }) {
-  const skip = ['type', 'circuit'];
+  const skip = ['type']; // , 'circuit'];
 
   const [state, setState] = useAtom(stateAtom);
   const [addingElement, setAddingElement] = useState(false);
@@ -65,6 +68,8 @@ export function JSONSchemaForm({
 
   function renderInput(k: string, v: JSONSchema) {
     const obj = { ...v, ...v.anyOf?.find((subv) => subv.type !== 'array') };
+
+    if (k === 'circuit' && circuit) return <CircuitDetails circuit={circuit} />;
 
     if (v.is_block_reference && v.properties && typeof v.properties.type.const === 'string') {
       const referenceKey = referenceTypesToConfigKeys[v.properties.type.const];
@@ -261,7 +266,7 @@ export function JSONSchemaForm({
             })
             .map(([k, v]) => {
               return (
-                <div key={k} className={styles.input}>
+                <div key={k}>
                   <div className="flex items-end gap-3">
                     <div
                       className="text-primary-9 text-base font-semibold uppercase"
@@ -271,8 +276,7 @@ export function JSONSchemaForm({
                     </div>
                     {v.units && <div className="text-lg text-gray-500">{v.units}</div>}
                   </div>
-                  {renderInput(k, v)}
-                  {v.description && <div className={styles.tooltip}>{v.description}</div>}
+                  <Tooltip value={v.description}>{renderInput(k, v)}</Tooltip>
 
                   {((schema.required?.includes(k) && !state[k]) ||
                     state[k] === null ||

--- a/src/features/small-microcircuit/_components/hooks/circuit.ts
+++ b/src/features/small-microcircuit/_components/hooks/circuit.ts
@@ -14,11 +14,16 @@ const pendingQueries = new Map<string, Promise<ICircuit | undefined | null>>();
  * @param circuitId
  * @returns `undefined` if the query is pending, `null` if an error occured and the circuit in case of success.
  */
-export function useCircuit(circuitId: string): ICircuit | undefined | null {
+export function useCircuit(circuitId: string | undefined): ICircuit | undefined | null {
   const { error } = useAppNotification();
   const [circuit, setCircuit] = React.useState<ICircuit | undefined | null>(undefined);
 
   React.useEffect(() => {
+    if (!circuitId) {
+      setCircuit(undefined);
+      return;
+    }
+
     getQuery(circuitId)
       .then(setCircuit)
       .catch((ex) => {
@@ -32,7 +37,7 @@ export function useCircuit(circuitId: string): ICircuit | undefined | null {
   return circuit;
 }
 
-export function useCircuitImageURL(circuitId: string) {
+export function useCircuitImageURL(circuitId: string | undefined) {
   const { error } = useAppNotification();
   const [url, setUrl] = React.useState<string | undefined>(undefined);
   const circuit = useCircuit(circuitId);

--- a/src/features/small-microcircuit/_components/tooltip/index.ts
+++ b/src/features/small-microcircuit/_components/tooltip/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./tooltip"

--- a/src/features/small-microcircuit/_components/tooltip/tooltip.module.css
+++ b/src/features/small-microcircuit/_components/tooltip/tooltip.module.css
@@ -19,7 +19,6 @@
   transform: translateY(calc(100% + 16px));
   transition: all 0.2s;
   opacity: 0;
-  transform: translateY(calc(100% + 8px));
 }
 
 .tooltipContainer:hover .tooltip {

--- a/src/features/small-microcircuit/_components/tooltip/tooltip.module.css
+++ b/src/features/small-microcircuit/_components/tooltip/tooltip.module.css
@@ -1,7 +1,6 @@
-.input {
+.tooltipContainer {
   position: relative;
   overflow: visible;
-  max-width: 100%;
 }
 
 .tooltip {
@@ -17,12 +16,13 @@
   width: 100%;
   pointer-events: none;
   z-index: 9;
+  transform: translateY(calc(100% + 16px));
   transition: all 0.2s;
   opacity: 0;
   transform: translateY(calc(100% + 8px));
 }
 
-.input:hover .tooltip {
+.tooltipContainer:hover .tooltip {
   opacity: 1;
 }
 

--- a/src/features/small-microcircuit/_components/tooltip/tooltip.tsx
+++ b/src/features/small-microcircuit/_components/tooltip/tooltip.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { classNames } from '@/util/utils';
+
+import styles from './tooltip.module.css';
+
+export interface TooltipProps {
+  className?: string;
+  value?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export default function Tooltip({ className, value, children }: TooltipProps) {
+  return (
+    <div className={classNames(className, styles.tooltipContainer)}>
+      {children}
+      {value && <div className={styles.tooltip}>{value}</div>}
+    </div>
+  );
+}

--- a/src/features/small-microcircuit/index.tsx
+++ b/src/features/small-microcircuit/index.tsx
@@ -13,6 +13,7 @@ import { useSectionRenderer } from './_components/section';
 import TabsSelector from './_components/tabs-selector';
 import { CATEGORIES, isAtom, ORDERING } from './_components/utils';
 import { AtomsMap, JSONSchema, TabType } from './types';
+import { useCircuit } from './_components/hooks/circuit';
 import CircuitName from './_components/circuit-name';
 import CircuitPreview from './_components/circuit-preview';
 
@@ -47,6 +48,7 @@ export default function SimulationCampaignConfiguration({
   if (!!initialCampaignId !== !!initialConfig)
     throw new Error('Both or none of initialCampaignId, initialConfigId should be passed');
 
+  const circuit = useCircuit(circuitId);
   const [tab, setTab] = useState<TabType>('configuration');
   const [configTab, setConfigTab] = useState<string>('info');
   const [editing, setEditing] = useState(true);
@@ -125,7 +127,7 @@ export default function SimulationCampaignConfiguration({
         <TabsSelector tab={tab} setTab={setTab} disableSimulationTab={!campaignId || loading} />
         <div className="flex items-center justify-center gap-8">
           {!!campaignId && <ButtonCopyId label="Copy simulation campaign ID" value={campaignId} />}
-          <CircuitName circuitId={circuitId} />
+          <CircuitName circuit={circuit} />
         </div>
       </header>
       <div className="w-full border-t border-gray-200" />
@@ -288,10 +290,11 @@ export default function SimulationCampaignConfiguration({
                       ? atomsMap[configTab]
                       : atomsMap[configTab][resolveKey(schema, configTab, selectedItemIdx)]
                   }
+                  circuit={circuit}
                 />
               )}
           </div>
-          <CircuitPreview circuitId={circuitId} />
+          <CircuitPreview circuit={circuit} />
         </div>
       )}
 


### PR DESCRIPTION
Added circuit id and circuit name as disabled inputs:

<img width="386" alt="image" src="https://github.com/user-attachments/assets/8966ce58-a29a-4ab7-9500-28cba097372e" />

Now, the tooltips are more accurate:

<img width="384" alt="image" src="https://github.com/user-attachments/assets/7244f219-e927-4693-acf5-de3a69e9a1ce" />
<img width="376" alt="image" src="https://github.com/user-attachments/assets/da5b9b05-7e88-42f4-a7a9-5103e49b5bb9" />

