### PR TITLE
Url builder: Throw error for non existing entities

### DIFF
--- a/src/utils/url-builder.ts
+++ b/src/utils/url-builder.ts
@@ -20,11 +20,14 @@ export function resolveExploreDetailsPageUrl({
 }) {
   if (dataType && entityType)
     throw Error('Only one of dataType and entityType should be specified');
-  if (!dataType && !entityType) return '/'; // TODO: find a better to handle this
+  if (!dataType && !entityType) throw new Error('Cannot resolve url');
 
   const entityConfig = dataType
     ? getEntityByLegacyType({ legacyType: dataType })
     : getEntityByCoreType({ type: entityType });
+
+  if (!entityConfig) throw new Error('Invalid Entity');
+
   const slug = entityConfig?.slug; // morphology, e-model, ...
   const usedSlug: string | undefined = slug;
   const routePrefix = entityConfig?.explore.routePrefix; // interactive/experimental, model, simulate


### PR DESCRIPTION
For entities that are not supported in core-web-app, the resolveDetailUrl function returns an url like

https://staging.openbraininstitute.org/app/virtual-lab/explore/**undefined**/**undefined**/04e95bdd-1427-454a-ab3e-d6e0706d5b1a

Which is a bit odd, this makes the function throw an error for such cases.