### PR TITLE
Remove the widget to summarize articles

### DIFF
--- a/src/components/ai-assistant/message-item/message-item.tsx
+++ b/src/components/ai-assistant/message-item/message-item.tsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import { ToolInvocation, UIMessage } from '@ai-sdk/ui-utils';
 
-import ToolArticles from '../../../services/ai-agent/tools/articles/tool-articles';
 import ToolMorphologies from '../../../services/ai-agent/tools/morphologies/tool-morphologies';
 import { IconPrice } from '../icons/price';
 import ToolsProgress from './tools-progress';
@@ -72,7 +71,8 @@ function renderMessage(
           {!hideTools && (
             <>
               <ToolsComponents message={value} />
-              <ToolArticles message={value} />
+              {/* This tool component has been disabled yet */}
+              {/* <ToolArticles message={value} /> */}
               <ToolMorphologies message={value} />
             </>
           )}

--- a/src/components/ai-assistant/message-item/tools-components/tools/tool-thumbnail-generation-morphology-getone/tool-thumbnail-generation-morphology-getone.tsx
+++ b/src/components/ai-assistant/message-item/tools-components/tools/tool-thumbnail-generation-morphology-getone/tool-thumbnail-generation-morphology-getone.tsx
@@ -37,11 +37,11 @@ function CustomPlot({ className, result }: { className?: string; result: ToolRes
   const file = usePlotFile(result.storage_id);
   if (!file) return null;
 
-  const { content } = file;
-  if (isString(content)) return null;
+  const { content, type } = file;
+  if (type !== 'image' || !isString(content)) return null;
 
   // eslint-disable-next-line @next/next/no-img-element
-  return <img className={className} src={content.src} alt="Morphology thumbnail" />;
+  return <img className={className} src={content} alt="Morphology thumbnail" />;
 }
 
 function usePlotFile(fileIdentifier: string) {

--- a/src/services/ai-agent/api/storage.ts
+++ b/src/services/ai-agent/api/storage.ts
@@ -1,5 +1,3 @@
-import { tgdLoadImageFromArrayBuffer } from '@tolokoban/tgd';
-
 import { fetchJSON } from './util';
 import { assertString, isString } from '@/util/type-guards';
 
@@ -21,10 +19,7 @@ export async function serviceAiAgentStorageGetFileContent({
   const resp = await fetch(url);
   const type = resp.headers.get('X-Amz-Meta-Category') ?? 'unknown';
   if (type === 'image') {
-    const content = await tgdLoadImageFromArrayBuffer(await resp.arrayBuffer());
-    if (!content) throw Error('Unable to load the image!');
-
-    return { content, type };
+    return { content: url, type };
   }
   return {
     content: await resp.text(),
@@ -33,6 +28,6 @@ export async function serviceAiAgentStorageGetFileContent({
 }
 
 export interface StorageGetFileContent {
-  content: string | HTMLImageElement;
+  content: string;
   type: string;
 }

--- a/src/services/ai-agent/tools/articles/tool-articles/hooks.ts
+++ b/src/services/ai-agent/tools/articles/tool-articles/hooks.ts
@@ -2,7 +2,9 @@ import React from 'react';
 import { UIMessage } from '@ai-sdk/ui-utils';
 
 import { extractTool, uniquify } from '../../common';
-import { isLiteratureSearchToolResult, isWebSearchToolResult, ScientificArticle } from './types';
+import { isLiteratureSearchToolResult, ScientificArticle } from './types';
+import { logError } from '@/util/logger';
+import { assertType } from '@/util/type-guards';
 
 export function useArticles(message: UIMessage) {
   return React.useMemo(() => {
@@ -18,15 +20,20 @@ function extractFromLiteratureSearch(message: UIMessage, articles: ScientificArt
   for (const { output } of invocations) {
     if (!isLiteratureSearchToolResult(output)) continue;
 
-    for (const item of output.articles) {
-      const article: ScientificArticle = {
-        tool: 'literature-search-tool',
-        title: item.article_title,
-        abstract: item.abstract ?? 'No abstract.',
-        authors: item.article_authors,
-        url: `https://doi.org/${item.article_doi}`,
-      };
-      articles.push(article);
+    for (const item of output.content) {
+      const content = parseLiteratureSearchContent(item);
+      if (!content) continue;
+
+      for (const result of content.results) {
+        const article: ScientificArticle = {
+          tool: 'literature-search-tool',
+          title: result.title,
+          abstract: result.text,
+          authors: [result.author],
+          url: result.url,
+        };
+        articles.push(article);
+      }
     }
   }
 }
@@ -34,17 +41,73 @@ function extractFromLiteratureSearch(message: UIMessage, articles: ScientificArt
 function extractFromWebSearch(message: UIMessage, articles: ScientificArticle[]) {
   const invocations = extractTool(message, 'web-search-tool');
   for (const { output } of invocations) {
-    if (!isWebSearchToolResult(output)) continue;
+    if (!isLiteratureSearchToolResult(output)) continue;
 
-    for (const item of output.results) {
-      const article: ScientificArticle = {
-        tool: 'web-search-tool',
-        title: item.title,
-        abstract: item.content,
-        authors: [],
-        url: item.url,
-      };
-      articles.push(article);
+    for (const item of output.content) {
+      const content = parseLiteratureSearchContent(item);
+      if (!content) continue;
+
+      for (const result of content.results) {
+        const article: ScientificArticle = {
+          tool: 'literature-search-tool',
+          title: result.title,
+          abstract: result.text,
+          authors: [result.author],
+          url: result.url,
+        };
+        articles.push(article);
+      }
     }
+  }
+}
+
+interface LiteratureSearchContent {
+  results: Array<{
+    id: string;
+    author: string;
+    title: string;
+    url: string;
+    text: string;
+    publishedDate: string;
+  }>;
+}
+
+function parseLiteratureSearchContent(item: {
+  type: 'text';
+  text: string;
+}): LiteratureSearchContent {
+  if (item.type !== 'text') {
+    throw new Error(`Don't know how to deal with type "${item.type}"!`);
+  }
+  const data = parseJSON(item.text);
+  try {
+    assertType<LiteratureSearchContent>(data, {
+      results: [
+        'array',
+        {
+          id: 'string',
+          author: 'string',
+          title: 'string',
+          url: 'string',
+          text: 'string',
+          publishedDate: 'string',
+        },
+      ],
+    });
+    return data;
+  } catch (ex) {
+    const error = new Error('Unable to parse literature search content!');
+    error.cause = ex;
+    throw error;
+  }
+}
+
+function parseJSON(text: string) {
+  try {
+    return JSON.parse(text);
+  } catch (ex) {
+    logError('Unable to parse JSON content:', text);
+    logError(ex);
+    throw ex;
   }
 }

--- a/src/services/ai-agent/tools/articles/tool-articles/tool-articles.tsx
+++ b/src/services/ai-agent/tools/articles/tool-articles/tool-articles.tsx
@@ -25,7 +25,7 @@ export default function ToolArticles({ className, message }: ToolArticlesProps) 
       }
     >
       {articles.map((item) => (
-        <ArticleCard key={item.title} article={item} />
+        <ArticleCard key={item.url} article={item} />
       ))}
     </Expand>
   );

--- a/src/services/ai-agent/tools/articles/tool-articles/types.ts
+++ b/src/services/ai-agent/tools/articles/tool-articles/types.ts
@@ -1,5 +1,5 @@
 import { logError, logInfo } from '@/util/logger';
-import { assertType, TypeDef } from '@/util/type-guards';
+import { assertType } from '@/util/type-guards';
 
 export interface ScientificArticle {
   title: string;
@@ -9,32 +9,25 @@ export interface ScientificArticle {
   tool: string;
 }
 
-interface LiteratureSearchToolItem {
-  article_title: string;
-  article_doi: string;
-  article_authors: string[];
-  abstract: string | null;
-}
-
 interface LiteratureSearchToolResult {
-  articles: LiteratureSearchToolItem[];
-  error: unknown;
+  content: Array<{
+    type: 'text';
+    text: string;
+  }>;
+  isError: boolean;
 }
 
 export function isLiteratureSearchToolResult(data: unknown): data is LiteratureSearchToolResult {
   try {
-    const typeStringOrNull: TypeDef = ['|', 'string', 'null'];
     assertType(data, {
-      articles: [
+      isError: 'boolean',
+      content: [
         'array',
         {
-          article_title: 'string',
-          article_doi: typeStringOrNull,
-          article_authors: ['array', 'string'],
-          abstract: typeStringOrNull,
+          text: 'string',
+          type: 'string',
         },
       ],
-      error: 'unknown',
     });
     return true;
   } catch (ex) {


### PR DESCRIPTION
When  the AI calls literature search, it is now smart enough to write a decent result with images and links.
We do not need to have a widget displaying the result of the tools ourself now.