### PR TITLE
Default block reference fix

### DIFF
--- a/src/features/small-microcircuit/_components/reference.tsx
+++ b/src/features/small-microcircuit/_components/reference.tsx
@@ -1,6 +1,5 @@
 import { Button, Select } from 'antd';
 import { ConfigObject } from './utils';
-import def from 'ajv/dist/vocabularies/discriminator';
 
 export default function Reference({
   onAddReferenceClick,


### PR DESCRIPTION
* Minor fix for this ticket: https://github.com/openbraininstitute/prod-circuit-simulation/issues/68
* Only show add block button if block reference is optional
* Tested that this produces the desired functionality