### PR TITLE
fix hydaration mismatch for ai assistant

### DIFF
--- a/src/app/app/virtual-lab/(free)/explore/layout.tsx
+++ b/src/app/app/virtual-lab/(free)/explore/layout.tsx
@@ -6,6 +6,7 @@ import { ReactNode, useLayoutEffect } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import SimpleErrorComponent from '@/components/GenericErrorFallback';
+import HydrateWrapper from '@/wrappers/hydrate-wrapper';
 import { sectionAtom } from '@/state/application';
 
 import styles from './layout.module.css';
@@ -27,7 +28,9 @@ export default function ExploreLayout({ children }: GenericLayoutProps) {
     <ErrorBoundary FallbackComponent={SimpleErrorComponent}>
       <div className={styles.main}>
         <div className={styles.content}>{children}</div>
-        <AiAssistant section="explore" />
+        <HydrateWrapper>
+          <AiAssistant section="explore" />
+        </HydrateWrapper>
       </div>
     </ErrorBoundary>
   );

--- a/src/app/app/virtual-lab/lab/[virtualLabId]/project/[projectId]/explore/layout.tsx
+++ b/src/app/app/virtual-lab/lab/[virtualLabId]/project/[projectId]/explore/layout.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { useSetAtom } from 'jotai/index';
 
 import SimpleErrorComponent from '@/components/GenericErrorFallback';
+import HydrateWrapper from '@/wrappers/hydrate-wrapper';
 import { sectionAtom } from '@/state/application';
 
 import styles from './layout.module.css';
@@ -27,7 +28,9 @@ export default function ExploreLayout({ children }: GenericLayoutProps) {
     <ErrorBoundary FallbackComponent={SimpleErrorComponent}>
       <div className={styles.main}>
         <div className={styles.content}>{children}</div>
-        <AiAssistant section="explore" />
+        <HydrateWrapper>
+          <AiAssistant section="explore" />
+        </HydrateWrapper>
       </div>
     </ErrorBoundary>
   );

--- a/src/components/ai-assistant/ai-assistant.tsx
+++ b/src/components/ai-assistant/ai-assistant.tsx
@@ -2,8 +2,8 @@
 
 import { MinusOutlined, PlusOutlined } from '@ant-design/icons';
 import React, { type CSSProperties } from 'react';
+import dynamic from 'next/dynamic';
 
-import { Spinner } from './spinner';
 import { AiContextProvider, useCollapsedPanel } from './hooks';
 import PanelSplitter from './panel-splitter';
 import { IconChat } from './icons/chat';
@@ -19,6 +19,8 @@ interface AiAssistantProps {
   className?: string;
   section: 'explore' | 'build' | 'simulate' | 'bookmark' | 'activity';
 }
+
+const Spinner = dynamic(() => import('./spinner/spinner'), { ssr: false });
 
 export default function AiAssistant({ className, section }: AiAssistantProps) {
   const [tab, setTab] = React.useState<'chat' | 'history'>('chat');


### PR DESCRIPTION
due the change of the ai-assistant panel width by using the local storage, the first render in the server is different from the client render, this is a fix is for:
- prevents `content flash` during hydration
- ensures content is only rendered after the component has been fully hydrated on the client side
