### PR TITLE
Extend entity download with readme templates and assets

### DIFF
--- a/src/api/entitycore/types/entities/ion-channel.ts
+++ b/src/api/entitycore/types/entities/ion-channel.ts
@@ -1,8 +1,9 @@
 import type { IBrainRegionHierarchy } from '@/api/entitycore/types/entities/brain-region';
 import type {
   EntityAuthorization,
+  EntityCoreBaseAsset,
   EntityCoreIdentifiable,
-  IAsset,
+  EntityCoreType,
   IContributor,
   ISpecies,
   IStrain,
@@ -40,7 +41,8 @@ export interface IonChannelModel
     Timestamps,
     EntityCoreIdentifiable,
     EntityAuthorization,
-    IAsset {
+    EntityCoreType,
+    EntityCoreBaseAsset {
   species: ISpecies;
   strain?: IStrain | null;
   brain_region: IBrainRegionHierarchy;

--- a/src/api/entitycore/types/shared/global.ts
+++ b/src/api/entitycore/types/shared/global.ts
@@ -158,16 +158,31 @@ enum AssetStatus {
 }
 
 export enum AssetLabel {
+  brain_atlas_annotation = 'brain_atlas_annotation',
+  brain_atlas_region_mesh = 'brain_atlas_region_mesh',
   campaign_generation_config = 'campaign_generation_config',
+  campaign_summary = 'campaign_summary',
   cell_composition_summary = 'cell_composition_summary',
   cell_composition_volumes = 'cell_composition_volumes',
+  custom_node_sets = 'custom_node_sets',
+  emodel_optimization_output = 'emodel_optimization_output',
+  morphology = 'morphology',
+  neuron_hoc = 'neuron_hoc',
+  neuron_mechanisms = 'neuron_mechanisms',
+  nwb = 'nwb',
+  replay_spikes = 'replay_spikes',
   simulation_designer_image = 'simulation_designer_image',
   simulation_generation_config = 'simulation_generation_config',
-  single_cell_simulation = 'single_cell_simulation_data',
+  single_neuron_simulation_data = 'single_neuron_simulation_data',
   single_neuron_synaptome_config = 'single_neuron_synaptome_config',
   single_neuron_synaptome_simulation_data = 'single_neuron_synaptome_simulation_data',
   sonata_circuit = 'sonata_circuit',
-  validation_result = 'validation_result_details',
+  sonata_simulation_config = 'sonata_simulation_config',
+  spike_report = 'spike_report',
+  validation_result_details = 'validation_result_details',
+  validation_result_figure = 'validation_result_figure',
+  voltage_report = 'voltage_report',
+  voxel_densities = 'voxel_densities',
 }
 
 type AssetBase = {

--- a/src/features/entity-download/file-handlers.ts
+++ b/src/features/entity-download/file-handlers.ts
@@ -1,28 +1,23 @@
-import { Readable } from 'stream';
-import kebabCase from 'lodash/kebabCase';
-
-import { Metadata } from './metadata';
+/* eslint-disable no-empty */
 import {
-  getReconstructionMorphology,
   getElectricalCellRecording,
-  getExperimentalNeuronDensity,
-  getExperimentalBoutonDensity,
-  getExperimentalSynapsesPerConnection,
   getEModel,
+  getExperimentalBoutonDensity,
+  getExperimentalNeuronDensity,
+  getExperimentalSynapsesPerConnection,
   getMEModel,
+  getReconstructionMorphology,
 } from '@/api/entitycore/queries';
-import { downloadAsset } from '@/api/entitycore/queries/assets';
 import { getSingleNeuronSynaptome } from '@/api/entitycore/queries/model/single-neuron-synaptome';
 import { EntityTypeEnum, EntityTypeValue } from '@/api/entitycore/types';
+import { Metadata } from '@/features/entity-download/metadata';
+import { FileEntry } from '@/features/entity-download/types';
+import { createAssetFileEntry, createTemplateFileEntry } from '@/features/entity-download/utils';
 import { WorkspaceContext } from '@/types/common';
 
 const ASSETS_BASE_PATH = 'data';
 
-type FileEntry = {
-  path: string;
-  stream: Readable;
-  size: number;
-};
+// TODO: Add error reporting to Sentry.
 
 type GetEntityFilesHandler = (
   entityIds: string[],
@@ -32,6 +27,10 @@ type GetEntityFilesHandler = (
 
 async function* getReconstructionMorphologyFiles(entityIds: string[], ctx?: WorkspaceContext) {
   const metadata = new Metadata();
+
+  try {
+    yield await createTemplateFileEntry(EntityTypeEnum.ReconstructionMorphology);
+  } catch {}
 
   for (const entityId of entityIds) {
     const morphology = await getReconstructionMorphology({
@@ -44,28 +43,11 @@ async function* getReconstructionMorphologyFiles(entityIds: string[], ctx?: Work
     const dataPath = `${ASSETS_BASE_PATH}/${idx}`;
     metadata.add({ idx, data_path: dataPath, ...morphology });
 
-    for await (const asset of morphology.assets ?? []) {
-      const fileName = asset.full_path.split('/').at(-1);
+    for await (const asset of morphology.assets) {
+      const path = `${ASSETS_BASE_PATH}/${idx}/${asset.path}`;
       try {
-        const response = await downloadAsset<Response>({
-          ctx,
-          entityType: kebabCase(EntityTypeEnum.ReconstructionMorphology) as EntityTypeValue,
-          entityId,
-          id: asset.id,
-          asRawResponse: true,
-          retryOnError: false,
-        });
-        yield {
-          path: `${ASSETS_BASE_PATH}/${idx}/${fileName}`,
-          stream: Readable.fromWeb(response.body),
-          size: Number(response.headers.get('content-length')),
-        };
-      } catch (error) {
-        /*
-          TODO: report to Sentry once we have data in S3.
-          ? Create an error.log in the root of the tar file listing the errors to notify the user.
-        */
-      }
+        yield await createAssetFileEntry({ entity: morphology, asset, path, ctx });
+      } catch (error) {}
     }
   }
 
@@ -76,6 +58,10 @@ async function* getReconstructionMorphologyFiles(entityIds: string[], ctx?: Work
 
 async function* getElectricalCellRecordingFiles(entityIds: string[], ctx?: WorkspaceContext) {
   const metadata = new Metadata();
+
+  try {
+    yield await createTemplateFileEntry(EntityTypeEnum.ElectricalCellRecording);
+  } catch {}
 
   for (const entityId of entityIds) {
     const trace = await getElectricalCellRecording({
@@ -88,28 +74,11 @@ async function* getElectricalCellRecordingFiles(entityIds: string[], ctx?: Works
     const dataPath = `${ASSETS_BASE_PATH}/${idx}`;
     metadata.add({ idx, data_path: dataPath, ...trace });
 
-    for await (const asset of trace.assets ?? []) {
-      const fileName = asset.full_path.split('/').at(-1);
+    for await (const asset of trace.assets) {
+      const path = `${ASSETS_BASE_PATH}/${idx}/${asset.path}`;
       try {
-        const response = await downloadAsset<Response>({
-          ctx,
-          entityType: kebabCase(EntityTypeEnum.ElectricalCellRecording) as EntityTypeValue,
-          entityId,
-          id: asset.id,
-          asRawResponse: true,
-          retryOnError: false,
-        });
-        yield {
-          path: `${ASSETS_BASE_PATH}/${idx}/${fileName}`,
-          stream: Readable.fromWeb(response.body),
-          size: Number(response.headers.get('content-length')),
-        };
-      } catch (error) {
-        /*
-          TODO: report to Sentry once we have data in S3.
-          ? Create an error.log in the root of the tar file listing the errors to notify the user.
-        */
-      }
+        yield await createAssetFileEntry({ entity: trace, asset, path, ctx });
+      } catch (error) {}
     }
   }
 
@@ -120,6 +89,10 @@ async function* getElectricalCellRecordingFiles(entityIds: string[], ctx?: Works
 
 async function* getExperimentalNeuronDensityFiles(entityIds: string[], ctx?: WorkspaceContext) {
   const metadata = new Metadata();
+
+  try {
+    yield await createTemplateFileEntry(EntityTypeEnum.ExperimentalNeuronDensity);
+  } catch {}
 
   for (const entityId of entityIds) {
     const idx = metadata.entriesCount;
@@ -134,6 +107,10 @@ async function* getExperimentalNeuronDensityFiles(entityIds: string[], ctx?: Wor
 
 async function* getExperimentalBoutonDensityFiles(entityIds: string[], ctx?: WorkspaceContext) {
   const metadata = new Metadata();
+
+  try {
+    yield await createTemplateFileEntry(EntityTypeEnum.ExperimentalBoutonDensity);
+  } catch {}
 
   for (const entityId of entityIds) {
     const idx = metadata.entriesCount;
@@ -151,6 +128,10 @@ async function* getExperimentalSynapsesPerConnectionFiles(
   ctx?: WorkspaceContext
 ) {
   const metadata = new Metadata();
+
+  try {
+    yield await createTemplateFileEntry(EntityTypeEnum.ExperimentalSynapsesPerConnection);
+  } catch {}
 
   for (const entityId of entityIds) {
     const idx = metadata.entriesCount;
@@ -170,7 +151,10 @@ async function* getExperimentalSynapsesPerConnectionFiles(
 async function* getEmodelFiles(entityIds: string[], ctx?: WorkspaceContext) {
   const metadata = new Metadata();
 
-  // TODO: add emodel assets when supported by the API
+  try {
+    yield await createTemplateFileEntry(EntityTypeEnum.Emodel);
+  } catch {}
+
   for (const entityId of entityIds) {
     const idx = metadata.entriesCount;
     const emodel = await getEModel({
@@ -179,6 +163,38 @@ async function* getEmodelFiles(entityIds: string[], ctx?: WorkspaceContext) {
     });
 
     metadata.add({ idx, ...emodel });
+
+    // HOC file
+    const hocFileAsset = emodel.assets.find((asset) => asset.label === 'neuron_hoc')!;
+
+    try {
+      const path = `${ASSETS_BASE_PATH}/${idx}/hoc/${hocFileAsset.path}`;
+      yield await createAssetFileEntry({ entity: emodel, asset: hocFileAsset, path, ctx });
+    } catch (error) {}
+
+    // Morphologies
+    const exemplarMorphology = await getReconstructionMorphology({
+      id: emodel.exemplar_morphology.id,
+      context: ctx,
+    });
+
+    const morphAssets = exemplarMorphology.assets.filter((asset) => asset.label === 'morphology');
+
+    for await (const asset of morphAssets) {
+      const path = `${ASSETS_BASE_PATH}/${idx}/morphology/${asset.path}`;
+      try {
+        yield await createAssetFileEntry({ entity: exemplarMorphology, asset, path, ctx });
+      } catch (error) {}
+    }
+
+    // MOD files
+    for await (const icEntity of emodel.ion_channel_models) {
+      const modAsset = icEntity.assets.find((asset) => asset.label === 'neuron_mechanisms')!;
+      const path = `${ASSETS_BASE_PATH}/${idx}/mechanisms/${modAsset.path}`;
+      try {
+        yield await createAssetFileEntry({ entity: icEntity, asset: modAsset, path, ctx });
+      } catch (error) {}
+    }
   }
 
   for await (const metadataFileEntry of metadata.getFileEntries()) {
@@ -189,15 +205,54 @@ async function* getEmodelFiles(entityIds: string[], ctx?: WorkspaceContext) {
 async function* getMEmodelFiles(entityIds: string[], ctx?: WorkspaceContext) {
   const metadata = new Metadata();
 
-  // TODO: add emodel assets when supported by the API
+  try {
+    yield await createTemplateFileEntry(EntityTypeEnum.Memodel);
+  } catch {}
+
   for (const entityId of entityIds) {
     const idx = metadata.entriesCount;
-    const emodel = await getMEModel({
+    const memodel = await getMEModel({
       id: entityId,
       context: ctx,
     });
 
-    metadata.add({ idx, ...emodel });
+    metadata.add({ idx, ...memodel });
+
+    const emodel = await getEModel({
+      id: memodel.emodel.id,
+      context: ctx,
+    });
+
+    // HOC file
+    const hocFileAsset = emodel.assets.find((asset) => asset.label === 'neuron_hoc')!;
+    try {
+      const path = `${ASSETS_BASE_PATH}/${idx}/hoc/${hocFileAsset.path}`;
+      yield await createAssetFileEntry({ entity: emodel, asset: hocFileAsset, path, ctx });
+    } catch (error) {}
+
+    // Morphologies
+    const morphology = await getReconstructionMorphology({
+      id: memodel.morphology.id,
+      context: ctx,
+    });
+
+    const morphAssets = morphology.assets.filter((asset) => asset.label === 'morphology');
+
+    for await (const asset of morphAssets) {
+      const path = `${ASSETS_BASE_PATH}/${idx}/morphology/${asset.path}`;
+      try {
+        yield await createAssetFileEntry({ entity: morphology, asset, path, ctx });
+      } catch (error) {}
+    }
+
+    // MOD files
+    for await (const icEntity of emodel.ion_channel_models) {
+      const asset = icEntity.assets.find((a) => a.label === 'neuron_mechanisms')!;
+      const path = `${ASSETS_BASE_PATH}/${idx}/mechanisms/${asset.path}`;
+      try {
+        yield await createAssetFileEntry({ entity: icEntity, asset, path, ctx });
+      } catch (error) {}
+    }
   }
 
   for await (const metadataFileEntry of metadata.getFileEntries()) {
@@ -208,15 +263,75 @@ async function* getMEmodelFiles(entityIds: string[], ctx?: WorkspaceContext) {
 async function* getSingleNeuronSynaptomeFiles(entityIds: string[], ctx?: WorkspaceContext) {
   const metadata = new Metadata();
 
+  try {
+    yield await createTemplateFileEntry(EntityTypeEnum.SingleNeuronSynaptome);
+  } catch {}
+
   // TODO: add emodel assets when supported by the API
   for (const entityId of entityIds) {
     const idx = metadata.entriesCount;
-    const emodel = await getSingleNeuronSynaptome({
+    const singleNeuronSynaptomeModel = await getSingleNeuronSynaptome({
       id: entityId,
       context: ctx,
     });
 
-    metadata.add({ idx, ...emodel });
+    metadata.add({ idx, ...singleNeuronSynaptomeModel });
+
+    // Synaptome config
+    const synaptomeConfigAsset = singleNeuronSynaptomeModel.assets.find(
+      (asset) => asset.label === 'single_neuron_synaptome_config'
+    )!;
+    try {
+      const path = `${ASSETS_BASE_PATH}/${idx}/${synaptomeConfigAsset.path}`;
+      yield await createAssetFileEntry({
+        entity: singleNeuronSynaptomeModel,
+        asset: synaptomeConfigAsset,
+        path,
+        ctx,
+      });
+    } catch (error) {}
+
+    const memodel = await getMEModel({
+      id: singleNeuronSynaptomeModel.me_model.id,
+      context: ctx,
+    });
+
+    const emodel = await getEModel({
+      id: memodel.emodel.id,
+      context: ctx,
+    });
+
+    // HOC file
+    const hocFileAsset = emodel.assets.find((asset) => asset.label === 'neuron_hoc')!;
+    try {
+      const fileName = hocFileAsset.full_path.split('/').at(-1);
+      const path = `${ASSETS_BASE_PATH}/${idx}/hoc/${fileName}`;
+      yield await createAssetFileEntry({ entity: emodel, asset: hocFileAsset, path, ctx });
+    } catch (error) {}
+
+    // Morphologies
+    const morphology = await getReconstructionMorphology({
+      id: memodel.morphology.id,
+      context: ctx,
+    });
+
+    const morphAssets = morphology.assets.filter((asset) => asset.label === 'morphology');
+
+    for await (const asset of morphAssets) {
+      const path = `${ASSETS_BASE_PATH}/${idx}/morphology/${asset.path}`;
+      try {
+        yield await createAssetFileEntry({ entity: morphology, asset, path, ctx });
+      } catch (error) {}
+    }
+
+    // MOD files
+    for await (const icEntity of emodel.ion_channel_models) {
+      const asset = icEntity.assets.find((a) => a.label === 'neuron_mechanisms')!;
+      const path = `${ASSETS_BASE_PATH}/${idx}/mechanisms/${asset.path}`;
+      try {
+        yield await createAssetFileEntry({ entity: icEntity, asset, path, ctx });
+      } catch (error) {}
+    }
   }
 
   for await (const metadataFileEntry of metadata.getFileEntries()) {

--- a/src/features/entity-download/readme-templates/electrical-cell-recording.md
+++ b/src/features/entity-download/readme-templates/electrical-cell-recording.md
@@ -1,0 +1,21 @@
+# README
+
+Date: ${ date }
+Downloaded by: ${ username }
+Copyright (c) ${ year } Open Brain Institute
+
+## Description
+
+The Electrophysiology Trace file was downloaded from the Open Brain Platform: https://www.openbraininstitute.org/. The trace is in Neurodata Without Borders (NWB) format. The NWB file contains the raw data and metadata from patch-clamp experiments.
+
+## Requirements
+
+The software requirements to work with this artifact are given below:
+
+- Python Version: ">=3.9"
+- Python Packages and their Versions: h5py>=8.2.6, matplotlib>=3.10.0", pynwb>=3.0.0
+
+## Notebook
+
+This notebook can help you understand how you can use the Electrophysiology Trace file:
+https://github.com/openbraininstitute/obi_platform_analysis_notebooks/tree/main/Cellular/efeature_extraction/current_clamp_ephys_extraction

--- a/src/features/entity-download/readme-templates/emodel.md
+++ b/src/features/entity-download/readme-templates/emodel.md
@@ -1,0 +1,21 @@
+# README
+
+Date: ${ date }
+Downloaded by: ${ username }
+Copyright (c) ${ year } Open Brain Institute
+
+## Description
+
+The E-Model (electrical model) was downloaded from the Open Brain Platform: https://www.openbraininstitute.org/. The folder contains the hoc files, the morphology files (swc, asc, h5), a mechanisms folder with mod files, and the metadata file.
+
+## Requirements
+
+The software requirements to work with this artifact are given below:
+
+- Python Version: ">=3.10"
+- Python Packages and their Versions: bluecellulab>=2.6.40, neuron>=8.0<9.0, seaborn>=0.13.2, matplotlib>=3.7.1, currentscape>=1.0.20, scipy>=1.15.1
+
+## Notebook
+
+This notebook can help you understand how you can use the E-Model:
+https://github.com/openbraininstitute/obi_platform_analysis_notebooks/blob/main/Cellular/emodels/cadpyr_showcase/analysis_notebook.ipynb

--- a/src/features/entity-download/readme-templates/experimental-bouton-density.md
+++ b/src/features/entity-download/readme-templates/experimental-bouton-density.md
@@ -1,0 +1,17 @@
+# README
+
+Date: ${ date }
+Downloaded by: ${ username }
+Copyright (c) ${ year } Open Brain Institute
+
+## Description
+
+The Bouton Density entity was downloaded from the Open Brain Platform: https://www.openbraininstitute.org/. The value is given in mean +- standard deviation per cubic micrometer (1/um^3). The Bouton Density entity is a scalar value present in corresponding metadata file.
+
+## Notebook
+
+None
+
+## Requirements
+
+None

--- a/src/features/entity-download/readme-templates/experimental-neuron-density.md
+++ b/src/features/entity-download/readme-templates/experimental-neuron-density.md
@@ -1,0 +1,17 @@
+# README
+
+Date: ${ date }
+Downloaded by: ${ username }
+Copyright (c) ${ year } Open Brain Institute
+
+## Description
+
+The Neuron Density entity was downloaded from the Open Brain Platform: https://www.openbraininstitute.org/. The value is in the unit per cubic micrometer (1/mm^3). The Neuron Density entity is a scalar value present in corresponding metadata file.
+
+## Notebook
+
+None
+
+## Requirements
+
+None

--- a/src/features/entity-download/readme-templates/experimental-synapses-per-connection.md
+++ b/src/features/entity-download/readme-templates/experimental-synapses-per-connection.md
@@ -1,0 +1,17 @@
+# README
+
+Date: ${ date }
+Downloaded by: ${ username }
+Copyright (c) ${ year } Open Brain Institute
+
+## Description
+
+The Synapse per Connection entity was downloaded from the Open Brain Platform: https://www.openbraininstitute.org/. The value is given in mean +- standard deviation per cubic micrometer (1/um^3). The Synapse per Connection entity is a scalar value present in corresponding metadata file.
+
+## Notebook
+
+None
+
+## Requirements
+
+None

--- a/src/features/entity-download/readme-templates/memodel.md
+++ b/src/features/entity-download/readme-templates/memodel.md
@@ -1,0 +1,21 @@
+# README
+
+Date: ${ date }
+Downloaded by: ${ username }
+Copyright (c) ${ year } Open Brain Institute
+
+## Description
+
+The ME-Model (morpho-electrical model) was downloaded from the Open Brain Platform: https://www.openbraininstitute.org/. The folder contains the hoc files, the morphology files (swc, asc, h5), a mechanisms folder with mod files, and the metadata file.
+
+## Requirements
+
+The software requirements to work with this artifact are given below:
+
+- Python Version: ">=3.10"
+- Python Packages and their Versions: bluecellulab>=2.6.40, neuron>=8.0<9.0, seaborn>=0.13.2, matplotlib>=3.7.1, currentscape>=1.0.20, scipy>=1.15.1
+
+## Notebook
+
+This notebook can help you understand how you can use the ME-Model:
+https://github.com/openbraininstitute/obi_platform_analysis_notebooks/blob/main/Cellular/emodels/cadpyr_showcase/analysis_notebook.ipynb

--- a/src/features/entity-download/readme-templates/reconstruction-morphology.md
+++ b/src/features/entity-download/readme-templates/reconstruction-morphology.md
@@ -1,0 +1,21 @@
+# README
+
+Date: ${ date }
+Downloaded by: ${ username }
+Copyright (c) ${ year } Open Brain Institute
+
+## Description
+
+The Morphology entity was downloaded from the Open Brain Platform: https://www.openbraininstitute.org/. The morphology files are 3 different formats: swc, asc, and h5.
+
+## Notebook
+
+These notebooks can help you understand how you can use the morphology files:
+https://github.com/openbraininstitute/obi_platform_analysis_notebooks/tree/main/Cellular/morphologies and
+https://github.com/openbraininstitute/NeuroM/blob/master/tutorial/getting_started.ipynb
+
+## Requirements
+
+The software requirements to work with this artifact are given below:
+
+- [NeuroM](https://github.com/openbraininstitute/NeuroM)

--- a/src/features/entity-download/types.ts
+++ b/src/features/entity-download/types.ts
@@ -1,0 +1,7 @@
+import { Readable } from 'stream';
+
+export type FileEntry = {
+  path: string;
+  stream: Readable;
+  size: number;
+};

--- a/src/features/entity-download/utils.ts
+++ b/src/features/entity-download/utils.ts
@@ -1,4 +1,20 @@
+import fs from 'fs/promises';
+import fsPath from 'path';
 import { Readable } from 'stream';
+
+import { format } from 'date-fns';
+import kebabCase from 'lodash/kebabCase';
+import template from 'lodash/template';
+
+import { downloadAsset } from '@/api/entitycore/queries/assets';
+import { EntityTypeValue } from '@/api/entitycore/types';
+import { IEntity } from '@/api/entitycore/types/entities/entity';
+import { IAsset } from '@/api/entitycore/types/shared/global';
+import { getSession } from '@/authFetch';
+import { FileEntry } from '@/features/entity-download/types';
+import { WorkspaceContext } from '@/types/common';
+
+const README_TEMPLATE_DIR = './src/features/entity-download/readme-templates';
 
 /**
  * Generates headers for a file download stream.
@@ -33,4 +49,121 @@ export async function bufferStream(readable: Readable): Promise<Buffer> {
   }
 
   return Buffer.concat(chunks);
+}
+
+/**
+ * Creates a file entry for downloading an entity asset.
+ *
+ * @param {Object} params - The parameters for creating an asset file entry.
+ * @param {IEntity} params.entity - The entity containing the asset to download.
+ * @param {IAsset} params.asset - The asset to download.
+ * @param {string} params.path - The file path for the downloaded asset.
+ * @param {WorkspaceContext} [params.ctx] - Optional workspace context for the download request.
+ * @returns {Promise<FileEntry>} A promise that resolves to a file entry with stream, path, and size information.
+ *
+ * @description
+ * - Downloads the asset using the entity type and ID
+ * - Converts the response body to a readable stream
+ * - Extracts content length from response headers for file size
+ * - Returns a structured file entry ready for download processing
+ */
+export async function createAssetFileEntry({
+  ctx,
+  entity,
+  asset,
+  path,
+}: {
+  entity: IEntity;
+  asset: IAsset;
+  path: string;
+  ctx?: WorkspaceContext;
+}): Promise<FileEntry> {
+  const response = await downloadAsset<Response>({
+    ctx,
+    entityType: entity.type,
+    entityId: entity.id,
+    id: asset.id,
+    asRawResponse: true,
+    retryOnError: false,
+  });
+  return {
+    path,
+    stream: Readable.fromWeb(response.body),
+    size: Number(response.headers.get('content-length')),
+  };
+}
+
+type TemplateRenderParams = {
+  date: string;
+  year: string;
+  username: string;
+};
+
+/**
+ * Gets template render parameters for README file generation.
+ *
+ * @returns {Promise<TemplateRenderParams>} A promise that resolves to template parameters containing date, year, and username.
+ *
+ * @description
+ * - Retrieves the current user session to extract username
+ * - Formats the current date in ISO format (yyyy-MM-dd)
+ * - Extracts the current year
+ * - Returns structured parameters for template rendering
+ */
+export async function getReadmeTemplateRenderParams(): Promise<TemplateRenderParams> {
+  const session = await getSession();
+
+  const username = session?.user.username!;
+
+  const now = new Date();
+
+  // Current date in ISO format
+  const date = format(now, 'yyyy-MM-dd');
+
+  const year = format(now, 'yyyy');
+
+  return {
+    date,
+    year,
+    username,
+  };
+}
+
+/**
+ * Creates a file entry for a README template based on entity type.
+ *
+ * @param {EntityTypeValue} entityType - The entity type to determine which template to use.
+ * @returns {Promise<FileEntry>} A promise that resolves to a file entry with README content stream, path, and size information.
+ *
+ * @description
+ * - Retrieves template render parameters (date, year, username)
+ * - Reads the appropriate template file based on entity type using kebab-case naming
+ * - Renders the template by replacing placeholders with actual values
+ * - Converts the rendered content to a readable stream
+ * - Returns a structured file entry ready for download processing
+ */
+export async function createTemplateFileEntry(entityType: EntityTypeValue): Promise<FileEntry> {
+  const renderParams = await getReadmeTemplateRenderParams();
+
+  // Read template file based on entity type
+  const templatePath = fsPath.join(
+    process.cwd(),
+    README_TEMPLATE_DIR,
+    `${kebabCase(entityType)}.md`
+  );
+  const templateContent = await fs.readFile(templatePath, 'utf-8');
+
+  // Render template by replacing placeholders
+  const compiled = template(templateContent);
+  const renderedContent = compiled(renderParams);
+
+  // Convert to buffer and then to readable stream
+  const buffer = Buffer.from(renderedContent, 'utf-8');
+  const stream = Readable.from(buffer);
+
+  return {
+    path: 'README.md',
+    stream,
+    size: buffer.length,
+  };
 }


### PR DESCRIPTION
This change:
* Adds a `README.md` file to download package for most of the entity types.
* Add entity assets for E-model, ME-model and synaptome download packages.
* Syncs AssetLabels with those from entitySDK.
* Corrects IonChannelModel type.