### PR TITLE
Added tool thumbnail-generation-electricalcellrecording-getone

### DIFF
--- a/src/components/ai-assistant/message-item/tools-components/tools-components.tsx
+++ b/src/components/ai-assistant/message-item/tools-components/tools-components.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { UIMessage } from '@ai-sdk/ui-utils';
 
 import ToolPlotGenerator from './tools/tool-plot-generator';
-import ToolThumbnailGenerationMorphologyGetone from './tools/tool-thumbnail-generation-morphology-getone';
+import ToolThumbnailGeneration from './tools/tool-thumbnail-generation-morphology-getone';
 import { isToolResult } from './tools/types';
 
 import { classNames } from '@/util/utils';
@@ -18,10 +18,13 @@ export default function ToolsComponents({ className, message }: ToolsComponentsP
   return (
     <div className={classNames(className, styles.toolsComponents)}>
       <ToolPlotGenerator results={extractToolsResults(message, ['plot-generator'], isToolResult)} />
-      <ToolThumbnailGenerationMorphologyGetone
+      <ToolThumbnailGeneration
         results={extractToolsResults(
           message,
-          ['thumbnail-generation-morphology-getone'],
+          [
+            'thumbnail-generation-morphology-getone',
+            'thumbnail-generation-electricalcellrecording-getone',
+          ],
           isToolResult
         )}
       />

--- a/src/components/ai-assistant/message-item/tools-components/tools/tool-thumbnail-generation-morphology-getone/tool-thumbnail-generation-morphology-getone.tsx
+++ b/src/components/ai-assistant/message-item/tools-components/tools/tool-thumbnail-generation-morphology-getone/tool-thumbnail-generation-morphology-getone.tsx
@@ -11,19 +11,19 @@ import { isString } from '@/util/type-guards';
 
 import styles from './tool-thumbnail-generation-morphology-getone.module.css';
 
-export interface ToolThumbnailGenerationMorphologyGetoneProps {
+export interface ToolThumbnailGenerationProps {
   className?: string;
   results: ToolResult[];
 }
 
-export default function ToolThumbnailGenerationMorphologyGetone({
+export default function ToolThumbnailGeneration({
   className,
   results,
-}: ToolThumbnailGenerationMorphologyGetoneProps) {
+}: ToolThumbnailGenerationProps) {
   return (
     <>
       {results.map((result) => (
-        <CustomPlot
+        <CustomThumbnail
           key={result.storage_id}
           className={classNames(className, styles.toolThumbnailGenerationMorphologyGetone)}
           result={result}
@@ -33,7 +33,7 @@ export default function ToolThumbnailGenerationMorphologyGetone({
   );
 }
 
-function CustomPlot({ className, result }: { className?: string; result: ToolResult }) {
+function CustomThumbnail({ className, result }: { className?: string; result: ToolResult }) {
   const file = usePlotFile(result.storage_id);
   if (!file) return null;
 
@@ -48,10 +48,15 @@ function usePlotFile(fileIdentifier: string) {
   const accessToken = useAccessToken() ?? 'NO-TOKEN';
   const file = useAsyncMemo(fileIdentifier, async () => {
     try {
+      console.log(
+        '🚀 [tool-thumbnail-generation-morphology-getone] fileIdentifier =',
+        fileIdentifier
+      ); // @FIXME: Remove this line written on 2025-09-02 at 11:06
       const data = await serviceAiAgentStorageGetFileContent({
         accessToken,
         fileIdentifier,
       });
+      console.log('🚀 [tool-thumbnail-generation-morphology-getone] data =', data); // @FIXME: Remove this line written on 2025-09-02 at 11:06
       return data;
     } catch (ex) {
       logError(`Unable to retrieve file "${fileIdentifier}":`, ex);

--- a/src/services/ai-agent/api/storage.ts
+++ b/src/services/ai-agent/api/storage.ts
@@ -17,7 +17,12 @@ export async function serviceAiAgentStorageGetFileContent({
   });
   assertString(url, 'presigned-url');
   const resp = await fetch(url);
-  const type = resp.headers.get('X-Amz-Meta-Category') ?? 'unknown';
+  console.log(
+    "🚀 [storage] url, resp.headers.get('x-amz-meta-category') =",
+    url,
+    resp.headers.get('X-Amz-Meta-Category')
+  ); // @FIXME: Remove this line written on 2025-09-02 at 11:08
+  const type = resp.headers.get('x-amz-meta-category') ?? 'unknown';
   if (type === 'image') {
     return { content: url, type };
   }


### PR DESCRIPTION
This tool do return images in the same exact way that tool `thumbnail-generation-morphology-getone` does:
1. The tool returns a file identifier.
2. We use it to ask `storage/${fileIdentifier}/presigned-url` backend entrypoint for the AWS bucket URL.
3. We fetch from the bucket and read the Response Header `X-Amz-Meta-Category` to get the mime type.

