### PR TITLE
Fix missing colors for synapses sets

### DIFF
--- a/src/api/entitycore/queries/model/single-neuron-synaptome.ts
+++ b/src/api/entitycore/queries/model/single-neuron-synaptome.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 import startsWith from 'es-toolkit/compat/startsWith';
 import some from 'es-toolkit/compat/some';
 
@@ -15,6 +16,7 @@ import type {
 } from '@/api/entitycore/types/entities/single-neuron-synaptome';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { WorkspaceContext } from '@/types/common';
+import { getColorFromGeneratedPalette } from '@/ui/segments/workflows/simulate/single-neuron/shared/steps/webgl-neuron-selector/colors';
 
 const baseUri = '/single-neuron-synaptome';
 
@@ -132,9 +134,17 @@ export async function getSingleNeuronSynaptomeConfiguration(
     if (error) {
       return null;
     }
-    return data as {
+    const result = data as {
       synapses: Array<TSingleNeuronSynaptomeConfiguration>;
     };
+    return assignColors(result);
   }
   return null;
+}
+
+function assignColors(result: { synapses: Array<TSingleNeuronSynaptomeConfiguration> }) {
+  for (let i = 0; i < result.synapses.length; i++) {
+    result.synapses[i].color = getColorFromGeneratedPalette(i);
+  }
+  return result;
 }

--- a/src/ui/segments/workflows/build/single-neuron-synaptome/synapse-set-menu-item.tsx
+++ b/src/ui/segments/workflows/build/single-neuron-synaptome/synapse-set-menu-item.tsx
@@ -10,11 +10,13 @@ import { Color } from 'three';
 import { getColorFromGeneratedPalette } from '../../simulate/single-neuron/shared/steps/webgl-neuron-selector/colors';
 import { useVisibleSynapsesSetter } from '../../simulate/single-neuron/shared/steps/webgl-neuron-selector/hooks';
 
-import { SingleNeuronSynaptomeBaseSchema } from '@/api/entitycore/types/entities/single-neuron-synaptome';
+import {
+  SingleNeuronSynaptomeBaseSchema,
+  TSingleNeuronSynaptomeConfiguration,
+} from '@/api/entitycore/types/entities/single-neuron-synaptome';
 import { createBubblesInstanced } from '@/services/bluenaas-single-cell/renderer-utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/molecules/tooltip';
 import {
-  DefaultColor,
   DefaultSynapseValue,
   SimulationColors,
   useBuildSingleNeuronSynaptomeSessionState,
@@ -48,21 +50,28 @@ export function SynapseSetMenuItems({ sessionId }: Props) {
     const id = crypto.randomUUID();
     const queryParams = new URLSearchParams(params);
     queryParams.set('set', id);
-    const cloneMap = new Map(sessionValue?.synapseSets);
+    const currentMap =
+      sessionValue?.synapseSets ?? new Map<string, TSingleNeuronSynaptomeConfiguration>();
+    const cloneMap = new Map<string, TSingleNeuronSynaptomeConfiguration>();
+    // Cleanup the dictionary.
+    for (const key of currentMap.keys()) {
+      const val = currentMap.get(key);
+      if (!val?.name || !val?.target) continue;
 
+      cloneMap.set(key, val);
+    }
     cloneMap?.set(id, {
       ...DefaultSynapseValue,
       id,
       seed: (sessionValue?.seed ?? 0) + getRandomIntInclusive(0, sessionValue?.seed ?? 0),
       color: sample(SimulationColors) ?? SimulationColors[cloneMap.size],
     });
-
+    resetColors(cloneMap);
     setSessionValue({
       ...sessionValue,
       seed: sessionValue?.seed ?? 100,
       synapseSets: cloneMap,
     });
-
     replace(`${pathname}?${queryParams.toString()}`);
   };
 
@@ -87,12 +96,11 @@ export function SynapseSetMenuItems({ sessionId }: Props) {
         ...DefaultSynapseValue,
         id: newId,
         seed: (sessionValue?.seed ?? 0) + getRandomIntInclusive(0, sessionValue?.seed ?? 0),
-        color: sample(SimulationColors) ?? SimulationColors.at(0) ?? DefaultColor,
       });
       setSessionValue({
         ...sessionValue,
         seed: sessionValue?.seed ?? 100,
-        synapseSets: newMap,
+        synapseSets: resetColors(newMap),
         synapseCount: new Map(),
       });
       replace(`${pathname}?${queryParams.toString()}`);
@@ -102,7 +110,7 @@ export function SynapseSetMenuItems({ sessionId }: Props) {
     setSessionValue({
       ...sessionValue,
       seed: sessionValue?.seed ?? 100,
-      synapseSets: cloneMap,
+      synapseSets: resetColors(cloneMap),
       synapseCount: cloneCountMap,
     });
 
@@ -365,4 +373,13 @@ function makeData(
     }
   }
   return new Float32Array(data);
+}
+
+// Reset the colors.
+function resetColors(cloneMap: Map<string, TSingleNeuronSynaptomeConfiguration>) {
+  let index = 0;
+  for (const [, val] of cloneMap.entries()) {
+    val.color = getColorFromGeneratedPalette(index++);
+  }
+  return cloneMap;
 }

--- a/src/ui/segments/workflows/simulate/single-neuron/shared/steps/webgl-neuron-selector/colors.ts
+++ b/src/ui/segments/workflows/simulate/single-neuron/shared/steps/webgl-neuron-selector/colors.ts
@@ -1,10 +1,5 @@
-import { TgdColor } from '@tolokoban/tgd';
+import { SimulationColors } from '@/ui/segments/workflows/build/single-neuron-synaptome/helpers';
 
-export function getColorFromGeneratedPalette(
-  index: number,
-  { saturation = 0.9, luminance = 0.66 }: Partial<{ saturation: number; luminance: number }> = {}
-) {
-  const start = 0.3333; // green
-  const hue = start + ((index * 92) % 307) / 307;
-  return TgdColor.fromHSL(hue, saturation, luminance).toString();
+export function getColorFromGeneratedPalette(index: number) {
+  return SimulationColors[index % SimulationColors.length];
 }

--- a/src/ui/segments/workflows/simulate/single-neuron/shared/steps/webgl-neuron-selector/painter/manager.ts
+++ b/src/ui/segments/workflows/simulate/single-neuron/shared/steps/webgl-neuron-selector/painter/manager.ts
@@ -192,7 +192,6 @@ export class PainterManager {
       this.initialPosition.from(context.camera.transfo.position);
       this.initCameraController(context, zoomMin, zoomMax);
       painter.structure = structure;
-      context.debugHierarchy();
     }
   }
 

--- a/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/index.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/index.tsx
@@ -30,11 +30,11 @@ export function Content({ sessionId, memodel, synaptome }: Props) {
     .with({ step: ExperimentStep.ExperimentalSetup }, () => (
       <ExperimentSetup sessionId={sessionId} />
     ))
-    .with({ step: ExperimentStep.StimulationProtocol }, () => (
-      <StimulationProtocol sessionId={sessionId} memodelId={memodel.id} />
-    ))
     .with({ step: ExperimentStep.SynapticInputs }, () => (
       <SynapticsConfiguration sessionId={sessionId} memodelId={memodel.id} synaptome={synaptome} />
+    ))
+    .with({ step: ExperimentStep.StimulationProtocol }, () => (
+      <StimulationProtocol sessionId={sessionId} memodelId={memodel.id} />
     ))
     .with({ step: ExperimentStep.Recording }, () => <Recording sessionId={sessionId} />)
     .otherwise(() => null);

--- a/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/synaptics.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/synaptics.tsx
@@ -77,7 +77,6 @@ export function SynapticsConfiguration({ sessionId, memodelId, synaptome }: Prop
     const simConfigForForm = state.find((_: SynapseConfiguration, ind) => ind === simFormIndex);
     return data?.synapses.find((s) => s.id === simConfigForForm?.id);
   };
-
   const onRemoveSynapseConfig = (_key: number) => {
     const safeStorage = typeof window !== 'undefined' ? sessionStorage : null;
     if (safeStorage) {


### PR DESCRIPTION
There was two main errors:

1. In the simuation for synaptomes, the colors of the synapses sets were missing.
2. When clicking on add, an empty (and invalid) synapse set was created in the map. This was never displayed on screen, but it shifted the colors of the other sets.