### PR TITLE
Migrate to new resolveExploreDetailsPageUrl

### DIFF
--- a/src/app/app/[virtualLabId]/[projectId]/[id]/page.tsx
+++ b/src/app/app/[virtualLabId]/[projectId]/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { redirect, notFound } from 'next/navigation';
 import { getEntity } from '@/api/entitycore/queries/general/entity';
 import { IEntity } from '@/api/entitycore/types/entities/entity';
-import { resolveExploreDetailsPageUrl2 } from '@/utils/url-builder';
+import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
 
 export default async function EntityDetail({
   params,
@@ -14,7 +14,7 @@ export default async function EntityDetail({
   let url: string;
   try {
     entity = await getEntity({ id });
-    url = resolveExploreDetailsPageUrl2({
+    url = resolveExploreDetailsPageUrl({
       ctx: { virtualLabId, projectId },
       entityId: id,
       dataType: entity.type,

--- a/src/app/app/entity/[id]/page.tsx
+++ b/src/app/app/entity/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { redirect, notFound } from 'next/navigation';
 import { getEntity } from '@/api/entitycore/queries/general/entity';
-import { resolveExploreDetailsPageUrl2 } from '@/utils/url-builder';
+import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
 import { tryCatch } from '@/api/utils';
 import { resolveWorkspace } from '@/ui/segments/app-setup/helpers';
 import { getUserGroups } from '@/api/virtual-lab-svc/queries/user';
@@ -27,7 +27,7 @@ export default async function EntityDetail({ params }: { params: Promise<{ id: s
     }
 
     redirect(
-      resolveExploreDetailsPageUrl2({ ctx: redirectCtx, entityId: id, dataType: entity.type })
+      resolveExploreDetailsPageUrl({ ctx: redirectCtx, entityId: id, dataType: entity.type })
     );
   }
 
@@ -40,7 +40,7 @@ export default async function EntityDetail({ params }: { params: Promise<{ id: s
   if (!group) notFound();
 
   redirect(
-    resolveExploreDetailsPageUrl2({
+    resolveExploreDetailsPageUrl({
       ctx: { virtualLabId: group.virtual_lab_id, projectId: group.project_id },
       entityId: id,
       dataType: entity.type,

--- a/src/features/entities/circuit/elements/related-circuits/derived-from.tsx
+++ b/src/features/entities/circuit/elements/related-circuits/derived-from.tsx
@@ -11,7 +11,7 @@ import { BaseTable } from '@/components/explore-section/ExploreSectionListingVie
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { activeColumnsAtom } from '@/state/explore-section/list-view-atoms';
 import { ExploreDataScope } from '@/types/explore-section/application';
-import { resolveExploreDetailsPageUrl2 } from '@/utils/url-builder';
+import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
 
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
 import type { WorkspaceContext } from '@/types/common';
@@ -47,7 +47,7 @@ export function DerivedFrom({ data }: Props) {
 
   const onCellClick = (basePath: string, record: ICircuit) => {
     navigate(
-      resolveExploreDetailsPageUrl2({
+      resolveExploreDetailsPageUrl({
         ctx: { virtualLabId, projectId },
         dataType: ExtendedEntitiesTypeDict.Circuit,
         entityId: record.id,

--- a/src/features/entities/circuit/elements/related-circuits/derived.tsx
+++ b/src/features/entities/circuit/elements/related-circuits/derived.tsx
@@ -15,7 +15,7 @@ import { HierarchyOutputNode } from '@/features/entities/circuit/elements/contex
 import { expandIcon } from '@/features/entities/circuit/elements/expand-icon';
 import { ArrowReturnRight } from '@/components/icons/ArrowReturnRight';
 import { ExploreDataScope } from '@/types/explore-section/application';
-import { resolveExploreDetailsPageUrl2 } from '@/utils/url-builder';
+import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
 import { VirtualLabInfo } from '@/types/virtual-lab/common';
 
 import type { ICircuitEnriched } from '@/features/entities/circuit/elements/helpers';
@@ -54,7 +54,7 @@ export function Derived({ data }: Props) {
 
   const onCellClick = (basePath: string, record: ICircuit) => {
     navigate(
-      resolveExploreDetailsPageUrl2({
+      resolveExploreDetailsPageUrl({
         ctx: { virtualLabId, projectId },
         dataType: ExtendedEntitiesTypeDict.Circuit,
         entityId: record.id,

--- a/src/features/entities/circuit/elements/related-circuits/parent.tsx
+++ b/src/features/entities/circuit/elements/related-circuits/parent.tsx
@@ -10,7 +10,7 @@ import { BaseTable } from '@/components/explore-section/ExploreSectionListingVie
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { activeColumnsAtom } from '@/state/explore-section/list-view-atoms';
 import { ExploreDataScope } from '@/types/explore-section/application';
-import { resolveExploreDetailsPageUrl2 } from '@/utils/url-builder';
+import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
 
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
 import type { WorkspaceContext } from '@/types/common';
@@ -45,7 +45,7 @@ export function Parent({ data }: Props) {
   const columns = cols.filter(({ key }) => (activeColumns || []).includes(key as string));
   const onCellClick = (basePath: string, record: ICircuit) => {
     navigate(
-      resolveExploreDetailsPageUrl2({
+      resolveExploreDetailsPageUrl({
         ctx: { virtualLabId, projectId },
         dataType: ExtendedEntitiesTypeDict.Circuit,
         entityId: record.id,

--- a/src/features/entities/circuit/elements/related-circuits/root.tsx
+++ b/src/features/entities/circuit/elements/related-circuits/root.tsx
@@ -10,7 +10,7 @@ import { activeColumnsAtom } from '@/state/explore-section/list-view-atoms';
 import { ExploreDataScope } from '@/types/explore-section/application';
 import { getCircuit } from '@/api/entitycore/queries/model/circuit';
 import { Error } from '@/features/entities/circuit/elements/error';
-import { resolveExploreDetailsPageUrl2 } from '@/utils/url-builder';
+import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
 import { tryCatch } from '@/api/utils';
 
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
@@ -56,7 +56,7 @@ export function Root({ circuit }: Props) {
 
   const onCellClick = (basePath: string, record: ICircuit) => {
     navigate(
-      resolveExploreDetailsPageUrl2({
+      resolveExploreDetailsPageUrl({
         ctx: { virtualLabId, projectId },
         dataType: ExtendedEntitiesTypeDict.Circuit,
         entityId: record.id,

--- a/src/features/entities/circuit/elements/related-circuits/subcircuits.tsx
+++ b/src/features/entities/circuit/elements/related-circuits/subcircuits.tsx
@@ -15,7 +15,7 @@ import { HierarchyOutputNode } from '@/features/entities/circuit/elements/contex
 import { expandIcon } from '@/features/entities/circuit/elements/expand-icon';
 import { ArrowReturnRight } from '@/components/icons/ArrowReturnRight';
 import { ExploreDataScope } from '@/types/explore-section/application';
-import { resolveExploreDetailsPageUrl2 } from '@/utils/url-builder';
+import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
 import { VirtualLabInfo } from '@/types/virtual-lab/common';
 
 import type { ICircuitEnriched } from '@/features/entities/circuit/elements/helpers';
@@ -54,7 +54,7 @@ export function Subcircuits({ data }: Props) {
 
   const onCellClick = (basePath: string, record: ICircuit) => {
     navigate(
-      resolveExploreDetailsPageUrl2({
+      resolveExploreDetailsPageUrl({
         ctx: { virtualLabId, projectId },
         dataType: ExtendedEntitiesTypeDict.Circuit,
         entityId: record.id,

--- a/src/ui/segments/contribute/cell-morphology/submit-entity.tsx
+++ b/src/ui/segments/contribute/cell-morphology/submit-entity.tsx
@@ -8,7 +8,7 @@ import { Form } from 'antd';
 import isNil from 'lodash/isNil';
 import { buildCellMorphologyMutationKeys } from '@/ui/segments/contribute/cell-morphology/use-pipeline';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
-import { resolveExploreDetailsPageUrl2 } from '@/utils/url-builder';
+import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
 import { HydrateWrapper } from '@/wrappers/hydrate-wrapper';
 import {
   CellMorphologySchema,
@@ -174,7 +174,7 @@ export function SubmitButton({ loading, sessionId }: { loading: boolean; session
   const { CreateCellMorphologyData } = useCreateCellMorphologyStatus({ sessionId });
 
   const detailsUrl = CreateCellMorphologyData?.id
-    ? resolveExploreDetailsPageUrl2({
+    ? resolveExploreDetailsPageUrl({
         ctx: { virtualLabId, projectId },
         entityId: CreateCellMorphologyData.id,
         dataType: ExtendedEntitiesTypeDict.CellMorphology,

--- a/src/utils/url-builder.ts
+++ b/src/utils/url-builder.ts
@@ -1,62 +1,18 @@
 import kebabCase from 'lodash/kebabCase';
+
+import { TEntityTypeDict } from '@/api/entitycore/types/entity-type';
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import { ROOT_ROUTE } from '@/config';
 import {
   getEntityByCoreType,
   getEntityByExtendedType,
 } from '@/entity-configuration/domain/helpers';
-import { TEntityTypeDict } from '@/api/entitycore/types/entity-type';
-
 import type { EntitySlugValue } from '@/entity-configuration/domain/slug';
-import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { WorkspaceContext } from '@/types/common';
-import { ROOT_ROUTE } from '@/config';
 
 export const baseUri = '/app/virtual-lab';
 
 export function resolveExploreDetailsPageUrl({
-  ctx,
-  entityId,
-  dataType,
-  entityType,
-}: {
-  ctx?: Partial<WorkspaceContext>;
-  entityId?: string;
-  dataType?: TExtendedEntitiesTypeDict;
-  entityType?: TEntityTypeDict;
-}) {
-  if (dataType && entityType)
-    throw Error('Only one of dataType and entityType should be specified');
-  if (!dataType && !entityType) return '/';
-
-  const entityConfig = dataType
-    ? getEntityByExtendedType({ type: dataType })
-    : getEntityByCoreType({ type: entityType });
-
-  if (!entityConfig) throw new Error('Invalid Entity');
-
-  const slug = entityConfig?.slug; // morphology, e-model, ...
-  const usedSlug: string | undefined = slug;
-  const routePrefix = entityConfig?.explore.routePrefix; // interactive/experimental, model, simulate
-
-  let baseUrl = `${baseUri}/explore/${routePrefix}/${usedSlug}`;
-  if (entityId) {
-    baseUrl = `${baseUrl}/${entityId}`;
-  }
-  if (ctx && ctx.virtualLabId && ctx.projectId) {
-    if (entityId && usedSlug) {
-      return `${baseUri}/lab/${ctx.virtualLabId}/project/${ctx.projectId}/explore/${routePrefix}/${usedSlug}/${entityId}`;
-    }
-    if (usedSlug) {
-      return `${baseUri}/lab/${ctx.virtualLabId}/project/${ctx.projectId}/explore/${routePrefix}/${usedSlug}`;
-    }
-    return `${baseUri}/lab/${ctx.virtualLabId}/project/${ctx.projectId}/explore/interactive`;
-  }
-  if (!dataType && !entityId) {
-    baseUrl = `${baseUri}/explore/interactive`;
-  }
-  return baseUrl;
-}
-
-export function resolveExploreDetailsPageUrl2({
   ctx,
   entityId,
   dataType,


### PR DESCRIPTION
I'm not sure this is 100% correct, so would be nice for you @bilalesi to have a look, but I've clicked around and it seems all the details links work as expected.

Relates to [Data>ME-model> Detail view>Configuration tab - clicking on "More details" -> redirects to Project home](https://github.com/openbraininstitute/prod-explore-functionality/issues/328)