### PR TITLE
Fix synapse generation, add label for myelin

### DIFF
--- a/src/features/entities/single-neuron-synaptome/build/elements/constants.ts
+++ b/src/features/entities/single-neuron-synaptome/build/elements/constants.ts
@@ -1,9 +1,10 @@
 export const SECTION_TARGET_MAPPING = {
-  dend: 'Basal dendrites',
-  soma: 'Soma',
   apic: 'Apical dendrites',
-  basal: 'Basal dendrites',
   axon: 'Axon',
+  basal: 'Basal dendrites',
+  dend: 'Basal dendrites',
+  myelin: 'Myelin',
+  soma: 'Soma',
 };
 
 export type SectionTargetMappingKeys = keyof typeof SECTION_TARGET_MAPPING;

--- a/src/ui/segments/workflows/build/single-neuron-synaptome/synapse-configuration.tsx
+++ b/src/ui/segments/workflows/build/single-neuron-synaptome/synapse-configuration.tsx
@@ -26,7 +26,7 @@ export function SynapseSetConfiguration({ sessionId }: Props) {
             projectId={projectId}
             meModelId={sessionValue?.memodel?.id}
             zoomPlacement="right"
-            sessionId="custom-me-model-build"
+            sessionId={sessionId}
           />
         )}
       </div>


### PR DESCRIPTION
It seems the sessionId was not set correctly - making synapse target selection impossible.
I've also added a  label for Myelin, so in the UI it is displayed with the same case as the others.