### PR TITLE
Disable run sim button during an active simulation request

### DIFF
--- a/src/ui/segments/workflows/simulate/single-neuron/shared/elements/menu.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/shared/elements/menu.tsx
@@ -4,7 +4,7 @@ import { RightOutlined, SettingFilled, WarningFilled } from '@ant-design/icons';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useVisibleSynapsesSetter } from '../steps/webgl-neuron-selector/hooks';
 
@@ -70,6 +70,9 @@ export function Menu({ sessionId, simulationType, modelId, memodelId }: Props) {
   const simulationStatus = useAtomValue(simulationStatusAtomFamily(sessionId));
   const step = searchParams.get('step') ?? ExperimentStep.Info;
   const setVisibleSynapses = useVisibleSynapsesSetter();
+
+  const [isLaunching, setIsLaunching] = useState(false);
+
   useEffect(() => {
     if (step === ExperimentStep.Info) {
       // Reset the synapses in the info panel.
@@ -104,6 +107,8 @@ export function Menu({ sessionId, simulationType, modelId, memodelId }: Props) {
   } = useSingleNeuronSimulationAtoms(sessionId);
 
   const onRun = async () => {
+    setIsLaunching(true);
+
     const protocol = stimulationConfiguration.stimulus.stimulus_protocol;
     let currentInjectionDuration = 0;
 
@@ -152,6 +157,8 @@ export function Menu({ sessionId, simulationType, modelId, memodelId }: Props) {
       () => updatePanelSelection(),
       notify
     );
+
+    setIsLaunching(false);
   };
 
   const warnInfo =
@@ -187,6 +194,7 @@ export function Menu({ sessionId, simulationType, modelId, memodelId }: Props) {
     !!Object.keys(warnStimulationProtocol ?? {}).length ||
     (simulationType === SimulationType.SingleNeuronSynaptome &&
       !!Object.keys(warnSynaptome ?? {}).length) ||
+    isLaunching ||
     simulationStatus?.status === SimulationStatus.LAUNCHED;
 
   return (


### PR DESCRIPTION
This is fixes the issue where the user can click multiple times on the run simulation button which will lead to multiple simulations being launched/saved and broken plots.

Relates to [Synaptome simulation> if running a simulation with more than 5 steps - error message - unable to save simulation files](https://github.com/openbraininstitute/prod-singlecell-simulation/issues/216).