### PR TITLE
Make 'run on EKS' visible in preview environment

### DIFF
--- a/src/app/app/_virtual-lab/lab/[virtualLabId]/project/[projectId]/(pages)/notebooks/NotebookTable.tsx
+++ b/src/app/app/_virtual-lab/lab/[virtualLabId]/project/[projectId]/(pages)/notebooks/NotebookTable.tsx
@@ -242,7 +242,8 @@ function NotebookTable({
                 </div>
               )}
               {(env.NEXT_PUBLIC_DEPLOYMENT_ENV === 'staging' ||
-                env.NEXT_PUBLIC_DEPLOYMENT_ENV === 'development') && (
+                env.NEXT_PUBLIC_DEPLOYMENT_ENV === 'development' ||
+                env.NEXT_PUBLIC_DEPLOYMENT_ENV === 'preview') && (
                 <div className="flex gap-4">
                   <button
                     type="button"


### PR DESCRIPTION
@bilalesi that 'run on eks' is currently no longer displayed in dev, likely because it's now based on the preview branch. Would this PR be ok to make it visible again in preview?