### PR TITLE
Provide workspace context for experimental data views

### DIFF
--- a/src/app/app/virtual-lab/lab/[virtualLabId]/project/[projectId]/explore/interactive/(data)/experimental/[type]/[id]/page.tsx
+++ b/src/app/app/virtual-lab/lab/[virtualLabId]/project/[projectId]/explore/interactive/(data)/experimental/[type]/[id]/page.tsx
@@ -4,9 +4,12 @@ import DetailView from '@/features/views/details/experimental';
 import { getEntityBySlug } from '@/entity-configuration/domain/helpers';
 
 import type { ExperimentalEntitySlugValue } from '@/entity-configuration/domain/slug';
-import type { ServerSideComponentProp } from '@/types/common';
+import type { ServerSideComponentProp, WorkspaceContext } from '@/types/common';
 
-type Props = ServerSideComponentProp<{ type: ExperimentalEntitySlugValue; id: string }, null>;
+type Props = ServerSideComponentProp<
+  { type: ExperimentalEntitySlugValue; id: string; virtualLabId: string; projectId: string },
+  null
+>;
 
 export const generateMetadata = async ({ params }: Props): Promise<Metadata> => {
   const { type } = await params;
@@ -21,5 +24,8 @@ export const generateMetadata = async ({ params }: Props): Promise<Metadata> => 
 export default async function Page({ params: promisedParams }: Props) {
   const params = await promisedParams;
 
-  return <DetailView type={params.type} />;
+  const { virtualLabId, projectId } = params;
+  const ctx: WorkspaceContext = { virtualLabId, projectId };
+
+  return <DetailView type={params.type} ctx={ctx} />;
 }

--- a/src/features/entities/reconstruction-morphology/detail-view.tsx
+++ b/src/features/entities/reconstruction-morphology/detail-view.tsx
@@ -18,8 +18,15 @@ import Morphometrics from '@/features/entities/reconstruction-morphology/morphom
 import { ensureArray } from '@/utils/array';
 
 import type { IReconstructionMorphology } from '@/api/entitycore/types/entities/reconstruction-morphology';
+import { WorkspaceContext } from '@/types/common';
 
-export default function MorphologyDetailView({ detail }: { detail: IReconstructionMorphology }) {
+export default function MorphologyDetailView({
+  detail,
+  ctx,
+}: {
+  detail: IReconstructionMorphology;
+  ctx?: WorkspaceContext;
+}) {
   if (!detail) return null;
   return (
     <>
@@ -33,7 +40,7 @@ export default function MorphologyDetailView({ detail }: { detail: IReconstructi
           customError: 'Error while loading morphology viewer',
         })}
       >
-        <MorphoViewerLoaderMemo resource={detail} />
+        <MorphoViewerLoaderMemo resource={detail} ctx={ctx} />
       </ErrorBoundary>
       {/* <ErrorBoundary
         FallbackComponent={withErrorConfig({
@@ -56,10 +63,16 @@ export default function MorphologyDetailView({ detail }: { detail: IReconstructi
   );
 }
 
-function MorphoViewerLoader({ resource }: { resource: IReconstructionMorphology }) {
+function MorphoViewerLoader({
+  resource,
+  ctx,
+}: {
+  resource: IReconstructionMorphology;
+  ctx?: WorkspaceContext;
+}) {
   const morphologyDataAtom = useMemo(
-    () => loadable(createMorphologyDataAtom(resource)),
-    [resource]
+    () => loadable(createMorphologyDataAtom(resource, ctx)),
+    [resource, ctx]
   );
   // We disable enhanced somas until they are fixed on the backend.
   // const swcContentUrl = useSwcContentUrl(resource.distribution);

--- a/src/features/views/details/experimental.tsx
+++ b/src/features/views/details/experimental.tsx
@@ -16,12 +16,14 @@ import type { IReconstructionMorphology } from '@/api/entitycore/types/entities/
 import type { IElectricalCellRecording } from '@/api/entitycore/types/entities/electrical-cell-recording';
 import type { ExperimentalEntitySlugValue } from '@/entity-configuration/domain/slug';
 import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
+import { WorkspaceContext } from '@/types/common';
 
 type Props = {
   type: ExperimentalEntitySlugValue;
+  ctx?: WorkspaceContext;
 };
 
-export default function DetailView({ type }: Props) {
+export default function DetailView({ type, ctx }: Props) {
   const entity = getEntityBySlug({ slug: type });
   if (!entity) notFound();
 
@@ -32,13 +34,15 @@ export default function DetailView({ type }: Props) {
       },
       () => (
         <Summary dataType={DataType.ExperimentalNeuronMorphology}>
-          {(detail) => <MorphologyDetailView detail={detail as IReconstructionMorphology} />}
+          {(detail) => (
+            <MorphologyDetailView detail={detail as IReconstructionMorphology} ctx={ctx} />
+          )}
         </Summary>
       )
     )
     .with({ legacyType: DataType.ExperimentalElectroPhysiology }, () => (
       <Summary dataType={DataType.ExperimentalElectroPhysiology}>
-        {(detail) => <EphysViewer resource={detail as IElectricalCellRecording} />}
+        {(detail) => <EphysViewer resource={detail as IElectricalCellRecording} ctx={ctx} />}
       </Summary>
     ))
     .with(

--- a/src/state/morpho-viewer/index.ts
+++ b/src/state/morpho-viewer/index.ts
@@ -5,9 +5,11 @@ import { downloadAsset } from '@/api/entitycore/queries/assets';
 import { EntityTypeEnum } from '@/api/entitycore/types';
 
 import type { IReconstructionMorphology } from '@/api/entitycore/types/entities/reconstruction-morphology';
+import { WorkspaceContext } from '@/types/common';
 
 export default function createMorphologyDataAtom(
-  morphology: IReconstructionMorphology
+  morphology: IReconstructionMorphology,
+  ctx?: WorkspaceContext
 ): Atom<Promise<string | null>> {
   return atom(async (get) => {
     const session = get(sessionAtom);
@@ -24,6 +26,7 @@ export default function createMorphologyDataAtom(
       entityType: EntityTypeEnum.ReconstructionMorphology,
       entityId: morphology.id,
       id: asset.id,
+      ctx,
     });
 
     const decoder = new TextDecoder('utf-8');


### PR DESCRIPTION
The workspace context is not provided in the explore detailed views. The issue originally reported in https://github.com/openbraininstitute/prod-human-data-and-models/issues/6#issuecomment-3089471036.

This change adds missing context for experimental data views (mostly exp morphologies and traces) so that user generated content can be loaded.

@bilalesi feels like we should find a better way to provide context instead of doing prop drilling through the whole tree of components. Perhaps via a global state initialised with some server component? But that will require something else for the nested server components to work.
If we don't have a good solution for the time being - I propose to merge this to unblock Ilkan, and seek for it afterwards.