### PR TITLE
Added fallback for font height in Google Chrome

### DIFF
--- a/src/ui/segments/workflows/simulate/single-neuron/shared/steps/webgl-neuron-selector/legend-overlay/legend-painter.ts
+++ b/src/ui/segments/workflows/simulate/single-neuron/shared/steps/webgl-neuron-selector/legend-overlay/legend-painter.ts
@@ -157,7 +157,8 @@ function drawLabel(ctx: CanvasRenderingContext2D, label: LabelToDraw) {
   ctx.font = `bold ${FONTSIZE}px sans-serif`;
   const measure = ctx.measureText(text);
   ctx.fillStyle = '#000';
-  ctx.fillText(text, boxX + PADDING, boxY + PADDING + measure.emHeightAscent);
+  const fontHeight = measure.emHeightAscent ?? measure.actualBoundingBoxAscent ?? FONTSIZE;
+  ctx.fillText(text, boxX + PADDING, boxY + PADDING + fontHeight);
 }
 
 /**


### PR DESCRIPTION
`measure.emHeightAscent` is not defined in Google Chrome.