### PR TITLE
Add simulation complexity evaluation, limit and a poptip warning

### DIFF
--- a/src/ui/segments/workflows/simulate/single-neuron/shared/elements/menu.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/shared/elements/menu.tsx
@@ -4,7 +4,7 @@ import { RightOutlined, SettingFilled, WarningFilled } from '@ant-design/icons';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 
 import { useVisibleSynapsesSetter } from '../steps/webgl-neuron-selector/hooks';
 
@@ -106,6 +106,34 @@ export function Menu({ sessionId, simulationType, modelId, memodelId }: Props) {
     stimulationConfiguration,
   } = useSingleNeuronSimulationAtoms(sessionId);
 
+  const overResourceThreshold = useMemo(() => {
+    const repetitionFactor = Math.max(
+      amperageConfiguration.computed.length,
+      ...synaptomeConfiguration.map((c) => (Array.isArray(c.frequency) ? c.frequency.length : 1))
+    );
+
+    const recordingFactor = recordLocationConfiguration.reduce(
+      (recFactor, c) => recFactor + (c.record_currents ? 6 : 1),
+      0
+    );
+
+    const recordingVectorLength =
+      experimentalSetupConfiguration.max_time / experimentalSetupConfiguration.time_step;
+
+    const sizeEstimate = repetitionFactor * recordingFactor * recordingVectorLength;
+    // Size estimate unit = ~35 bytes in the resulting JSON asset.
+    // The threshold is set to ~150 MB which is the current limit for entitycore asset uploads,
+    // see https://github.com/openbraininstitute/entitycore/blob/main/app/config.py#L51
+    const threshold = 5_500_000;
+
+    return sizeEstimate > threshold;
+  }, [
+    amperageConfiguration,
+    synaptomeConfiguration,
+    recordLocationConfiguration,
+    experimentalSetupConfiguration,
+  ]);
+
   const onRun = async () => {
     setIsLaunching(true);
 
@@ -192,6 +220,7 @@ export function Menu({ sessionId, simulationType, modelId, memodelId }: Props) {
     !!Object.keys(warnRecordLocation ?? {}).length ||
     !!Object.keys(warnExperimentalSetup ?? {}).length ||
     !!Object.keys(warnStimulationProtocol ?? {}).length ||
+    overResourceThreshold ||
     (simulationType === SimulationType.SingleNeuronSynaptome &&
       !!Object.keys(warnSynaptome ?? {}).length) ||
     isLaunching ||
@@ -435,7 +464,7 @@ export function Menu({ sessionId, simulationType, modelId, memodelId }: Props) {
           </div>
         </div>
       </Button>
-      <Tooltip>
+      <Tooltip open={overResourceThreshold ? true : undefined}>
         <TooltipTrigger asChild>
           <div className="mt-auto w-full">
             <Button
@@ -452,11 +481,27 @@ export function Menu({ sessionId, simulationType, modelId, memodelId }: Props) {
             </Button>
           </div>
         </TooltipTrigger>
-        <TooltipContent sideOffset={0} arrowClassName="bg-primary-9">
-          <p className={cn('max-w-80 text-left text-base text-balance')}>
-            Please fill all the required information <br />
-            along with experiment configurations.
-          </p>
+        <TooltipContent
+          sideOffset={0}
+          arrowClassName={overResourceThreshold ? 'bg-warning' : 'bg-primary-9'}
+          className={overResourceThreshold ? 'bg-warning' : undefined}
+        >
+          {overResourceThreshold ? (
+            <div className="max-w-80 text-white">
+              <span className="text-sm">Simulation is too complex, please decrease either:</span>
+              <ul className="mt-2 list-disc pl-4">
+                <li>Number of steps for current/synaptic inputs</li>
+                <li>Number of recording locations and/or current recordings</li>
+                <li>Duration of the simulation</li>
+                <li>Precision by increasing time step</li>
+              </ul>
+            </div>
+          ) : (
+            <p className={cn('max-w-80 text-left text-base text-balance')}>
+              Please fill all the required information <br />
+              along with experiment configurations.
+            </p>
+          )}
         </TooltipContent>
       </Tooltip>
     </div>


### PR DESCRIPTION
The app fails to save the results of highly complex single neuron simulations due to reaching the maximum asset size limit in [Entitycore limit - 150 MB](https://github.com/openbraininstitute/entitycore/blob/main/app/config.py#L51).

This change provides an approximate evaluation and prevents the submission of simulations by disabling the run button and displaying a warning in the form of a tooltip explaining how to reduce the complexity.

<img width="875" height="567" alt="Screenshot 2025-12-01 at 17 52 26" src="https://github.com/user-attachments/assets/7979afb9-5d95-4e00-ad98-7bfb7345eb99" />

Relates to https://github.com/openbraininstitute/prod-singlecell-simulation/issues/216.