### PR TITLE
246/add url for ai chat

### DIFF
--- a/src/services/ai-agent/api/thread.ts
+++ b/src/services/ai-agent/api/thread.ts
@@ -111,6 +111,7 @@ export async function serviceAiAgentThreadList({
       sort: '-update_date',
       cursor,
       page_size: `${pageSize}`,
+      exclude_empty: 'true',
     },
     typeGuard: isThreadListResponse,
   });

--- a/src/services/ai-agent/hooks/chat.ts
+++ b/src/services/ai-agent/hooks/chat.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import { ChatRequestOptions } from '@ai-sdk/ui-utils';
 import { CreateMessage, Message, useChat } from '@ai-sdk/react';
@@ -33,6 +35,7 @@ export function useServiceAiAgentChat(threadId: string) {
       return {
         content: (lastMessage?.content ?? '').trim(),
         tool_selection: activeTools,
+        frontend_url: `${globalThis.location.pathname}${globalThis.location.search}`,
       };
     },
     fetch: async (url, options) => {


### PR DESCRIPTION
When calling the chat, we add a n ew parameter to tell them what URL we are in. That will help the agent have a context.