### PR TITLE
remove additionalProperties option for Block plotting

### DIFF
--- a/src/features/small-microcircuit/index.tsx
+++ b/src/features/small-microcircuit/index.tsx
@@ -335,11 +335,7 @@ export default function SimulationCampaignConfiguration({
                   onAddReferenceClick={handleAddReferenceClick}
                   disabled={!!campaignId || loading}
                   config={config}
-                  schema={
-                    selectedCatSchema ??
-                    schema.properties[configTab]?.additionalProperties ??
-                    schema.properties[configTab]
-                  }
+                  schema={selectedCatSchema ?? schema.properties[configTab]}
                   stateAtom={
                     isAtom(atomsMap[configTab])
                       ? atomsMap[configTab]


### PR DESCRIPTION
* Fix following improvement to obi-one schema, and root blocks no longer displaying
* Particularly, `additionalProperties=False` was added to the schema for individual Blocks by the addition of these two changes in obi-one 2025.10.8:
1) Not allowing non-validation parameters to be passed to Block models: https://github.com/openbraininstitute/obi-one/blob/6ea9f2cb671966a508c7e830865994128299ec72/obi_one/core/block.py#L13
2) Updating the cls.model_config dictionary for Blocks, rather than (incorrectly) overwriting the dictionary: https://github.com/openbraininstitute/obi-one/blob/6ea9f2cb671966a508c7e830865994128299ec72/obi_one/core/block.py#L29

* additionalProperties=False represents that non-validation parameters cannot be passed to Block models, which is preferred because it stops you passing arbitrary parameters in model construction by mistake, without realising

* I'm not sure why, but when determining the schema of a single Block to be passed to the display code (the line changed in this PR), the second possibility was `schema.properties[configTab]?.additionalProperties ??` - i.e. the value of "additionalProperties", which previously shouldn't have existed for Blocks (maybe it did several months ago - I'm not sure). Now `additionalProperties` was added to the schema, the javascript code was selecting this option, which had value `False`, which obviously isn't something which can be displayed, hence why nothing appeared for Info and Initialize

* Removing this line, fixes the behaviour. I have also tested the confirguration page some more with this fix, and things work as expected
