### PR TITLE
Collapsed header blank

### DIFF
--- a/src/features/small-microcircuit/_components/section.tsx
+++ b/src/features/small-microcircuit/_components/section.tsx
@@ -12,196 +12,210 @@ import { ErrorObject } from 'ajv';
 import { AtomsMap, JSONSchema } from '../types';
 import { Chevron, Config, ConfigValue, Tab } from './components';
 import { isAtom, isPlainObject } from './utils';
+import { isRootCategory, resolveKey } from './hooks/schema';
 
 import { classNames } from '@/util/utils';
 
-export function useSectionRenderer(
-  schema: JSONSchema | null,
-  atomsMap: AtomsMap,
-  setAtomsMap: React.Dispatch<React.SetStateAction<AtomsMap>>,
-  configTab: string,
-  setConfigTab: (configTab: string) => void,
-  isRootCategory: (schema: JSONSchema, key: string) => boolean | undefined,
-  resolveKey: (schema: JSONSchema, tabKey: string, itemIdx: number | null) => string,
-  config: Config,
-  campaignId: string,
-  loading: boolean,
-  errors: ErrorObject<string, Record<string, any>, unknown>[] | null | undefined,
-  selectedItemIdx: number | null,
-  setSelectedItemIdx: (selectedItemIdx: number | null) => void,
-  setEditing: React.Dispatch<React.SetStateAction<boolean>>,
-  setSelectedCategory: React.Dispatch<React.SetStateAction<string>>,
-  readOnly?: boolean
-) {
-  const renderSection = ([k, v]: [string, JSONSchema]) => {
-    if (!schema || !schema?.properties) return;
+export function Section({
+  schema,
+  k,
+  sectionSchema,
+  atomsMap,
+  setAtomsMap,
+  configTab,
+  setConfigTab,
+  config,
+  campaignId,
+  loading,
+  errors,
+  selectedItemIdx,
+  setSelectedItemIdx,
+  setEditing,
+  setSelectedCategory,
+  readOnly,
+}: {
+  schema: JSONSchema | null; // The global schema
+  k: string // secition key
+  sectionSchema: JSONSchema; // The schema for this section
+  atomsMap: AtomsMap;
+  setAtomsMap: React.Dispatch<React.SetStateAction<AtomsMap>>;
+  configTab: string; // Key for selected section
+  setConfigTab: (configTab: string) => void;
+  config: Config;
+  campaignId: string;
+  loading: boolean;
+  errors: ErrorObject<string, Record<string, any>, unknown>[] | null | undefined;
+  selectedItemIdx: number | null;
+  setSelectedItemIdx: (selectedItemIdx: number | null) => void;
+  setEditing: React.Dispatch<React.SetStateAction<boolean>>;
+  setSelectedCategory: React.Dispatch<React.SetStateAction<string>>;
+  readOnly?: boolean;
+}) {
+  if (!schema || !schema?.properties) return;
 
-    const handleHeaderClick = (subkey: string, subValue: unknown) => {
-      if (isPlainObject(subValue)) {
-        setSelectedCategory(typeof subValue.type === 'string' ? subValue.type : '');
-        setSelectedItemIdx(parseInt(subkey.split('_')[1], 10));
-      }
-      setEditing(true);
-    };
+  const handleHeaderClick = (subkey: string, subValue: unknown) => {
+    if (isPlainObject(subValue)) {
+      setSelectedCategory(typeof subValue.type === 'string' ? subValue.type : '');
+      setSelectedItemIdx(parseInt(subkey.split('_')[1], 10));
+    }
+    setEditing(true);
+  };
 
-    return (
-      <Fragment key={k}>
-        <Tab
-          tab={k}
-          selectedTab={configTab}
-          onClick={() => {
-            if (configTab === k && !isRootCategory(schema, k)) {
-              setEditing(false);
-              setSelectedCategory('');
-              setSelectedItemIdx(null);
-              setConfigTab('');
-              return;
-            }
-
-            setConfigTab(k);
+  return (
+    <>
+      <Tab
+        tab={k}
+        selectedTab={configTab}
+        onClick={() => {
+          if (configTab === k && !isRootCategory(schema, k)) {
+            setEditing(false);
+            setSelectedCategory('');
             setSelectedItemIdx(null);
-            if (!v.additionalProperties) setEditing(true);
-            else setEditing(false);
-          }}
-          extraClass="w-full flex justify-between h-[50px] min-h-[50px] items-center drop-shadow"
-        >
-          {schema.properties?.[k]?.title}
-          <div className="flex gap-1">
-            {errors?.find((error) => error.instancePath.startsWith('/' + k)) ? (
-              <WarningFilled className="text-yellow-400" />
-            ) : (
-              <CheckCircleFilled className="text-green-600" />
-            )}
-            <Chevron rotate={v.additionalProperties ? 90 : 0} />
-          </div>
-        </Tab>
-        {v.additionalProperties && configTab === k && config[k] && (
-          <>
-            {Object.entries(config[k]).map(([subkey, subValue]) => {
-              const idx = parseInt(subkey.split('_')[1], 10);
+            setConfigTab('');
+            return;
+          }
 
-              const isSelected = configTab === k && idx === selectedItemIdx;
+          setConfigTab(k);
+          setSelectedItemIdx(null);
+          if (!sectionSchema.additionalProperties) setEditing(true);
+          else setEditing(false);
+        }}
+        extraClass="w-full flex justify-between h-[50px] min-h-[50px] items-center drop-shadow"
+      >
+        {schema.properties?.[k]?.title}
+        <div className="flex gap-1">
+          {errors?.find((error) => error.instancePath.startsWith('/' + k)) ? (
+            <WarningFilled className="text-yellow-400" />
+          ) : (
+            <CheckCircleFilled className="text-green-600" />
+          )}
+          <Chevron rotate={sectionSchema.additionalProperties ? 90 : 0} />
+        </div>
+      </Tab>
+      {sectionSchema.additionalProperties && configTab === k && config[k] && (
+        <>
+          {Object.entries(config[k]).map(([subkey, subValue]) => {
+            const idx = parseInt(subkey.split('_')[1], 10);
 
-              return (
-                <Fragment key={subkey}>
-                  <div
-                    className={classNames(
-                      'text-primary-8 flex h-[50px] min-h-[50px] w-[90%] min-w-[150px] items-center justify-between rounded-full bg-gray-100 px-5 py-2 text-sm drop-shadow hover:bg-gradient-to-r hover:from-[#003A8C] hover:to-[#001026] hover:text-white',
-                      isSelected ? 'bg-gradient-to-r from-[#003A8C] to-[#001026] text-white' : ''
+            const isSelected = configTab === k && idx === selectedItemIdx;
+
+            return (
+              <Fragment key={subkey}>
+                <div
+                  className={classNames(
+                    'text-primary-8 flex h-[50px] min-h-[50px] w-[90%] min-w-[150px] items-center justify-between rounded-full bg-gray-100 px-5 py-2 text-sm drop-shadow hover:bg-gradient-to-r hover:from-[#003A8C] hover:to-[#001026] hover:text-white',
+                    isSelected ? 'bg-gradient-to-r from-[#003A8C] to-[#001026] text-white' : ''
+                  )}
+                  tabIndex={0}
+                  role="button"
+                  onClick={() => handleHeaderClick(subkey, subValue)}
+                  onKeyDown={(evt) => {
+                    if (evt.key === ' ' || evt.key === 'Enter') {
+                      handleHeaderClick(subkey, subValue);
+                    }
+                  }}
+                >
+                  {subkey}
+                  <div className="flex gap-2">
+                    {errors?.find((error) => error.instancePath.startsWith(`/${k}/${subkey}`)) ? (
+                      <WarningFilled className="text-yellow-400" />
+                    ) : (
+                      <CheckCircleFilled className="text-green-600" />
                     )}
-                    tabIndex={0}
-                    role="button"
-                    onClick={() => handleHeaderClick(subkey, subValue)}
-                    onKeyDown={(evt) => {
-                      if (evt.key === ' ' || evt.key === 'Enter') {
-                        handleHeaderClick(subkey, subValue);
-                      }
-                    }}
-                  >
-                    {subkey}
-                    <div className="flex gap-2">
-                      {errors?.find((error) => error.instancePath.startsWith(`/${k}/${subkey}`)) ? (
-                        <WarningFilled className="text-yellow-400" />
-                      ) : (
-                        <CheckCircleFilled className="text-green-600" />
-                      )}
 
-                      {!campaignId && !loading && !readOnly && (
-                        <DeleteOutlined
-                          className="cursor-pointer"
-                          onClick={(e) => {
-                            e.stopPropagation();
+                    {!campaignId && !loading && !readOnly && (
+                      <DeleteOutlined
+                        className="cursor-pointer"
+                        onClick={(e) => {
+                          e.stopPropagation();
 
-                            setSelectedCategory('');
-                            setEditing(false);
+                          setSelectedCategory('');
+                          setEditing(false);
 
-                            const selectedTabAtoms = atomsMap[configTab];
-                            if (!isAtom(selectedTabAtoms)) {
-                              const refereeKey = resolveKey(schema, configTab, idx);
+                          const selectedTabAtoms = atomsMap[configTab];
+                          if (!isAtom(selectedTabAtoms)) {
+                            const refereeKey = resolveKey(schema, configTab, idx);
 
-                              delete selectedTabAtoms[refereeKey];
+                            delete selectedTabAtoms[refereeKey];
 
-                              // Initialize case
-                              const configInitialize = config.initialize;
-                              if (
-                                isPlainObject(configInitialize) &&
-                                isPlainObject(configInitialize.node_set) &&
-                                typeof configInitialize.node_set.block_name === 'string' &&
-                                configInitialize.node_set.block_name === refereeKey
-                              ) {
-                                atomsMap.initialize = atom<Record<string, ConfigValue>>({
-                                  ...configInitialize,
-                                  node_set: null,
-                                });
-                              }
-
-                              // Check all keys in the config
-                              Object.entries(config)
-                                .filter(([configK]) => configK !== 'initialize')
-                                .forEach(([configK, configV]) => {
-                                  if (typeof configV !== 'object') return;
-
-                                  // Check all keys in a section (e.g stimuli, recordings)
-                                  Object.entries(configV).forEach(([entryKey, entryV]) => {
-                                    if (!isPlainObject(entryV)) return;
-
-                                    // Check all values in a particular object (a single stimuli, a single timestamp, etc)
-                                    Object.entries(entryV).forEach(([fieldK, field]) => {
-                                      if (
-                                        !isPlainObject(entryV) ||
-                                        !isPlainObject(field) ||
-                                        typeof field.block_name !== 'string' ||
-                                        isAtom(atomsMap[configK]) || // skip top level atoms (e.g initialize)
-                                        field.block_name !== refereeKey
-                                      )
-                                        return;
-
-                                      // Deleting the reference to current object
-
-                                      delete entryV[fieldK]; //eslint-disable-line
-
-                                      // The atom that has a reference to current object
-                                      atomsMap[configK][entryKey] =
-                                        atom<Record<string, ConfigValue>>(entryV);
-                                    });
-                                  });
-                                });
-
-                              setAtomsMap({
-                                ...atomsMap,
-                                [configTab]: {
-                                  ...selectedTabAtoms,
-                                },
+                            // Initialize case
+                            const configInitialize = config.initialize;
+                            if (
+                              isPlainObject(configInitialize) &&
+                              isPlainObject(configInitialize.node_set) &&
+                              typeof configInitialize.node_set.block_name === 'string' &&
+                              configInitialize.node_set.block_name === refereeKey
+                            ) {
+                              atomsMap.initialize = atom<Record<string, ConfigValue>>({
+                                ...configInitialize,
+                                node_set: null,
                               });
                             }
 
-                            setSelectedItemIdx(null);
-                          }}
-                        />
-                      )}
-                    </div>
-                  </div>
-                </Fragment>
-              );
-            })}
-            {!campaignId && !loading && !readOnly && (
-              <button
-                className="text-primary-8 flex h-[50px] min-h-[50px] w-[90%] min-w-[150px] items-center justify-between rounded-full bg-gray-100 px-5 py-2 text-sm drop-shadow"
-                type="button"
-                onClick={() => {
-                  setEditing(true);
-                  setSelectedCategory('');
-                }}
-              >
-                Add {v.singular_name ?? v.title ?? 'item'}
-                <PlusCircleOutlined />
-              </button>
-            )}
-          </>
-        )}
-      </Fragment>
-    );
-  };
+                            // Check all keys in the config
+                            Object.entries(config)
+                              .filter(([configK]) => configK !== 'initialize')
+                              .forEach(([configK, configV]) => {
+                                if (typeof configV !== 'object') return;
 
-  return renderSection;
+                                // Check all keys in a section (e.g stimuli, recordings)
+                                Object.entries(configV).forEach(([entryKey, entryV]) => {
+                                  if (!isPlainObject(entryV)) return;
+
+                                  // Check all values in a particular object (a single stimuli, a single timestamp, etc)
+                                  Object.entries(entryV).forEach(([fieldK, field]) => {
+                                    if (
+                                      !isPlainObject(entryV) ||
+                                      !isPlainObject(field) ||
+                                      typeof field.block_name !== 'string' ||
+                                      isAtom(atomsMap[configK]) || // skip top level atoms (e.g initialize)
+                                      field.block_name !== refereeKey
+                                    )
+                                      return;
+
+                                    // Deleting the reference to current object
+
+                                    delete entryV[fieldK]; //eslint-disable-line
+
+                                    // The atom that has a reference to current object
+                                    atomsMap[configK][entryKey] =
+                                      atom<Record<string, ConfigValue>>(entryV);
+                                  });
+                                });
+                              });
+
+                            setAtomsMap({
+                              ...atomsMap,
+                              [configTab]: {
+                                ...selectedTabAtoms,
+                              },
+                            });
+                          }
+
+                          setSelectedItemIdx(null);
+                        }}
+                      />
+                    )}
+                  </div>
+                </div>
+              </Fragment>
+            );
+          })}
+          {!campaignId && !loading && !readOnly && (
+            <button
+              className="text-primary-8 flex h-[50px] min-h-[50px] w-[90%] min-w-[150px] items-center justify-between rounded-full bg-gray-100 px-5 py-2 text-sm drop-shadow"
+              type="button"
+              onClick={() => {
+                setEditing(true);
+                setSelectedCategory('');
+              }}
+            >
+              Add {sectionSchema.singular_name ?? sectionSchema.title ?? 'item'}
+              <PlusCircleOutlined />
+            </button>
+          )}
+        </>
+      )}
+    </>
+  );
 }

--- a/src/features/small-microcircuit/_components/section.tsx
+++ b/src/features/small-microcircuit/_components/section.tsx
@@ -33,8 +33,6 @@ export function useSectionRenderer(
   setSelectedCategory: React.Dispatch<React.SetStateAction<string>>,
   readOnly?: boolean
 ) {
-  const [collapsedHeader, setCollapsedHeader] = React.useState(false);
-
   const renderSection = ([k, v]: [string, JSONSchema]) => {
     if (!schema || !schema?.properties) return;
 
@@ -50,23 +48,20 @@ export function useSectionRenderer(
       <Fragment key={k}>
         <Tab
           tab={k}
-          selectedTab={!v.additionalProperties ? configTab : 'NO SELECTION FOR THIS SECTION'}
+          selectedTab={configTab}
           onClick={() => {
             if (configTab === k && !isRootCategory(schema, k)) {
               setEditing(false);
               setSelectedCategory('');
               setSelectedItemIdx(null);
-              setCollapsedHeader(!collapsedHeader);
+              setConfigTab('');
               return;
             }
 
-            setCollapsedHeader(false);
             setConfigTab(k);
             setSelectedItemIdx(null);
             if (!v.additionalProperties) setEditing(true);
-            else {
-              setEditing(false);
-            }
+            else setEditing(false);
           }}
           extraClass="w-full flex justify-between h-[50px] min-h-[50px] items-center drop-shadow"
         >
@@ -80,7 +75,7 @@ export function useSectionRenderer(
             <Chevron rotate={v.additionalProperties ? 90 : 0} />
           </div>
         </Tab>
-        {v.additionalProperties && configTab === k && config[k] && !collapsedHeader && (
+        {v.additionalProperties && configTab === k && config[k] && (
           <>
             {Object.entries(config[k]).map(([subkey, subValue]) => {
               const idx = parseInt(subkey.split('_')[1], 10);

--- a/src/features/small-microcircuit/index.tsx
+++ b/src/features/small-microcircuit/index.tsx
@@ -9,7 +9,7 @@ import { Fragment, Suspense, useRef, useMemo, useState } from 'react';
 import { Config, ConfigValue, JSONSchemaForm } from './_components/components';
 import { useConfigAtom } from './_components/hooks/config-atom';
 import { isRootCategory, resolveKey, useObioneJsonSchema } from './_components/hooks/schema';
-import { useSectionRenderer } from './_components/section';
+import { Section } from './_components/section';
 import TabsSelector from './_components/tabs-selector';
 import { CATEGORIES, isAtom, ORDERING } from './_components/utils';
 import { AtomsMap, JSONSchema, TabType } from './types';
@@ -94,24 +94,6 @@ export default function SimulationCampaignConfiguration({
   }, [validate, config]);
 
   useObioneJsonSchema(circuitId, notification, setSchema, setAtomsMap, initialConfig);
-  const renderSection = useSectionRenderer(
-    schema,
-    atomsMap,
-    setAtomsMap,
-    configTab,
-    setConfigTab,
-    isRootCategory,
-    resolveKey,
-    config,
-    campaignId,
-    loading,
-    errors,
-    selectedItemIdx,
-    setSelectedItemIdx,
-    setEditing,
-    setSelectedCategory,
-    readOnly
-  );
 
   if (!schema) {
     return (
@@ -147,8 +129,28 @@ export default function SimulationCampaignConfiguration({
                           const order = (k: string) => ORDERING[k]?.order ?? 999;
                           return order(a[0]) - order(b[0]);
                         })
-                        .map((entry) => {
-                          return renderSection(entry);
+                        .map(([k, v]) => {
+                          return (
+                            <Section
+                              key={k}
+                              k={k}
+                              schema={schema}
+                              sectionSchema={v}
+                              atomsMap={atomsMap}
+                              setAtomsMap={setAtomsMap}
+                              configTab={configTab}
+                              setConfigTab={setConfigTab}
+                              config={config}
+                              campaignId={campaignId}
+                              loading={loading}
+                              errors={errors}
+                              selectedItemIdx={selectedItemIdx}
+                              setSelectedItemIdx={setSelectedItemIdx}
+                              setEditing={setEditing}
+                              setSelectedCategory={setSelectedCategory}
+                              readOnly={readOnly}
+                            />
+                          );
                         })}
                   </Fragment>
                 );


### PR DESCRIPTION
For "non root categories" the tab should be blank only when the header is collapsed, but when expanded it should be highlighted.

It was also easier to remove the collapsedHeaderState and refactor renderSection into a component.