### PR TITLE
Avoid requests to entitycore for circuits with the ID 'undefined'

### DIFF
--- a/src/api/entitycore/queries/model/circuit.ts
+++ b/src/api/entitycore/queries/model/circuit.ts
@@ -62,6 +62,9 @@ export async function getCircuit({
   id: string;
   context?: WorkspaceContext | null;
 }) {
+  if (id == null) {
+    throw new Error(`circuit id is not valid ${id}`);
+  }
   const api = await entityCoreApi();
   return await api.get<ICircuit>(`${baseUri}/${id}`, {
     headers: {


### PR DESCRIPTION
We're getting a lot of errors in the logs of entitycore for circuits with GUID 'undefined', all coming from core web app. This  is a bit a stopgap: avoid such requests and raise an error instead, so hopefully we'll find the root cause.