### PR TITLE
Better persist status overrides, add status polling

### DIFF
--- a/src/features/small-microcircuit/_components/atoms/index.ts
+++ b/src/features/small-microcircuit/_components/atoms/index.ts
@@ -1,21 +1,21 @@
 import { atom } from 'jotai';
+import { atomWithRefresh } from 'jotai/utils';
 import isEqual from 'lodash/isEqual';
 
+import { downloadAsset } from '@/api/entitycore/queries/assets';
+import { getCircuit } from '@/api/entitycore/queries/model/circuit';
 import { getCircuitSimulations } from '@/api/entitycore/queries/simulation/circuit-simulation';
 import { getCircuitSimulationExecutions } from '@/api/entitycore/queries/simulation/circuit-simulation-execution';
 import { getCircuitSimulationResult } from '@/api/entitycore/queries/simulation/circuit-simulation-result';
-import { ICircuitSimulation } from '@/api/entitycore/types/entities/circuit-simulation';
-import { ICircuitSimulationResult } from '@/api/entitycore/types/entities/circuit-simulation-result';
-import { readAtomFamilyWithExpiration } from '@/util/atoms';
-import { ICircuit } from '@/api/entitycore/types/entities/circuit';
-import { getCircuit } from '@/api/entitycore/queries/model/circuit';
-import { downloadAsset } from '@/api/entitycore/queries/assets';
 import { EntityTypeValue } from '@/api/entitycore/types';
-import {
-  CircuitSimulationExecutionStatus,
-  ICircuitSimulationExecution,
-} from '@/api/entitycore/types/entities/circuit-simulation-execution';
+import { ICircuit } from '@/api/entitycore/types/entities/circuit';
+import { ICircuitSimulation } from '@/api/entitycore/types/entities/circuit-simulation';
+import { ICircuitSimulationExecution } from '@/api/entitycore/types/entities/circuit-simulation-execution';
+import { ICircuitSimulationResult } from '@/api/entitycore/types/entities/circuit-simulation-result';
+import { getLatestSimExecStatus } from '@/features/small-microcircuit/_components/utils';
+import { SimExecStatusMap } from '@/features/small-microcircuit/types';
 import { WorkspaceContext } from '@/types/common';
+import { atomFamilyWithExpiration, readAtomFamilyWithExpiration } from '@/util/atoms';
 
 export const simExecBySimIdAtomFamily = readAtomFamilyWithExpiration(
   ({ simulationId, context }: { simulationId: string; context: WorkspaceContext }) =>
@@ -34,9 +34,9 @@ export const simExecBySimIdAtomFamily = readAtomFamilyWithExpiration(
   }
 );
 
-export const simExecStatusMapAtomFamily = readAtomFamilyWithExpiration(
+export const simExecRemoteStatusMapAtomFamily = atomFamilyWithExpiration(
   ({ simulationIds, context }: { simulationIds: string[]; context: WorkspaceContext }) =>
-    atom<Promise<Map<string, CircuitSimulationExecutionStatus>>>(async () => {
+    atomWithRefresh<Promise<SimExecStatusMap>>(async () => {
       const simulationExecutionFilters = { used__id__in: simulationIds.join(',') };
       const res = await getCircuitSimulationExecutions({
         filters: simulationExecutionFilters,
@@ -48,6 +48,47 @@ export const simExecStatusMapAtomFamily = readAtomFamilyWithExpiration(
         new Map()
       );
     }),
+  {
+    ttl: 120000, // 2 minutes
+    areEqual: isEqual,
+  }
+);
+
+type SimExecStatusMapAtomFamilyArg = { simulationIds: string[]; context: WorkspaceContext };
+
+export const simExecStatusMapAtomFamily = atomFamilyWithExpiration(
+  ({ simulationIds, context }: SimExecStatusMapAtomFamilyArg) => {
+    const simExecRemoteStatusMapAtom = simExecRemoteStatusMapAtomFamily({
+      simulationIds,
+      context,
+    });
+
+    const localStatusMapAtom = atom<SimExecStatusMap>(new Map());
+
+    return atom<Promise<SimExecStatusMap>, [SimExecStatusMap], void>(
+      async (get) => {
+        const remoteStatusMap = await get(simExecRemoteStatusMapAtom);
+        const localStatusMap = get(localStatusMapAtom);
+
+        const simIds = Array.from(new Set([...remoteStatusMap.keys(), ...localStatusMap.keys()]));
+        const statusMap = simIds.reduce((map, simId) => {
+          const remoteStatus = remoteStatusMap.get(simId);
+          const localStatus = localStatusMap.get(simId);
+          // If both are set we take the latest possible one,
+          // because the status change in a particular sequence.
+          // See definition of getLatestSimExecStatus
+          const status =
+            remoteStatus && localStatus
+              ? getLatestSimExecStatus(remoteStatus, localStatus)
+              : (localStatus ?? remoteStatus);
+          return map.set(simId, status);
+        }, new Map());
+
+        return statusMap;
+      },
+      (get, set, newStatusMap) => set(localStatusMapAtom, new Map(newStatusMap))
+    );
+  },
   {
     ttl: 120000, // 2 minutes
     areEqual: isEqual,

--- a/src/features/small-microcircuit/_components/utils.ts
+++ b/src/features/small-microcircuit/_components/utils.ts
@@ -1,3 +1,4 @@
+import { CircuitSimulationExecutionStatus } from '@/api/entitycore/types/entities/circuit-simulation-execution';
 import { Atom } from 'jotai';
 import uniq from 'lodash/uniq';
 
@@ -46,3 +47,23 @@ export const ORDERING: Record<string, { order: number; category: string }> = {
 };
 
 export const CATEGORIES: string[] = uniq(Object.values(ORDERING).map((o) => o.category));
+
+const simExecStatusListordered = [
+  CircuitSimulationExecutionStatus.CREATED,
+  CircuitSimulationExecutionStatus.PENDING,
+  CircuitSimulationExecutionStatus.RUNNING,
+  CircuitSimulationExecutionStatus.DONE,
+  CircuitSimulationExecutionStatus.ERROR,
+];
+
+export function getLatestSimExecStatus(
+  remoteStatus: CircuitSimulationExecutionStatus,
+  localStatus: CircuitSimulationExecutionStatus
+) {
+  const remoteStatusIdx = simExecStatusListordered.indexOf(remoteStatus);
+  const localStatusIdx = simExecStatusListordered.indexOf(localStatus);
+
+  const latestStatus = Math.max(remoteStatusIdx, localStatusIdx);
+
+  return simExecStatusListordered[latestStatus];
+}

--- a/src/features/small-microcircuit/index.tsx
+++ b/src/features/small-microcircuit/index.tsx
@@ -2,10 +2,14 @@
 
 import { LoadingOutlined, RightOutlined } from '@ant-design/icons';
 import Ajv, { AnySchema } from 'ajv';
-import { atom, useAtomValue } from 'jotai';
+import { atom, useAtomValue, useSetAtom } from 'jotai';
 import { Fragment, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 
-import { simExecStatusMapAtomFamily, simulationsByCampaignIdAtomFamily } from './_components/atoms';
+import {
+  simExecRemoteStatusMapAtomFamily,
+  simExecStatusMapAtomFamily,
+  simulationsByCampaignIdAtomFamily,
+} from './_components/atoms';
 import CircuitPreview from './_components/circuit-preview';
 import { Config, ConfigValue, JSONSchemaForm } from './_components/components';
 import { FileViewer } from './_components/file-viewer';
@@ -335,44 +339,59 @@ function SimulationsTab({ campaignId, virtualLabId, projectId }: SimulationTabPr
   const simulationsAtom = simulationsByCampaignIdAtomFamily({ campaignId, context });
   const simulations = useAtomValue(simulationsAtom);
 
-  const initialStatusMap = useLastTruthyValue(
-    simExecStatusMapAtomFamily({ context, simulationIds: simulations.map((s) => s.id) })
+  const simulationIds = simulations.map((s) => s.id);
+
+  const simExecStatusMapAtom = simExecStatusMapAtomFamily({ context, simulationIds });
+  const fetchRemoteSimExecStatuseMap = useSetAtom(
+    simExecRemoteStatusMapAtomFamily({ simulationIds, context })
   );
 
+  const statusMap = useLastTruthyValue(simExecStatusMapAtom);
+  const updateStatusMap = useSetAtom(simExecStatusMapAtom);
+
   const [simRequestInProgress, setSimRequestInProgress] = useState<boolean>(false);
-  const [statusMap, setStatusMap] = useState<Map<string, CircuitSimulationExecutionStatus>>(
-    new Map(initialStatusMap)
-  );
   const [simExecSelectedSimulationIds, setSimExecSelectedSimulationIds] = useState<string[]>([]);
   const [selectedSimulation, setSelectedSimulation] = useState<null | ICircuitSimulation>(null);
   const [selectedFile, setSelectedFile] = useState<File | undefined>(undefined);
 
   const activeSimulationExecStatus = selectedSimulation && statusMap?.get(selectedSimulation.id);
 
-  const setExecStatus = (simulationId: string, status: CircuitSimulationExecutionStatus) =>
-    setStatusMap(new Map(statusMap).set(simulationId, status));
-
-  useEffect(() => {
-    // TODO: check if this is usefull.
-    // Reset all exec status updates from streaming if initialStatusMap is getting reloaded.
-    setStatusMap(new Map(initialStatusMap));
-  }, [initialStatusMap]);
-
   useEffect(() => {
     // Auto select all simulations with status "created" on page load.
-    if (initialStatusMap) {
+    if (statusMap) {
       setSimExecSelectedSimulationIds(
         simulations
           .filter((s) => ['created', undefined].includes(statusMap.get(s.id)))
           .map((s) => s.id)
       );
     }
-  }, [simulations, statusMap, initialStatusMap]);
+  }, [simulations, statusMap]);
 
   useEffect(() => {
     // If there is only one simulation in the campaign - make it active on page load.
     if (simulations.length === 1) setSelectedSimulation(simulations[0]);
   }, [simulations]);
+
+  useEffect(() => {
+    // Poll simulation statuses if there are active (running/pending) simulations
+    // and no active simulation request with the status streaming
+    if (simRequestInProgress) return;
+
+    const hasActiveSimulations = statusMap
+      ?.values()
+      .some((status) =>
+        [
+          CircuitSimulationExecutionStatus.PENDING,
+          CircuitSimulationExecutionStatus.RUNNING,
+        ].includes(status)
+      );
+
+    if (!hasActiveSimulations) return;
+
+    const intervalId = setInterval(fetchRemoteSimExecStatuseMap, 15_000);
+
+    return () => clearInterval(intervalId);
+  }, [fetchRemoteSimExecStatuseMap, simRequestInProgress, statusMap]);
 
   const run = async () => {
     setSimRequestInProgress(true);
@@ -382,7 +401,7 @@ function SimulationsTab({ campaignId, virtualLabId, projectId }: SimulationTabPr
           ctx: { virtualLabId, projectId },
           simulationId: simulations[0].id,
           onMessage: (msg) => {
-            setExecStatus(simId, msg.status);
+            updateStatusMap(statusMap!.set(simId, msg.status));
             if (msg.status !== 'done') return;
 
             notification.success({ message: `Simulation ${simulations[0].name} done` });

--- a/src/features/small-microcircuit/types.ts
+++ b/src/features/small-microcircuit/types.ts
@@ -1,6 +1,7 @@
 import { atom } from 'jotai';
 
 import { ConfigValue } from './_components/components';
+import { CircuitSimulationExecutionStatus } from '@/api/entitycore/types/entities/circuit-simulation-execution';
 
 export type JSONSchema = {
   type?: 'string' | 'number' | 'integer' | 'object' | 'array' | 'boolean' | 'null';
@@ -30,3 +31,5 @@ export interface AtomsMap {
 }
 
 export type TabType = 'configuration' | 'simulations';
+
+export type SimExecStatusMap = Map<string, CircuitSimulationExecutionStatus>;

--- a/src/util/atoms.tsx
+++ b/src/util/atoms.tsx
@@ -1,4 +1,4 @@
-import { Atom } from 'jotai';
+import { Atom, WritableAtom } from 'jotai';
 import { atomFamily, atomWithRefresh } from 'jotai/utils';
 
 /**
@@ -46,6 +46,62 @@ export function readAtomFamilyWithExpiration<T, P>(
     };
 
     return wrapperAtomWithRefresh;
+  }, options.areEqual);
+
+  return family;
+}
+
+// ! This is potential fix for the issue where refresh doesn't work as expected
+// TODO: to be tested and to replace the original fn (above) afterwards.
+/**
+  Creates an atom family with automatic expiration after a specified time-to-live (TTL).
+
+  @param initializeReadAtom - Function that creates a writable atom for a given parameter
+  @param options - Configuration object containing:
+    - ttl: Time-to-live in milliseconds before the atom is removed
+    - areEqual: Optional comparison function to determine parameter equality
+
+  @returns An atom family that automatically removes atoms after their TTL expires
+*/
+export function atomFamilyWithExpiration<
+  FamilyParam,
+  AtomValue,
+  SetAtomArgs extends unknown[],
+  SetAtomResult extends unknown,
+>(
+  initializeWritableAtom: (
+    param: FamilyParam
+  ) => WritableAtom<AtomValue, SetAtomArgs, SetAtomResult>,
+  options: { ttl: number; areEqual?: (a: FamilyParam, b: FamilyParam) => boolean }
+) {
+  const family = atomFamily((param) => {
+    const atom = initializeWritableAtom(param);
+
+    let ttlTimeoutId: ReturnType<typeof setTimeout>;
+    let createdAt: number = 0;
+
+    const cleanup = () => family.remove(param);
+
+    atom.onMount = () => {
+      if (ttlTimeoutId) {
+        clearTimeout(ttlTimeoutId);
+      } else {
+        createdAt = Date.now();
+      }
+
+      return () => {
+        const now = Date.now();
+        if (now - createdAt > options.ttl) {
+          // Clean up if already expired.
+          cleanup();
+        } else {
+          // Clean up after ttl.
+          ttlTimeoutId = setTimeout(cleanup, now - createdAt + options.ttl);
+        }
+      };
+    };
+
+    return atom;
   }, options.areEqual);
 
   return family;


### PR DESCRIPTION
There were two issues with status updates:
1. Local changes (when status update arrives via streaming response) were not stored in atom, but rather in react state and were getting lost when navigating to other panel. Now status overrides (localStatus) is stored in the atom (with expiration) as well.
2. If the user leaves the page (or reloaded) there is no stream to update statuses. This is fixed by polling.

Now, it's a bit over-engineered. I think a good solution would be to split the sim request and the status update stream, so we can connect to it while the simulation running, but that will require additional changes - hopefully will do that after CNS.