### PR TITLE
Wrap long names in cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@tanstack/react-query": "^5.84.1",
     "@tanstack/react-query-devtools": "^5.84.1",
     "@tanstack/react-virtual": "^3.13.12",
-    "@tolokoban/tgd": "^2.0.67",
+    "@tolokoban/tgd": "^2.0.69",
     "ajv": "^8.17.1",
     "antd": "^5.13.3",
     "chroma-js": "^3.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,8 +150,8 @@ importers:
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tolokoban/tgd':
-        specifier: ^2.0.67
-        version: 2.0.68
+        specifier: ^2.0.69
+        version: 2.0.69
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
@@ -4643,8 +4643,8 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@tolokoban/tgd@2.0.68':
-    resolution: {integrity: sha512-80YxoC1JpEAQRworGEYSr189a8w66KlCQMjDkwpLW+4BIWrr7nl81N/hU2a4T6JXjn0IFK6/RIhtSH+VFMVxdA==}
+  '@tolokoban/tgd@2.0.69':
+    resolution: {integrity: sha512-Kp9eYED20fgNvKvAdOmw//ExqxEz8frJr9liB0ZTjeRHaujj+//gxxIL8hdO0E6ayTBSYh7bMpkANtQkvww6dA==}
 
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
@@ -17190,7 +17190,7 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.0
 
-  '@tolokoban/tgd@2.0.68':
+  '@tolokoban/tgd@2.0.69':
     dependencies:
       '@loaders.gl/core': 4.3.4
       '@loaders.gl/draco': 4.3.4(@loaders.gl/core@4.3.4)

--- a/src/features/entities/me-model/detail-view/card-viewers/card-container.module.css
+++ b/src/features/entities/me-model/detail-view/card-viewers/card-container.module.css
@@ -1,0 +1,18 @@
+.cardContainer {
+  /* "border-neutral-2 w-full rounded-[6px] border p-10" */
+  width: 100%;
+  border-radius: 6px;
+  border: 1px solid var(--color-neutral-2);
+  padding: calc(var(--spacing) * 10);
+
+  div.name {
+    white-space: wrap;
+    text-wrap: balance;
+    word-break: break-word;
+    font-weight: bold;
+    font-size: var(--text-3xl);
+    color: var(--color-primary-8);
+    line-height: var(--tw-leading, var(--text-3xl--line-height));
+    margin-block: calc(var(--spacing) * 1);
+  }
+}

--- a/src/features/entities/me-model/detail-view/card-viewers/card-container.tsx
+++ b/src/features/entities/me-model/detail-view/card-viewers/card-container.tsx
@@ -7,6 +7,8 @@ import { classNames } from '@/util/utils';
 import type { ICellMorphology } from '@/api/entitycore/types/entities/cell-morphology';
 import type { IEModel } from '@/api/entitycore/types/entities/e-model';
 
+import styles from './card-container.module.css';
+
 const subtitleStyle = 'uppercase font-thin text-neutral-4';
 
 type Detail = {
@@ -72,7 +74,7 @@ export default function ModelCard({
   );
 
   return (
-    <div className="border-neutral-2 w-full rounded-[6px] border p-10">
+    <div className={styles.cardContainer}>
       <div className="flex justify-between">
         <div className={classNames('text-2xl', subtitleStyle)}>{title}</div>
         {cardLink}
@@ -87,7 +89,7 @@ export default function ModelCard({
         </div>
         <div className="grow">
           <div className={subtitleStyle}>NAME</div>
-          <div className="text-primary-8 my-1 text-3xl font-bold">{model.name}</div>
+          <div className={styles.name}>{model.name}</div>
           <ModelDetails details={modelDetails} />
         </div>
       </div>


### PR DESCRIPTION
The names of ME-Models can be long and until now they just overflow on small screens.

<img width="866" height="713" alt="image" src="https://github.com/user-attachments/assets/eb51e051-2f95-469a-aeac-e16d9e7ee215" />
