### PR TITLE
313/count filters not displayed

### DIFF
--- a/src/ui/segments/data-table/elements/filter-controls.tsx
+++ b/src/ui/segments/data-table/elements/filter-controls.tsx
@@ -47,7 +47,11 @@ export function FilterControls({
   const selectedFiltersCount = filters
     ? filters.filter((filter) => filterHasValue(filter)).length
     : 0;
-
+  console.log(
+    '🚀 [filter-controls] filters, selectedFiltersCount =',
+    filters,
+    selectedFiltersCount
+  ); // @FIXME: Remove this line written on 2025-09-29 at 11:55
   const onFilterClick = () => setDisplayControlPanel(!displayControlPanel);
 
   return (

--- a/src/ui/segments/data-table/elements/filter-controls.tsx
+++ b/src/ui/segments/data-table/elements/filter-controls.tsx
@@ -47,11 +47,6 @@ export function FilterControls({
   const selectedFiltersCount = filters
     ? filters.filter((filter) => filterHasValue(filter)).length
     : 0;
-  console.log(
-    '🚀 [filter-controls] filters, selectedFiltersCount =',
-    filters,
-    selectedFiltersCount
-  ); // @FIXME: Remove this line written on 2025-09-29 at 11:55
   const onFilterClick = () => setDisplayControlPanel(!displayControlPanel);
 
   return (

--- a/src/ui/segments/data-table/elements/listing-filter-panel/util.ts
+++ b/src/ui/segments/data-table/elements/listing-filter-panel/util.ts
@@ -19,7 +19,7 @@ export function filterHasValue(filter: CoreFilter) {
     case CoreFieldFilterTypeEnum.DateRange:
       return !isEmpty(filter.value.gte) || !isEmpty(filter.value.lte);
     case CoreFieldFilterTypeEnum.ValueRange:
-      return !isEmpty(filter.value.gte) || !isEmpty(filter.value.lte);
+      return isNumber(filter.value.gte) || isNumber(filter.value.lte);
     case CoreFieldFilterTypeEnum.WithinList:
       return false; // TODO: this is need to be discussed/fixed
     case CoreFieldFilterTypeEnum.ValueOrRange:


### PR DESCRIPTION
For range filters, the widget with the number of active filters was not updates.
It was due to the function `isEmpty` that does not work with numbers.