### PR TITLE
Force long links in chat response to wrap

### DIFF
--- a/src/components/ai-assistant/message-item/message-item.module.css
+++ b/src/components/ai-assistant/message-item/message-item.module.css
@@ -115,6 +115,7 @@
 .markdown a {
   color: var(--color-secondary-5);
   text-decoration: underline;
+  word-break: break-all;
 }
 
 button.debugButton {

--- a/src/components/github-flavor-markdown/github-flavor-markdown.module.css
+++ b/src/components/github-flavor-markdown/github-flavor-markdown.module.css
@@ -1,19 +1,21 @@
-.githubFlavorMarkdown table {
-  border-collapse: collapse;
-}
+.githubFlavorMarkdown {
+  table {
+    border-collapse: collapse;
 
-.githubFlavorMarkdown table td {
-  border: 1px solid #0007;
-  padding: 0 0.5em;
-}
+    td {
+      border: 1px solid #0007;
+      padding: 0 0.5em;
+    }
 
-.githubFlavorMarkdown table th {
-  color: #fff;
-  background-color: #003a8c;
-  padding: 0 0.5em;
-  border: 1px solid #fff7;
-}
+    th {
+      color: #fff;
+      background-color: #003a8c;
+      padding: 0 0.5em;
+      border: 1px solid #fff7;
+    }
+  }
 
-.githubFlavorMarkdown :global(span.katex-html) {
-  display: none;
+  :global(span.katex-html) {
+    display: none;
+  }
 }


### PR DESCRIPTION
On Safari, long links were not wrapped and just overflowed.

<img width="346" height="300" alt="image" src="https://github.com/user-attachments/assets/45718ca3-aaa8-47e4-a401-275135afa6c3" />
