### PR TITLE
Change initial voltage from -73mV to -80mV

### DIFF
--- a/src/ui/segments/workflows/simulate/single-neuron/shared/constant.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/shared/constant.tsx
@@ -119,7 +119,7 @@ export const DEFAULT_RECORDING_LOCATION: RecordLocation = {
 
 export const DEFAULT_SIMULATION_EXPERIMENTAL_SETUP: SimulationExperimentalSetup = {
   celsius: 34,
-  vinit: -73,
+  vinit: -80,
   hypamp: 0,
   max_time: 2000,
   time_step: 0.05,


### PR DESCRIPTION
@darshanmandge  requested in openbraininstitute/prod-singlecell-simulation#142 to change that default value from -73mV to -80mV. I did a quick search&replace and tried locally and this very small PR seems to fix that issue.

<img width="766" height="507" alt="Screenshot 2025-10-20 at 14 41 10" src="https://github.com/user-attachments/assets/0fa95cbc-d5b9-474b-87fd-db645ad8f93c" />
