### PR TITLE
Sync species filter types with entitycore

### DIFF
--- a/src/api/entitycore/types/entities/bouton-density.ts
+++ b/src/api/entitycore/types/entities/bouton-density.ts
@@ -5,7 +5,6 @@ import type {
   SharedFilter,
   ContributionFilter,
   BrainRegionFilter,
-  SpeciesFilter,
   StainFilter,
   MtypeFilter,
 } from '@/api/entitycore/types/shared/request';
@@ -21,7 +20,6 @@ export type ExperimentalBoutonDensityFilter = Partial<
     PaginationFilter &
     ContributionFilter &
     BrainRegionFilter &
-    SpeciesFilter &
     StainFilter &
     MtypeFilter
 >;

--- a/src/api/entitycore/types/entities/ion-channel.ts
+++ b/src/api/entitycore/types/entities/ion-channel.ts
@@ -11,12 +11,12 @@ import type {
 } from '@/api/entitycore/types/shared/global';
 
 import type {
+  BrainRegionFilter,
   ContributionFilter,
   IMorphologyFilter,
-  BrainRegionFilter,
-  SpeciesFilter,
-  SharedFilter,
   PaginationFilter,
+  SharedFilter,
+  SubjectFilter,
 } from '@/api/entitycore/types/shared/request';
 
 type UseIon = {
@@ -60,8 +60,8 @@ export interface IonChannelModel
 
 export interface IonChannelModelFilter
   extends ContributionFilter,
-    SpeciesFilter,
     BrainRegionFilter,
-    SharedFilter,
     IMorphologyFilter,
-    PaginationFilter {}
+    PaginationFilter,
+    SharedFilter,
+    SubjectFilter {}

--- a/src/api/entitycore/types/entities/neuron-density.ts
+++ b/src/api/entitycore/types/entities/neuron-density.ts
@@ -1,16 +1,16 @@
+import type { IExperimentalDensity } from '@/api/entitycore/types/shared/density';
 import type { EntityCoreType, IEType, IMType } from '@/api/entitycore/types/shared/global';
 import type {
-  TimestampsFilter,
-  PaginationFilter,
-  SharedFilter,
-  ContributionFilter,
   BrainRegionFilter,
-  SpeciesFilter,
-  StainFilter,
+  ContributionFilter,
   EtypeFilter,
   MtypeFilter,
+  PaginationFilter,
+  SharedFilter,
+  StainFilter,
+  SubjectFilter,
+  TimestampsFilter,
 } from '@/api/entitycore/types/shared/request';
-import type { IExperimentalDensity } from '@/api/entitycore/types/shared/density';
 
 export interface IExperimentalNeuronDensity extends IExperimentalDensity, EntityCoreType {
   mtypes: Array<IMType> | null;
@@ -19,12 +19,12 @@ export interface IExperimentalNeuronDensity extends IExperimentalDensity, Entity
 
 export type ExperimentalNeuronDensityFilter = Partial<
   SharedFilter &
-    TimestampsFilter &
-    PaginationFilter &
-    ContributionFilter &
     BrainRegionFilter &
-    SpeciesFilter &
-    StainFilter &
+    ContributionFilter &
     EtypeFilter &
-    MtypeFilter
+    MtypeFilter &
+    PaginationFilter &
+    StainFilter &
+    SubjectFilter &
+    TimestampsFilter
 >;

--- a/src/api/entitycore/types/entities/synapses-per-connection.ts
+++ b/src/api/entitycore/types/entities/synapses-per-connection.ts
@@ -1,15 +1,15 @@
 import type { IBrainRegionHierarchy } from '@/api/entitycore/types/entities/brain-region';
-import type { IMType, EntityCoreType } from '@/api/entitycore/types/shared/global';
 import type { IExperimentalDensity } from '@/api/entitycore/types/shared/density';
+import type { EntityCoreType, IMType } from '@/api/entitycore/types/shared/global';
 import type {
-  TimestampsFilter,
+  BrainRegionFilter,
+  ContributionFilter,
+  EtypeFilter,
   PaginationFilter,
   SharedFilter,
-  ContributionFilter,
-  BrainRegionFilter,
-  SpeciesFilter,
-  EtypeFilter,
   StainFilter,
+  SubjectFilter,
+  TimestampsFilter,
 } from '@/api/entitycore/types/shared/request';
 
 export interface IExperimentalSynapsesPerConnection extends IExperimentalDensity, EntityCoreType {
@@ -58,15 +58,15 @@ type PostMtypeFilter = {
 
 export type ExperimentalSynapsesPerConnectionFilter = Partial<
   SharedFilter &
-    TimestampsFilter &
-    PaginationFilter &
-    ContributionFilter &
     BrainRegionFilter &
-    SpeciesFilter &
-    StainFilter &
+    ContributionFilter &
     EtypeFilter &
-    PreMtypeFilter &
+    PaginationFilter &
     PostMtypeFilter &
+    PostRegionFilter &
+    PreMtypeFilter &
     PreRegionFilter &
-    PostRegionFilter
+    StainFilter &
+    SubjectFilter &
+    TimestampsFilter
 >;

--- a/src/api/entitycore/types/shared/species.ts
+++ b/src/api/entitycore/types/shared/species.ts
@@ -5,13 +5,11 @@ import type {
   OwnershipFilter,
   PaginationFilter,
   SearchFilter,
-  SpeciesFilter,
 } from '@/api/entitycore/types/shared/request';
 
 export interface ISpeciesFilter
   extends PaginationFilter,
     OwnershipFilter,
-    SpeciesFilter,
     IDFilter,
     SearchFilter,
     ContributionFilter {}

--- a/src/entity-configuration/definitions/fields-defs/common.tsx
+++ b/src/entity-configuration/definitions/fields-defs/common.tsx
@@ -281,6 +281,7 @@ export const FieldsDefinition: Partial<FieldsDefinitionRegistry<EntityCoreObject
       [ExtendedEntitiesTypeDict.ExperimentalBoutonDensity]: 'subject__species__name__in',
       [ExtendedEntitiesTypeDict.ExperimentalSynapsesPerConnection]: 'subject__species__name__in',
       [ExtendedEntitiesTypeDict.IonChannelModel]: 'subject__species__name__in',
+      [ExtendedEntitiesTypeDict.IonChannelRecording]: 'subject__species__name__in',
       [ExtendedEntitiesTypeDict.Circuit]: 'subject__species__name__in',
       [ExtendedEntitiesTypeDict.MEModelWithSynapses]: 'subject__species__name__in',
     },


### PR DESCRIPTION
Relates to [Enable filtering for species in UI for Ion Channel Models](https://github.com/openbraininstitute/prod-build-ion-channel-model/issues/30).