### PR TITLE
feat: filter electrical cell recording by recording-origin in explore/experimental data

### DIFF
--- a/src/api/entitycore/types/entities/electrical-cell-recording.ts
+++ b/src/api/entitycore/types/entities/electrical-cell-recording.ts
@@ -18,13 +18,74 @@ import type {
   EntityCoreOwnership,
 } from '@/api/entitycore/types/shared/global';
 
+const RecordingType = {
+  Intracellular: {
+    key: 'intracellular',
+    label: 'Intracellular',
+  },
+  Extracellular: {
+    key: 'extracellular',
+    label: 'extracellular',
+  },
+  Both: {
+    key: 'both',
+    label: 'both',
+  },
+  Unknown: {
+    key: 'unknown',
+    label: 'unknown',
+  },
+} as const;
+
+export const RecordingTypeDictionary = Object.fromEntries(
+  Object.entries(RecordingType).map(([name, value]) => [name, value.key])
+) as {
+  [K in keyof typeof RecordingType]: (typeof RecordingType)[K]['key'];
+};
+
+export type TRecordingTypeDictionary =
+  (typeof RecordingTypeDictionary)[keyof typeof RecordingTypeDictionary];
+
+export const ElectricalRecordingOrigin = {
+  InVivo: {
+    key: 'in_vivo',
+    label: 'in vivo',
+  },
+  InVitro: {
+    key: 'in_vitro',
+    label: 'in vitro',
+  },
+  InSilico: {
+    key: 'in_silico',
+    label: 'in silico',
+  },
+  Unknown: {
+    key: 'unknown',
+    label: 'unknown',
+  },
+} as const;
+
+export const ElectricalRecordingOriginDictionary = Object.fromEntries(
+  Object.entries(ElectricalRecordingOrigin).map(([name, value]) => [name, value.key])
+) as {
+  [K in keyof typeof ElectricalRecordingOrigin]: (typeof ElectricalRecordingOrigin)[K]['key'];
+};
+
+export type TElectricalRecordingOriginDictionary =
+  (typeof ElectricalRecordingOriginDictionary)[keyof typeof ElectricalRecordingOriginDictionary];
+
 export type ElectricalCellRecordingFilter = Partial<
   IDFilter &
     TimestampsFilter &
     ContributionFilter &
     BrainRegionFilter &
     PaginationFilter &
-    SharedFilter
+    SharedFilter & {
+      recording_type: TRecordingTypeDictionary | null;
+      recording_type__in: Array<TRecordingTypeDictionary> | null;
+      recording_origin: TElectricalRecordingOriginDictionary | null;
+      recording_origin__in: Array<TElectricalRecordingOriginDictionary> | null;
+    }
 >;
 
 interface IElectricalCellRecordingBase extends EntityCoreIdentifiable, EntityCoreOwnership {

--- a/src/entity-configuration/domain/experimental/electrical-cell-recording.ts
+++ b/src/entity-configuration/domain/experimental/electrical-cell-recording.ts
@@ -1,3 +1,4 @@
+import { ElectricalRecordingOriginDictionary } from '@/api/entitycore/types/entities/electrical-cell-recording';
 import { DataType } from '@/constants/explore-section/list-views';
 import { EntityTypeEnum } from '@/api/entitycore/types/entity-type';
 import { EntitySlug } from '@/entity-configuration/domain/slug';
@@ -20,7 +21,14 @@ export const ElectricalCellRecording: EntityCoreTypeConfig<IElectricalCellRecord
       allowedFacets: true,
     },
     query: {
-      list: getElectricalCellRecordings,
+      list: (params: Parameters<typeof getElectricalCellRecordings>[0]) =>
+        getElectricalCellRecordings({
+          ...params,
+          filters: {
+            ...params.filters,
+            recording_origin: ElectricalRecordingOriginDictionary.InVitro,
+          },
+        }),
       one: getElectricalCellRecording,
     },
   },

--- a/src/services/entitycore/entities-count.ts
+++ b/src/services/entitycore/entities-count.ts
@@ -3,15 +3,19 @@
 import { atomFamily, atomWithRefresh } from 'jotai/utils';
 import { useAtomValue } from 'jotai';
 
+import { ElectricalRecordingOriginDictionary } from '@/api/entitycore/types/entities/electrical-cell-recording';
 import {
   brainRegionBasicCellGroupsRegionsHierarchyAtom,
   DEFAULT_BRAIN_REGION_HIERARCHY_ID,
 } from '@/features/brain-region-hierarchy/context';
 import { getEntitiesCount } from '@/api/entitycore/queries/general/entity';
 import { findParentIds } from '@/features/brain-region-hierarchy/helpers';
+import { getElectricalCellRecordings } from '@/api/entitycore/queries';
+import { EntityTypeEnum } from '@/api/entitycore/types';
 import { tryCatch } from '@/api/utils';
 
-import { WorkspaceContext } from '@/types/common';
+import type { EntityCountResponse } from '@/api/entitycore/types/entities/entity';
+import type { WorkspaceContext } from '@/types/common';
 
 type Params = WorkspaceContext & {
   brainRegionId?: string | null;
@@ -28,7 +32,7 @@ const isListAtomEqual = (a: Params, b: Params): boolean =>
 export const entitiesCountAtom = atomFamily(
   ({ brainRegionId, virtualLabId, projectId }: Params) => {
     const childAtom = atomWithRefresh(async () => {
-      const { data, error } = await tryCatch(
+      const { data: restData, error: restError } = await tryCatch(
         getEntitiesCount({
           context: virtualLabId && projectId ? { virtualLabId, projectId } : undefined,
           types: [
@@ -36,7 +40,6 @@ export const entitiesCountAtom = atomFamily(
             'experimental_neuron_density',
             'experimental_bouton_density',
             'reconstruction_morphology',
-            'electrical_cell_recording',
             'single_neuron_synaptome',
             'memodel',
             'emodel',
@@ -48,6 +51,28 @@ export const entitiesCountAtom = atomFamily(
           },
         })
       );
+      const { data: ephysData, error: ephysError } = await tryCatch(
+        getElectricalCellRecordings({
+          withFacets: false,
+          context: virtualLabId && projectId ? { virtualLabId, projectId } : undefined,
+          filters: {
+            recording_origin: ElectricalRecordingOriginDictionary.InVitro,
+            page: 1,
+            page_size: 1,
+          },
+        })
+      );
+
+      const data: EntityCountResponse = {} as EntityCountResponse;
+      let error = null;
+
+      if (restData) Object.assign(data, restData);
+      if (ephysData)
+        Object.assign(data, {
+          [EntityTypeEnum.ElectricalCellRecording]: ephysData.pagination.total_items,
+        });
+
+      if (ephysError || restError) error = restError ?? ephysError;
       return { data, error };
     });
     childAtom.debugLabel = `count-atom/${brainRegionId}`;


### PR DESCRIPTION
in explore -> experimental, electrophysiology is filtered by the `recording_origin: in_vitro`,

Note that the electrophysiology (electrical cell recoding) will be added in the model data too with the filter of `recording_origin: in_silio`, this change will require to change the entity count components and also the domain `src/entity-configuration/domain/experimental/electrical-cell-recording.ts`

for future changes:

1. `DataType` should be renamed to `ExtendedTypes`.
2. create a new domain entity: (`ElectricalCellRecordingInVitro`, `ElectricalCellRecordingInSilio`) this will allow us to use the same entity model api and diverge when needed as listing page 
3. use DataType (ExtendedTypes) in the counter instead of the `EntityTypes` 