### PR TITLE
make derivation type required

### DIFF
--- a/src/api/entitycore/queries/general/derivation.ts
+++ b/src/api/entitycore/queries/general/derivation.ts
@@ -1,11 +1,12 @@
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
+
 import type {
   IDerivationFilter,
   IDerivationBase,
 } from '@/api/entitycore/types/entities/derivation';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
-import type { KebabCase, NormalizeChars } from '@/utils/type';
 import type { TEntityTypeDict } from '@/api/entitycore/types/entity-type';
+import type { KebabCase, NormalizeChars } from '@/utils/type';
 import type { WorkspaceContext } from '@/types/common';
 
 /**

--- a/src/api/entitycore/types/entities/derivation.ts
+++ b/src/api/entitycore/types/entities/derivation.ts
@@ -5,19 +5,40 @@ import type {
   SharedFilter,
 } from '@/api/entitycore/types/shared/request';
 
-export interface IDerivationBase extends EntityCoreIdentifiable, EntityCoreType {}
-export interface IDerivationFilter extends PaginationFilter, SharedFilter, EntityCoreTypeFilter {}
-
+/**
+ * Represents the type of derivation relationship between two entities.
+ *
+ * - circuit_extraction: Indicates that the entity was derived by extracting a set of nodes from
+ *   a circuit.
+ * - circuit_rewiring: Indicates that the entity was derived by rewiring the connectivity of
+ *   a circuit.
+ * - unspecified: Indicates a derivation that does not require a specific type.
+ */
 export const DerivationType = {
-  /**
-   * Indicates that the entity was derived by extracting a set of nodes from a circuit.
-   */
-  circuit_extraction: 'circuit_extraction',
-
-  /**
-   * Indicates that the entity was derived by rewiring the connectivity of a circuit.
-   */
-  circuit_rewiring: 'circuit_rewiring',
+  CircuitExtraction: {
+    key: 'circuit_extraction',
+    label: 'Circuit extraction',
+  },
+  CircuitRewiring: {
+    key: 'circuit_rewiring',
+    label: 'Circuit rewiring',
+  },
+  Unspecified: {
+    key: 'unspecified',
+    label: 'Unspecified',
+  },
 } as const;
 
-export type TDerivationType = (typeof DerivationType)[keyof typeof DerivationType];
+export const DerivationTypeDictionary = Object.fromEntries(
+  Object.entries(DerivationType).map(([name, value]) => [name, value.key])
+) as {
+  [K in keyof typeof DerivationType]: (typeof DerivationType)[K]['key'];
+};
+
+export type TDerivationType =
+  (typeof DerivationTypeDictionary)[keyof typeof DerivationTypeDictionary];
+
+export interface IDerivationBase extends EntityCoreIdentifiable, EntityCoreType {}
+export interface IDerivationFilter extends PaginationFilter, SharedFilter, EntityCoreTypeFilter {
+  derivation_type: TDerivationType;
+}

--- a/src/features/entities/circuit/elements/context.tsx
+++ b/src/features/entities/circuit/elements/context.tsx
@@ -11,8 +11,8 @@ import { atom } from 'jotai';
 import _get from 'lodash/get';
 import pMap from 'p-map';
 
+import { DerivationTypeDictionary } from '@/api/entitycore/types/entities/derivation';
 import { getAllCircuitIds } from '@/features/entities/circuit/elements/helpers';
-import { DerivationType } from '@/api/entitycore/types/entities/derivation';
 import {
   getCircuitHierarchyByDerivation,
   getCircuits,
@@ -121,7 +121,7 @@ export const hierarchyByExtractionDerivationAtomFamily = atomFamily(
     const childAtom = atom(async () => {
       const hierarchyByDerivation = await getCircuitHierarchyByDerivation({
         context: virtualLabId && projectId ? { virtualLabId, projectId } : undefined,
-        derivation_type: DerivationType.circuit_extraction,
+        derivation_type: DerivationTypeDictionary.CircuitExtraction,
       });
       childAtom.debugLabel = `circuit_extraction-derivation/${key}`;
       return hierarchyByDerivation;
@@ -135,7 +135,7 @@ export const hierarchyByRewiringDerivationAtomFamily = atomFamily(
     const childAtom = atom(async () => {
       const hierarchyByDerivation = await getCircuitHierarchyByDerivation({
         context: virtualLabId && projectId ? { virtualLabId, projectId } : undefined,
-        derivation_type: DerivationType.circuit_rewiring,
+        derivation_type: DerivationTypeDictionary.CircuitRewiring,
       });
       childAtom.debugLabel = `circuit_rewiring-derivation/${key}`;
       return hierarchyByDerivation;

--- a/src/state/e-model.ts
+++ b/src/state/e-model.ts
@@ -2,6 +2,7 @@ import { Atom, atom } from 'jotai';
 import { atomFamily } from 'jotai/utils';
 
 import { pageNumberAtom, pageSizeAtom } from '@/state/explore-section/list-view-atoms';
+import { DerivationTypeDictionary } from '@/api/entitycore/types/entities/derivation';
 import { getEntityDerivations } from '@/api/entitycore/queries/general/derivation';
 import { getElectricalCellRecordings } from '@/api/entitycore/queries';
 import { tryCatch } from '@/api/utils';
@@ -23,6 +24,7 @@ export const experimentalTracesAtomFamily = atomFamily<
           entityId: ctx.id,
           entityRoute: 'emodel',
           filters: {
+            derivation_type: DerivationTypeDictionary.Unspecified,
             page: pageNumber,
             page_size: pageSize,
           },

--- a/src/ui/segments/explore/circuit/context.tsx
+++ b/src/ui/segments/explore/circuit/context.tsx
@@ -11,8 +11,8 @@ import { atom } from 'jotai';
 import _get from 'lodash/get';
 import pMap from 'p-map';
 
+import { DerivationTypeDictionary } from '@/api/entitycore/types/entities/derivation';
 import { getAllCircuitIds } from '@/features/entities/circuit/elements/helpers';
-import { DerivationType } from '@/api/entitycore/types/entities/derivation';
 import {
   getCircuitHierarchyByDerivation,
   getCircuits,
@@ -121,7 +121,7 @@ export const hierarchyByExtractionDerivationAtomFamily = atomFamily(
     const childAtom = atom(async () => {
       const hierarchyByDerivation = await getCircuitHierarchyByDerivation({
         context: virtualLabId && projectId ? { virtualLabId, projectId } : undefined,
-        derivation_type: DerivationType.circuit_extraction,
+        derivation_type: DerivationTypeDictionary.CircuitExtraction,
       });
       childAtom.debugLabel = `circuit_extraction-derivation/${key}`;
       return hierarchyByDerivation;
@@ -135,7 +135,7 @@ export const hierarchyByRewiringDerivationAtomFamily = atomFamily(
     const childAtom = atom(async () => {
       const hierarchyByDerivation = await getCircuitHierarchyByDerivation({
         context: virtualLabId && projectId ? { virtualLabId, projectId } : undefined,
-        derivation_type: DerivationType.circuit_rewiring,
+        derivation_type: DerivationTypeDictionary.CircuitRewiring,
       });
       childAtom.debugLabel = `circuit_rewiring-derivation/${key}`;
       return hierarchyByDerivation;

--- a/src/ui/segments/explore/circuit/use-hierarchy.tsx
+++ b/src/ui/segments/explore/circuit/use-hierarchy.tsx
@@ -18,10 +18,10 @@ import {
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { useQueryExtendedEntityType } from '@/ui/hooks/use-query-extended-entity-type';
 import { CircuitView, getAllCircuitIds } from '@/ui/segments/explore/circuit/helpers';
-import { DerivationType } from '@/api/entitycore/types/entities/derivation';
+import { DerivationTypeDictionary } from '@/api/entitycore/types/entities/derivation';
 import { DEFAULT_PAGE_SIZE, WorkspaceScope } from '@/constants';
-import { keyBuilder } from '@/ui/use-query-keys/data';
 import { useWorkspace } from '@/ui/hooks/use-workspace';
+import { keyBuilder } from '@/ui/use-query-keys/data';
 import {
   getCircuitHierarchyByDerivation,
   getCircuits,
@@ -54,12 +54,12 @@ export function useHierarchy({
       queryKey: keyBuilder.circuitsByDerivationTree({
         virtualLabId,
         projectId,
-        derivationType: DerivationType.circuit_extraction,
+        derivationType: DerivationTypeDictionary.CircuitExtraction,
       }),
       queryFn: () =>
         getCircuitHierarchyByDerivation({
           context: { virtualLabId, projectId },
-          derivation_type: DerivationType.circuit_extraction,
+          derivation_type: DerivationTypeDictionary.CircuitExtraction,
         }),
       enabled: view === CircuitView.Hierarchy,
       staleTime: Infinity,
@@ -72,12 +72,12 @@ export function useHierarchy({
         queryKey: keyBuilder.circuitsByDerivationTree({
           virtualLabId,
           projectId,
-          derivationType: DerivationType.circuit_extraction,
+          derivationType: DerivationTypeDictionary.CircuitExtraction,
         }),
         queryFn: () =>
           getCircuitHierarchyByDerivation({
             context: { virtualLabId, projectId },
-            derivation_type: DerivationType.circuit_extraction,
+            derivation_type: DerivationTypeDictionary.CircuitExtraction,
           }),
       });
       const IDs = getAllCircuitIds(hierarchyByDerivationData);


### PR DESCRIPTION
- use `DerivationTypeDictionary` instead of DerivationType
- use unspecified derivation type for experimental traces