### PR TITLE
Revert to old viewer

### DIFF
--- a/src/components/neuron-viewer/neuron-viewer-with-actions.tsx
+++ b/src/components/neuron-viewer/neuron-viewer-with-actions.tsx
@@ -44,7 +44,7 @@ export function NeuronViewerContainer({
     useState<TNeuronViewerClickData | null>(null);
   const [neuronViewerHoverData, setNeuronViewerOnHoverData] =
     useState<TNeuronViewerHoverData | null>(null);
-  const newViewer = true;
+  const newViewer = false;
 
   return (
     <ErrorBoundary


### PR DESCRIPTION
We just changed the flag to revert to the old viewer because the new one misses the synapses.