### PR TITLE
feat: allow filters, page, sorting, search to persist in user session in data section

### DIFF
--- a/src/app/app/virtual-lab/[virtualLabId]/[projectId]/data/layout.tsx
+++ b/src/app/app/virtual-lab/[virtualLabId]/[projectId]/data/layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 
+import { TeardownDataListStoreOnUnmount } from '@/ui/segments/data-table/elements/persistent-data-list';
 import type { ServerSideComponentProp, WorkspaceContext } from '@/types/common';
 
 export default function DataLayout({
@@ -7,5 +8,10 @@ export default function DataLayout({
 }: ServerSideComponentProp<WorkspaceContext, null> & {
   children: ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <>
+      <TeardownDataListStoreOnUnmount />
+      {children}
+    </>
+  );
 }

--- a/src/features/views/listing/browse-entity.tsx
+++ b/src/features/views/listing/browse-entity.tsx
@@ -6,14 +6,15 @@ import { parseAsString, SingleParserBuilder, useQueryState } from 'nuqs';
 import { ReactElement, useEffect, type ComponentProps } from 'react';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { WarningOutlined } from '@ant-design/icons';
-import { compact, get } from 'es-toolkit/compat';
+import { get } from 'es-toolkit/compat';
 import { RESET } from 'jotai/utils';
 import dynamic from 'next/dynamic';
 
+import { SetupDataListStoreOnMount } from '@/ui/segments/data-table/elements/persistent-data-list';
+import { makeDataKey, useDataListStoreSession } from '@/ui/segments/data-table/elements/helpers';
 import { useDataTableColumns } from '@/ui/segments/data-table/elements/use-data-table-columns';
 import { useQueryExtendedEntityType } from '@/ui/hooks/use-query-extended-entity-type';
 import { DownloadPanel } from '@/ui/segments/explore/circuit/elements/download-panel';
-
 import { DEFAULT_PAGE_NUMBER, WorkspaceScope, WorkspaceSection } from '@/constants';
 import { getEntityByExtendedType } from '@/entity-configuration/domain/helpers';
 import { MiniDetailView } from '@/ui/segments/mini-detail-view';
@@ -87,14 +88,31 @@ export function BrowseEntityScope({
       .withOptions({ shallow: true }) as NonNullable<SingleParserBuilder<TWorkspaceScope>>
   );
 
-  const dataKey = compact([virtualLabId, projectId, section, dataType, scope, id]).join('/');
+  const dataKey = makeDataKey({
+    virtualLabId,
+    projectId,
+    section,
+    dataType,
+    scope,
+    id,
+  });
+
   const entity = getEntityByExtendedType({ type: dataType });
   const setPageNumber = useSetAtom(corePageNumberAtom(dataKey));
+  const { sessionValue: dataListStoreSession, setSessionValue: updateDataListStoreSession } =
+    useDataListStoreSession({ dataKey, dataType });
 
   const [sortState, setSortState] = useAtom(coreSortStateAtom({ key: dataKey }));
   const onSortChange = (newSortState: any) => {
     setPageNumber(DEFAULT_PAGE_NUMBER);
     setSortState(newSortState);
+    if (section === WorkspaceSection.Data) {
+      updateDataListStoreSession({
+        ...dataListStoreSession,
+        Sort: newSortState,
+        Page: DEFAULT_PAGE_NUMBER,
+      });
+    }
   };
 
   const allColumns = useDataTableColumns<EntityCoreIdentifiableNamed>({
@@ -175,6 +193,7 @@ export function BrowseEntityScope({
 
   return (
     <>
+      <SetupDataListStoreOnMount {...{ dataKey, dataType }} />
       <div
         id="data-table-container"
         data-testid="data-table-container"

--- a/src/features/views/listing/browse-library.tsx
+++ b/src/features/views/listing/browse-library.tsx
@@ -2,17 +2,20 @@
 
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { WarningOutlined } from '@ant-design/icons';
+import { map, snakeCase } from 'es-toolkit/compat';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
 import { RESET } from 'jotai/utils';
 import { useEffect } from 'react';
-import snakeCase from 'es-toolkit/compat/snakeCase';
-import compact from 'es-toolkit/compat/compact';
 import dynamic from 'next/dynamic';
-import map from 'es-toolkit/compat/map';
 
 import { useDataTableColumns } from '@/ui/segments/data-table/elements/use-data-table-columns';
-import { DEFAULT_PAGE_MEDIUM_SIZE, DEFAULT_PAGE_NUMBER, WorkspaceScope } from '@/constants';
+import {
+  DEFAULT_PAGE_MEDIUM_SIZE,
+  DEFAULT_PAGE_NUMBER,
+  WorkspaceScope,
+  WorkspaceSection,
+} from '@/constants';
 import { useQueryExtendedEntityType } from '@/ui/hooks/use-query-extended-entity-type';
 import {
   coreActiveColumnsAtom,
@@ -21,6 +24,7 @@ import {
   coreSortStateAtom,
 } from '@/ui/segments/data-table/elements/context';
 import { getEntityByExtendedType } from '@/entity-configuration/domain/helpers';
+import { makeDataKey } from '@/ui/segments/data-table/elements/helpers';
 import { Card, CardDescription, CardTitle } from '@/ui/molecules/card';
 import { MiniDetailView } from '@/ui/segments/mini-detail-view';
 import { GenericError } from '@/ui/molecules/generic-error';
@@ -50,8 +54,14 @@ const MainTable = dynamic(() => import('@/ui/segments/data-table'), { ssr: false
 export function BrowseLibraryScope() {
   const { virtualLabId, projectId } = useWorkspace();
   const { type } = useParams<WorkspaceContext & { type: KebabCase<TExtendedEntitiesTypeDict> }>();
-  const dataKey = compact([virtualLabId, projectId, type, WorkspaceScope.Bookmarks]).join('/');
   const dataType = snakeCase(type) as TExtendedEntitiesTypeDict;
+  const dataKey = makeDataKey({
+    virtualLabId,
+    projectId,
+    dataType,
+    section: WorkspaceSection.Data,
+    scope: WorkspaceScope.Bookmarks,
+  });
   const [pageNumber, setPageNumber] = useAtom(corePageNumberAtom(dataKey));
   const { mdv, setMdv } = useMiniDetailView();
 

--- a/src/types/explore-section/application.ts
+++ b/src/types/explore-section/application.ts
@@ -13,10 +13,15 @@ export enum ExploreDataScope {
   BookmarkedResources = 'BookmarkedResources',
 }
 
+export const SortOrder = {
+  ASC: 'asc',
+  DESC: 'desc',
+} as const;
+export type TSortOrder = (typeof SortOrder)[keyof typeof SortOrder];
 export interface SortState {
   field: string;
   backendField: string;
-  order: 'asc' | 'desc' | null;
+  order: TSortOrder | null;
 }
 
 export type DetailViewUrlParams = Prettify<

--- a/src/ui/hooks/use-query-extended-entity-type.tsx
+++ b/src/ui/hooks/use-query-extended-entity-type.tsx
@@ -1,3 +1,5 @@
+import { isEmpty } from 'es-toolkit/compat';
+import { useAtomValue } from 'jotai';
 import {
   useQuery,
   keepPreviousData,
@@ -5,17 +7,15 @@ import {
   type QueryFunction,
   hashKey,
 } from '@tanstack/react-query';
-import { useAtomValue } from 'jotai';
-import isEmpty from 'es-toolkit/compat/isEmpty';
 
 import { BrainRegionDirection } from '@/api/entitycore/types/shared/request';
 import { transformFiltersToQuery } from '@/api/entitycore/transformers';
+import { DEFAULT_PAGE_SIZE, WorkspaceScope } from '@/constants';
 import {
   DEFAULT_BRAIN_REGION_HIERARCHY_ID,
   selectedBrainRegionAtom,
 } from '@/features/brain-region-hierarchy/context';
 import { compactRecord } from '@/utils/dictionary';
-import { DEFAULT_PAGE_SIZE, WorkspaceScope } from '@/constants';
 import {
   coreFiltersAtom,
   coreSortStateAtom,

--- a/src/ui/segments/data-table/elements/context.ts
+++ b/src/ui/segments/data-table/elements/context.ts
@@ -11,7 +11,7 @@ import { DEFAULT_PAGE_NUMBER } from '@/constants';
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { EntityCoreExtendedType } from '@/entity-configuration/domain/helpers';
 import type { CoreFilter } from '@/entity-configuration/definitions/types';
-import type { SortState } from '@/types/explore-section/application';
+import { SortOrder, type SortState } from '@/types/explore-section/application';
 
 export const coreActiveColumnsAtom = atomFamily(
   ({ dataType }: { key: string; dataType: EntityCoreExtendedType }) =>
@@ -44,7 +44,7 @@ export const coreSortStateAtom = atomFamily(
     const initialState: SortState = {
       field: EntityCoreFields.CreationDate,
       backendField: EntityCoreFields.CreationDate,
-      order: 'desc',
+      order: SortOrder.DESC,
     };
 
     const writableAtom = atom<SortState, [SortState], void>(initialState, (_, set, update) => {

--- a/src/ui/segments/data-table/elements/context.ts
+++ b/src/ui/segments/data-table/elements/context.ts
@@ -1,16 +1,14 @@
-import { atomFamily, atomWithDefault } from 'jotai/utils';
-import { atom } from 'jotai';
-import _get from 'es-toolkit/compat/get';
+'use client';
 
-import { columnKeyToFilter } from '@/ui/segments/data-table/elements/column-key-to-filter';
+import { atomFamily, atomWithDefault, atomWithReset } from 'jotai/utils';
+import { atom } from 'jotai';
+
 import { EntityCoreFields } from '@/entity-configuration/definitions/fields-defs/enums';
-import { getFieldsDefinition } from '@/entity-configuration/definitions';
-import {
-  getViewDefinitionByExtendedType,
-  ViewsDefinitionRegistry,
-} from '@/entity-configuration/definitions/view-defs';
+import { ViewsDefinitionRegistry } from '@/entity-configuration/definitions/view-defs';
+import { makeTypeDefaultFilters } from '@/ui/segments/data-table/elements/helpers';
 import { DEFAULT_PAGE_NUMBER } from '@/constants';
 
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { EntityCoreExtendedType } from '@/entity-configuration/domain/helpers';
 import type { CoreFilter } from '@/entity-configuration/definitions/types';
 import type { SortState } from '@/types/explore-section/application';
@@ -25,20 +23,9 @@ export const coreActiveColumnsAtom = atomFamily(
 );
 
 export const coreFiltersAtom = atomFamily(
-  ({ dataType, key }: { key: string; dataType: EntityCoreExtendedType }) => {
+  ({ dataType, key }: { key: string; dataType: TExtendedEntitiesTypeDict }) => {
     const childAtom = atomWithDefault<Array<CoreFilter>>(() => {
-      const columns = getViewDefinitionByExtendedType(dataType)?.columns;
-      const fields = columns ? getFieldsDefinition(columns) : [];
-      const filteredColumns = [
-        ...(columns
-          ?.filter(
-            (o) =>
-              _get(fields, o, { isFilterable: false })?.isFilterable === true ||
-              _get(fields, o, { isDisplayable: false })?.isDisplayable === true
-          )
-          ?.map((colKey) => columnKeyToFilter(colKey, dataType)) ?? []),
-      ];
-      return filteredColumns;
+      return makeTypeDefaultFilters({ dataType });
     });
     childAtom.debugLabel = `filter-atom/${key}`;
     return childAtom;
@@ -70,7 +57,7 @@ export const coreSortStateAtom = atomFamily(
 );
 
 export const corePageNumberAtom = atomFamily((key: string) => {
-  const childAtom = atom<number>(DEFAULT_PAGE_NUMBER);
+  const childAtom = atomWithReset<number>(DEFAULT_PAGE_NUMBER);
   childAtom.debugLabel = `page-number/${key}`;
   return childAtom;
 });

--- a/src/ui/segments/data-table/elements/helpers.tsx
+++ b/src/ui/segments/data-table/elements/helpers.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { get as _get, compact } from 'es-toolkit/compat';
+
+import { getViewDefinitionByExtendedType } from '@/entity-configuration/definitions/view-defs';
+import { columnKeyToFilter } from '@/ui/segments/data-table/elements/column-key-to-filter';
+import { EntityCoreFields } from '@/entity-configuration/definitions/fields-defs/enums';
+import { getFieldsDefinition } from '@/entity-configuration/definitions';
+import { useSessionStorage } from '@/hooks/use-session-storage';
+import { DEFAULT_PAGE_NUMBER } from '@/constants';
+
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import type { TWorkspaceScope, TWorkspaceSection } from '@/constants';
+
+export const makeTypeDefaultFilters = ({ dataType }: { dataType: TExtendedEntitiesTypeDict }) => {
+  const columns = getViewDefinitionByExtendedType(dataType)?.columns;
+  const fields = columns ? getFieldsDefinition(columns) : [];
+  const filteredColumns = [
+    ...(columns
+      ?.filter(
+        (o) =>
+          _get(fields, o, { isFilterable: false })?.isFilterable === true ||
+          _get(fields, o, { isDisplayable: false })?.isDisplayable === true
+      )
+      ?.map((colKey) => columnKeyToFilter(colKey, dataType)) ?? []),
+  ];
+  return filteredColumns;
+};
+
+export const makeDataListStoreAtomsInitialValue = ({
+  dataType,
+}: {
+  dataType: TExtendedEntitiesTypeDict;
+}) => ({
+  Sort: {
+    field: EntityCoreFields.CreationDate,
+    backendField: EntityCoreFields.CreationDate,
+    order: 'desc' as const,
+  },
+  Search: '',
+  Page: DEFAULT_PAGE_NUMBER,
+  Filters: makeTypeDefaultFilters({ dataType }),
+});
+
+export const useDataListStoreSession = ({
+  dataKey,
+  dataType,
+}: {
+  dataKey: string;
+  dataType: TExtendedEntitiesTypeDict;
+}) => {
+  return useSessionStorage(dataKey, makeDataListStoreAtomsInitialValue({ dataType }));
+};
+
+type DataKeyParts = {
+  virtualLabId?: string;
+  projectId?: string;
+  section?: TWorkspaceSection;
+  dataType?: TExtendedEntitiesTypeDict;
+  scope?: TWorkspaceScope;
+  id?: string;
+};
+
+export const makeDataKey = ({
+  virtualLabId,
+  projectId,
+  section,
+  dataType,
+  scope,
+  id,
+}: Omit<Required<DataKeyParts>, 'scope' | 'id'> & {
+  scope?: TWorkspaceScope | null;
+  id?: string | null;
+}) => {
+  return compact([virtualLabId, projectId, section, dataType, scope, id]).join('/');
+};
+
+/**
+ * safely extract parts from a dataKey created by makeDataKey().
+ * returns undefined for parts that were omitted.
+ */
+export function extractPartsFromDataKey(dataKey: string): DataKeyParts {
+  const parts = dataKey.split('/');
+  const [virtualLabId, projectId, section, dataType, scope, id] = [
+    parts[0] ?? undefined,
+    parts[1] ?? undefined,
+    parts[2] ?? undefined,
+    parts[3] ?? undefined,
+    parts[4] ?? undefined,
+    parts[5] ?? undefined,
+  ];
+
+  return {
+    virtualLabId,
+    projectId,
+    section: section as TWorkspaceSection | undefined,
+    dataType: dataType as TExtendedEntitiesTypeDict | undefined,
+    scope: scope as TWorkspaceScope | undefined,
+    id,
+  };
+}

--- a/src/ui/segments/data-table/elements/helpers.tsx
+++ b/src/ui/segments/data-table/elements/helpers.tsx
@@ -6,11 +6,17 @@ import { getViewDefinitionByExtendedType } from '@/entity-configuration/definiti
 import { columnKeyToFilter } from '@/ui/segments/data-table/elements/column-key-to-filter';
 import { EntityCoreFields } from '@/entity-configuration/definitions/fields-defs/enums';
 import { getFieldsDefinition } from '@/entity-configuration/definitions';
+import {
+  CircuitRepresentationView,
+  type TCircuitRepresentationView,
+} from '@/ui/segments/explore/circuit/helpers';
 import { useSessionStorage } from '@/hooks/use-session-storage';
 import { DEFAULT_PAGE_NUMBER } from '@/constants';
 
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import type { CoreFilter } from '@/entity-configuration/definitions/types';
 import type { TWorkspaceScope, TWorkspaceSection } from '@/constants';
+import type { TSortOrder } from '@/types/explore-section/application';
 
 export const makeTypeDefaultFilters = ({ dataType }: { dataType: TExtendedEntitiesTypeDict }) => {
   const columns = getViewDefinitionByExtendedType(dataType)?.columns;
@@ -40,17 +46,28 @@ export const makeDataListStoreAtomsInitialValue = ({
   Search: '',
   Page: DEFAULT_PAGE_NUMBER,
   Filters: makeTypeDefaultFilters({ dataType }),
+  View: CircuitRepresentationView.Hierarchy,
 });
 
-export const useDataListStoreSession = ({
+export function useDataListStoreSession({
   dataKey,
   dataType,
 }: {
   dataKey: string;
   dataType: TExtendedEntitiesTypeDict;
-}) => {
-  return useSessionStorage(dataKey, makeDataListStoreAtomsInitialValue({ dataType }));
-};
+}) {
+  return useSessionStorage<{
+    Sort: {
+      field: EntityCoreFields;
+      backendField: EntityCoreFields;
+      order: TSortOrder;
+    };
+    Search: string;
+    Page: number;
+    Filters: Array<CoreFilter>;
+    View: TCircuitRepresentationView;
+  }>(dataKey, makeDataListStoreAtomsInitialValue({ dataType }));
+}
 
 type DataKeyParts = {
   virtualLabId?: string;
@@ -59,6 +76,7 @@ type DataKeyParts = {
   dataType?: TExtendedEntitiesTypeDict;
   scope?: TWorkspaceScope;
   id?: string;
+  extra?: string | null;
 };
 
 export const makeDataKey = ({
@@ -68,11 +86,13 @@ export const makeDataKey = ({
   dataType,
   scope,
   id,
-}: Omit<Required<DataKeyParts>, 'scope' | 'id'> & {
+  extra,
+}: Omit<Required<DataKeyParts>, 'scope' | 'id' | 'extra'> & {
   scope?: TWorkspaceScope | null;
   id?: string | null;
+  extra?: string | undefined | null;
 }) => {
-  return compact([virtualLabId, projectId, section, dataType, scope, id]).join('/');
+  return compact([virtualLabId, projectId, section, dataType, scope, id, extra]).join('/');
 };
 
 /**
@@ -81,13 +101,14 @@ export const makeDataKey = ({
  */
 export function extractPartsFromDataKey(dataKey: string): DataKeyParts {
   const parts = dataKey.split('/');
-  const [virtualLabId, projectId, section, dataType, scope, id] = [
+  const [virtualLabId, projectId, section, dataType, scope, id, extra] = [
     parts[0] ?? undefined,
     parts[1] ?? undefined,
     parts[2] ?? undefined,
     parts[3] ?? undefined,
     parts[4] ?? undefined,
     parts[5] ?? undefined,
+    parts[6] ?? undefined,
   ];
 
   return {
@@ -97,5 +118,6 @@ export function extractPartsFromDataKey(dataKey: string): DataKeyParts {
     dataType: dataType as TExtendedEntitiesTypeDict | undefined,
     scope: scope as TWorkspaceScope | undefined,
     id,
+    extra,
   };
 }

--- a/src/ui/segments/data-table/elements/listing-filter-panel/listing-filter-panel.tsx
+++ b/src/ui/segments/data-table/elements/listing-filter-panel/listing-filter-panel.tsx
@@ -31,26 +31,32 @@ import { ValueRange } from '@/ui/segments/data-table/elements/listing-filter-pan
 import { CoreFieldFilterTypeEnum } from '@/entity-configuration/definitions/fields-defs/enums';
 import { getViewDefinitionByExtendedType } from '@/entity-configuration/definitions/view-defs';
 import { getFieldDefinition } from '@/entity-configuration/definitions';
+import { DEFAULT_PAGE_NUMBER, WorkspaceSection } from '@/constants';
 import { fieldTitleSentenceCase } from '@/util/utils';
+import {
+  makeDataListStoreAtomsInitialValue,
+  extractPartsFromDataKey,
+  useDataListStoreSession,
+} from '@/ui/segments/data-table/elements/helpers';
 import {
   coreActiveColumnsAtom,
   coreFiltersAtom,
   corePageNumberAtom,
   coreSearchStringAtom,
 } from '@/ui/segments/data-table/elements/context';
+import { Button } from '@/ui/molecules/button';
+import { cn } from '@/utils/css-class';
 
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { Facets } from '@/api/entitycore/types/shared/response';
 import type { WorkspaceContext } from '@/types/common';
-import { DEFAULT_PAGE_NUMBER, type TWorkspaceScope } from '@/constants';
+import type { TWorkspaceScope } from '@/constants';
 import type {
   ValueOrRangeFilter,
   CoreFilterValues,
   GteLteValue,
   CoreFilter,
 } from '@/entity-configuration/definitions/types';
-import { cn } from '@/utils/css-class';
-import { Button } from '@/ui/molecules/button';
 
 type Props = {
   children?: ReactNode;
@@ -207,6 +213,10 @@ export function ListingFilterPanel({
   const setPageNumber = useSetAtom(corePageNumberAtom(dataKey));
   const [filterValues, setFilterValues] = useState<CoreFilterValues>({});
   const [isApplyingFilters, setIsApplyingFilters] = useState(false);
+  const { sessionValue: dataListStoreSession, setSessionValue: updateDataListStoreSession } =
+    useDataListStoreSession({ dataKey, dataType });
+
+  const { section } = extractPartsFromDataKey(dataKey);
   const resetFilters = useResetAtom(
     coreFiltersAtom({
       dataType,
@@ -283,6 +293,13 @@ export function ListingFilterPanel({
       value: filterValues[fil.field],
     }));
     setFilters(appliedFilters);
+    if (section === WorkspaceSection.Data) {
+      updateDataListStoreSession({
+        ...dataListStoreSession,
+        Filters: appliedFilters as Array<CoreFilter>,
+        Page: DEFAULT_PAGE_NUMBER,
+      });
+    }
   };
 
   const Entity = getViewDefinitionByExtendedType(dataType);
@@ -331,6 +348,7 @@ export function ListingFilterPanel({
   const clearFilters = () => {
     resetFilters();
     setSearchString('');
+    updateDataListStoreSession(makeDataListStoreAtomsInitialValue({ dataType }));
   };
 
   if (!activeColumns) return null;

--- a/src/ui/segments/data-table/elements/pagination.tsx
+++ b/src/ui/segments/data-table/elements/pagination.tsx
@@ -3,14 +3,17 @@ import { useRef, useEffect } from 'react';
 import { useAtom } from 'jotai';
 import type { ComponentProps } from 'react';
 
+import { useDataListStoreSession } from '@/ui/segments/data-table/elements/helpers';
 import { corePageNumberAtom } from '@/ui/segments/data-table/elements/context';
 import { DEFAULT_PAGE_SIZE } from '@/constants';
 import { cn } from '@/utils/css-class';
 
 import type { Pagination as EntitycorePagination } from '@/api/entitycore/types/shared/response';
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 
 type Props = {
   dataKey: string;
+  dataType: TExtendedEntitiesTypeDict;
   size?: PaginationProps['size'];
   resultPagination?: {
     pagination: EntitycorePagination;
@@ -19,8 +22,10 @@ type Props = {
   className?: ComponentProps<'ul'>['className'];
 };
 
-export function Pagination({ dataKey, size, resultPagination, className }: Props) {
+export function Pagination({ dataKey, size, resultPagination, className, dataType }: Props) {
   const [page, updatePage] = useAtom(corePageNumberAtom(dataKey));
+  const { sessionValue: dataListStoreSession, setSessionValue: updateDataListStoreSession } =
+    useDataListStoreSession({ dataKey, dataType });
   const lastTotalItemsRef = useRef<number | undefined>(undefined);
   const lastDataKeyRef = useRef<string>(dataKey);
 
@@ -39,6 +44,11 @@ export function Pagination({ dataKey, size, resultPagination, className }: Props
 
   const totalItems = resultPagination?.pagination?.total_items ?? lastTotalItemsRef.current;
 
+  const onUpdatePage = (p: number) => {
+    updateDataListStoreSession({ ...dataListStoreSession, Page: p });
+    updatePage(p);
+  };
+
   if (totalItems === undefined) {
     return null;
   }
@@ -52,7 +62,7 @@ export function Pagination({ dataKey, size, resultPagination, className }: Props
       data-testid="listing-pagination"
       pageSize={DEFAULT_PAGE_SIZE}
       defaultPageSize={DEFAULT_PAGE_SIZE}
-      onChange={updatePage}
+      onChange={onUpdatePage}
       align="center"
       size={size}
       current={page}

--- a/src/ui/segments/data-table/elements/persistent-data-list.tsx
+++ b/src/ui/segments/data-table/elements/persistent-data-list.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useParams, useSearchParams } from 'next/navigation';
+import { snakeCase } from 'es-toolkit/compat';
+import { useResetAtom } from 'jotai/utils';
+import { useEffect, useRef } from 'react';
+import { useAtom } from 'jotai';
+
+import { WorkspaceScope, WorkspaceSection } from '@/constants';
+import { useWorkspace } from '@/ui/hooks/use-workspace';
+import {
+  makeDataKey,
+  makeDataListStoreAtomsInitialValue,
+  useDataListStoreSession,
+} from '@/ui/segments/data-table/elements/helpers';
+import {
+  coreSearchStringAtom,
+  corePageNumberAtom,
+  coreSortStateAtom,
+  coreFiltersAtom,
+} from '@/ui/segments/data-table/elements/context';
+import { WorkspaceContext } from '@/types/common';
+import { isBrowser } from '@/utils/environment';
+
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import type { TWorkspaceScope } from '@/constants';
+import type { KebabCase } from '@/utils/type';
+
+export function SetupDataListStoreOnMount({
+  dataType,
+  dataKey,
+}: {
+  dataType: TExtendedEntitiesTypeDict;
+  dataKey: string;
+}) {
+  const isMounted = useRef(false);
+  const { sessionValue: coreListingSession } = useDataListStoreSession({
+    dataKey,
+    dataType,
+  });
+
+  const [, updateSortState] = useAtom(coreSortStateAtom({ key: dataKey }));
+  const [, updateSearchString] = useAtom(coreSearchStringAtom(dataKey));
+  const [, updatePageNumber] = useAtom(corePageNumberAtom(dataKey));
+  const [, updateFilters] = useAtom(coreFiltersAtom({ dataType, key: dataKey }));
+
+  useEffect(() => {
+    // set from session only in first render
+    if (!isMounted.current) {
+      updateSortState(coreListingSession.Sort);
+      updateSearchString(coreListingSession.Search);
+      updatePageNumber(coreListingSession.Page);
+      updateFilters(coreListingSession.Filters);
+      isMounted.current = true;
+    }
+
+    return () => {
+      isMounted.current = false;
+    };
+  }, [coreListingSession]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return null;
+}
+
+export function TeardownDataListStoreOnUnmount() {
+  const { virtualLabId, projectId } = useWorkspace();
+  const params = useParams<WorkspaceContext & { type: KebabCase<TExtendedEntitiesTypeDict> }>();
+  const scope = (useSearchParams().get('scope') ?? WorkspaceScope.Public) as TWorkspaceScope;
+  const dataType = snakeCase(params.type) as TExtendedEntitiesTypeDict;
+  const dataKey = makeDataKey({
+    virtualLabId,
+    projectId,
+    dataType,
+    section: WorkspaceSection.Data,
+    scope,
+  });
+  const [, updateSortState] = useAtom(coreSortStateAtom({ key: dataKey }));
+  const [, updateSearchString] = useAtom(coreSearchStringAtom(dataKey));
+  const [, updateFilters] = useAtom(coreFiltersAtom({ dataType, key: dataKey }));
+  const updatePageNumber = useResetAtom(corePageNumberAtom(dataKey));
+
+  const defaultAtomValues = makeDataListStoreAtomsInitialValue({ dataType });
+
+  useEffect(() => {
+    return () => {
+      updatePageNumber();
+      updateSearchString('');
+      updateSortState(defaultAtomValues.Sort);
+      updateFilters(defaultAtomValues.Filters);
+      if (isBrowser()) {
+        window.sessionStorage.removeItem(dataKey);
+      }
+    };
+  }, [dataKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return null;
+}

--- a/src/ui/segments/data-table/elements/persistent-data-list.tsx
+++ b/src/ui/segments/data-table/elements/persistent-data-list.tsx
@@ -6,6 +6,7 @@ import { useResetAtom } from 'jotai/utils';
 import { useEffect, useRef } from 'react';
 import { useAtom } from 'jotai';
 
+import { circuitRepresentationViewAtom } from '@/ui/segments/explore/circuit/helpers';
 import { WorkspaceScope, WorkspaceSection } from '@/constants';
 import { useWorkspace } from '@/ui/hooks/use-workspace';
 import {
@@ -34,7 +35,7 @@ export function SetupDataListStoreOnMount({
   dataKey: string;
 }) {
   const isMounted = useRef(false);
-  const { sessionValue: coreListingSession } = useDataListStoreSession({
+  const { sessionValue: dataListStoreSession } = useDataListStoreSession({
     dataKey,
     dataType,
   });
@@ -43,21 +44,23 @@ export function SetupDataListStoreOnMount({
   const [, updateSearchString] = useAtom(coreSearchStringAtom(dataKey));
   const [, updatePageNumber] = useAtom(corePageNumberAtom(dataKey));
   const [, updateFilters] = useAtom(coreFiltersAtom({ dataType, key: dataKey }));
+  const [, updateCircuitView] = useAtom(circuitRepresentationViewAtom);
 
   useEffect(() => {
     // set from session only in first render
     if (!isMounted.current) {
-      updateSortState(coreListingSession.Sort);
-      updateSearchString(coreListingSession.Search);
-      updatePageNumber(coreListingSession.Page);
-      updateFilters(coreListingSession.Filters);
+      updateSearchString(dataListStoreSession.Search);
+      updateCircuitView(dataListStoreSession.View);
+      updateFilters(dataListStoreSession.Filters);
+      updatePageNumber(dataListStoreSession.Page);
+      updateSortState(dataListStoreSession.Sort);
       isMounted.current = true;
     }
 
     return () => {
       isMounted.current = false;
     };
-  }, [coreListingSession]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [dataListStoreSession]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return null;
 }
@@ -77,6 +80,7 @@ export function TeardownDataListStoreOnUnmount() {
   const [, updateSortState] = useAtom(coreSortStateAtom({ key: dataKey }));
   const [, updateSearchString] = useAtom(coreSearchStringAtom(dataKey));
   const [, updateFilters] = useAtom(coreFiltersAtom({ dataType, key: dataKey }));
+  const [, updateCircuitView] = useAtom(circuitRepresentationViewAtom);
   const updatePageNumber = useResetAtom(corePageNumberAtom(dataKey));
 
   const defaultAtomValues = makeDataListStoreAtomsInitialValue({ dataType });
@@ -87,6 +91,7 @@ export function TeardownDataListStoreOnUnmount() {
       updateSearchString('');
       updateSortState(defaultAtomValues.Sort);
       updateFilters(defaultAtomValues.Filters);
+      updateCircuitView(defaultAtomValues.View);
       if (isBrowser()) {
         window.sessionStorage.removeItem(dataKey);
       }

--- a/src/ui/segments/data-table/index.tsx
+++ b/src/ui/segments/data-table/index.tsx
@@ -163,7 +163,7 @@ export function MainTable<T extends EntityCoreIdentifiableNamed>({
           allowDownload={allowDownload}
           controls={
             <div className="w-full">
-              <Pagination {...{ dataKey, resultPagination }} />
+              <Pagination {...{ dataType, dataKey, resultPagination }} />
             </div>
           }
         />

--- a/src/ui/segments/data-table/search.tsx
+++ b/src/ui/segments/data-table/search.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, ComponentProps, useDeferredValue, useEffect, useRef, useSt
 import { SearchOutlined, CloseOutlined } from '@ant-design/icons';
 import { useAtom, useSetAtom } from 'jotai';
 
+import { useDataListStoreSession } from '@/ui/segments/data-table/elements/helpers';
 import {
   corePageNumberAtom,
   coreSearchStringAtom,
@@ -9,12 +10,15 @@ import {
 import { DEFAULT_PAGE_NUMBER } from '@/constants';
 import { cn } from '@/utils/css-class';
 
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+
 type SearchProps = {
   dataKey: string;
+  dataType: TExtendedEntitiesTypeDict;
   className?: ComponentProps<'div'>['className'];
 };
 
-export function Search({ dataKey, className }: SearchProps) {
+export function Search({ dataKey, dataType, className }: SearchProps) {
   const [isSearchOpen, setIsSearchOpen] = useState<boolean>(false);
   const [searchInput, setSearchInput] = useState<string>('');
   const deferredSearchInput = useDeferredValue(searchInput);
@@ -22,10 +26,21 @@ export function Search({ dataKey, className }: SearchProps) {
   const [searchString, setSearchString] = useAtom(coreSearchStringAtom(dataKey));
   const searchInputRef = useRef<HTMLInputElement>(null);
   const setPageNumber = useSetAtom(corePageNumberAtom(dataKey));
+  const previousSearchRef = useRef<string>(deferredSearchInput);
+  const { sessionValue: dataListStoreSession, setSessionValue: updateDataListStoreSession } =
+    useDataListStoreSession({ dataKey, dataType });
 
   useEffect(() => {
-    setPageNumber(DEFAULT_PAGE_NUMBER);
+    // only reset page if search value actually changed (not on mount)
+    const searchChanged = previousSearchRef.current !== deferredSearchInput;
+    previousSearchRef.current = deferredSearchInput;
+
+    if (searchChanged) {
+      setPageNumber(DEFAULT_PAGE_NUMBER);
+      updateDataListStoreSession({ ...dataListStoreSession, Page: DEFAULT_PAGE_NUMBER });
+    }
     setSearchString(deferredSearchInput);
+    updateDataListStoreSession({ ...dataListStoreSession, Search: deferredSearchInput });
   }, [deferredSearchInput]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
@@ -46,12 +61,18 @@ export function Search({ dataKey, className }: SearchProps) {
   };
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
-    setSearchInput(e.target.value);
+    const { value } = e.target;
+    setSearchInput(value);
   };
 
   const handleClearSearch = (): void => {
     setSearchInput('');
     setPageNumber(DEFAULT_PAGE_NUMBER);
+    updateDataListStoreSession({
+      ...dataListStoreSession,
+      Search: '',
+      Page: DEFAULT_PAGE_NUMBER,
+    });
     searchInputRef.current?.focus();
   };
 

--- a/src/ui/segments/explore/circuit/elements/recursive-expandable-table.tsx
+++ b/src/ui/segments/explore/circuit/elements/recursive-expandable-table.tsx
@@ -8,7 +8,10 @@ import { createExpandableTableConfig } from '@/ui/segments/explore/circuit/eleme
 import { useExpandableTable } from '@/ui/segments/explore/circuit/elements/use-expandable-table';
 
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
-import type { ICircuitEnriched, TCircuitView } from '@/ui/segments/explore/circuit/helpers';
+import type {
+  ICircuitEnriched,
+  TCircuitRepresentationView,
+} from '@/ui/segments/explore/circuit/helpers';
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
 import type { WorkspaceContext } from '@/types/common';
 import type { TWorkspaceScope } from '@/constants';
@@ -22,7 +25,7 @@ type Props = {
   workspace?: WorkspaceContext;
   onCellClick?: (basePath: string, record: ICircuit) => void;
   level?: number;
-  view: TCircuitView | null;
+  view: TCircuitRepresentationView | null;
 };
 
 export function RecursiveExpandableTable({

--- a/src/ui/segments/explore/circuit/elements/view-toggle.tsx
+++ b/src/ui/segments/explore/circuit/elements/view-toggle.tsx
@@ -1,21 +1,39 @@
-import { parseAsString, SingleParserBuilder, useQueryState } from 'nuqs';
+import { useAtom } from 'jotai';
 import { Tooltip } from 'antd';
 
-import { CircuitView, TCircuitView } from '@/ui/segments/explore/circuit/helpers';
+import {
+  CircuitRepresentationView,
+  circuitRepresentationViewAtom,
+} from '@/ui/segments/explore/circuit/helpers';
 import { FlatListViewIcon, HierarchicalViewIcon } from '@/components/icons';
+import { useDataListStoreSession } from '@/ui/segments/data-table/elements/helpers';
 import { classNames } from '@/util/utils';
 
-export function CircuitViewToggle() {
-  const [view, updateView] = useQueryState(
-    'view',
-    parseAsString
-      .withDefault(CircuitView.Hierarchy)
-      .withOptions({ shallow: true, clearOnDefault: false }) as SingleParserBuilder<TCircuitView>
-  );
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+
+type Props = {
+  dataType: TExtendedEntitiesTypeDict;
+  dataKey: string;
+};
+
+export function CircuitViewToggle({ dataType, dataKey }: Props) {
+  const [view, updateView] = useAtom(circuitRepresentationViewAtom);
+  const { sessionValue: dataListStoreSession, setSessionValue: updateDataListStoreSession } =
+    useDataListStoreSession({
+      dataKey,
+      dataType,
+    });
 
   const handleViewChange = () => {
-    const newView = view === 'hierarchy' ? 'flat' : 'hierarchy';
+    const newView =
+      view === CircuitRepresentationView.Hierarchy
+        ? CircuitRepresentationView.Flat
+        : CircuitRepresentationView.Hierarchy;
     updateView(newView);
+    updateDataListStoreSession({
+      ...dataListStoreSession,
+      View: newView,
+    });
   };
 
   return (

--- a/src/ui/segments/explore/circuit/helpers.ts
+++ b/src/ui/segments/explore/circuit/helpers.ts
@@ -1,11 +1,12 @@
+import { atomWithReset } from 'jotai/utils';
+import { keyBy } from 'es-toolkit/compat';
 import { atom } from 'jotai';
-import keyBy from 'es-toolkit/compat/keyBy';
 
 import type { HierarchyNode, HierarchyTreeResponse } from '@/api/entitycore/types/shared/hierarchy';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
 
-export const circuitRepresentationAtom = atom<'flat' | 'hierarchy'>('hierarchy');
+export const circuitRepresentationViewAtom = atomWithReset<TCircuitRepresentationView>('hierarchy');
 export const resetFilterSignalAtom = atom(0);
 
 export interface HierarchyOutputNode extends Omit<HierarchyNode, 'children'>, ICircuit {
@@ -47,11 +48,12 @@ export function countDeepSubCircuits(node: ICircuitEnriched): number {
   return node.sub_circuits.reduce((sum, child) => sum + 1 + countDeepSubCircuits(child), 0);
 }
 
-export const CircuitView = {
+export const CircuitRepresentationView = {
   Flat: 'flat',
   Hierarchy: 'hierarchy',
 } as const;
-export type TCircuitView = (typeof CircuitView)[keyof typeof CircuitView];
+export type TCircuitRepresentationView =
+  (typeof CircuitRepresentationView)[keyof typeof CircuitRepresentationView];
 
 export function findParentInTree(roots: HierarchyNode[], targetId: string): HierarchyNode | null {
   for (const node of roots) {

--- a/src/ui/segments/explore/circuit/index.tsx
+++ b/src/ui/segments/explore/circuit/index.tsx
@@ -2,17 +2,18 @@
 
 'use client';
 
-import { parseAsString, SingleParserBuilder, useQueryStates } from 'nuqs';
+import { parseAsString, SingleParserBuilder, useQueryState } from 'nuqs';
 import { ReactNode, useEffect, type ComponentProps } from 'react';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { WarningOutlined } from '@ant-design/icons';
-import { compact, get } from 'es-toolkit/compat';
+import { get } from 'es-toolkit/compat';
 import { RESET } from 'jotai/utils';
 import dynamic from 'next/dynamic';
 
 import { RecursiveExpandableTable } from '@/ui/segments/explore/circuit/elements/recursive-expandable-table';
 import { createExpandableTableConfig } from '@/ui/segments/explore/circuit/elements/expandable-base-table';
-import { CircuitView, ICircuitEnriched, TCircuitView } from '@/ui/segments/explore/circuit/helpers';
+import { SetupDataListStoreOnMount } from '@/ui/segments/data-table/elements/persistent-data-list';
+import { makeDataKey, useDataListStoreSession } from '@/ui/segments/data-table/elements/helpers';
 import { useExpandableTable } from '@/ui/segments/explore/circuit/elements/use-expandable-table';
 import { useFilterStateWatcher } from '@/ui/segments/explore/circuit/use-filter-state-watcher';
 import { useDataTableColumns } from '@/ui/segments/data-table/elements/use-data-table-columns';
@@ -33,6 +34,11 @@ import {
   corePageNumberAtom,
   coreSortStateAtom,
 } from '@/ui/segments/data-table/elements/context';
+import {
+  CircuitRepresentationView,
+  circuitRepresentationViewAtom,
+  type ICircuitEnriched,
+} from '@/ui/segments/explore/circuit/helpers';
 import {
   makeSelectEntityClickEvent,
   useMiniDetailView,
@@ -80,28 +86,41 @@ export function BrowseCircuit({
 }: Props) {
   const { virtualLabId, projectId } = useWorkspace();
   const { mdv, setMdv } = useMiniDetailView();
-  const [{ scope, view }] = useQueryStates({
-    view: parseAsString
-      .withDefault(CircuitView.Hierarchy)
-      .withOptions({ shallow: true, clearOnDefault: false }) as NonNullable<
-      SingleParserBuilder<TCircuitView>
-    >,
-    scope: parseAsString
+  const [view] = useAtom(circuitRepresentationViewAtom);
+  const [scope] = useQueryState(
+    'scope',
+    parseAsString
       .withDefault(defaultScope ?? WorkspaceScope.Public)
       .withOptions({ shallow: true, clearOnDefault: false }) as NonNullable<
       SingleParserBuilder<TWorkspaceScope>
-    >,
-  });
+    >
+  );
 
-  const dataKey = compact([virtualLabId, projectId, section, dataType, scope, view, id]).join('/');
+  const dataKey = makeDataKey({
+    virtualLabId,
+    projectId,
+    section,
+    dataType,
+    scope,
+    id,
+  });
   const resetFilterOnExit = useSetAtom(coreFiltersAtom({ dataType, key: dataKey }));
   const activeColumns = useAtomValue(coreActiveColumnsAtom({ dataType, key: dataKey }));
   const setPageNumber = useSetAtom(corePageNumberAtom(dataKey));
   const [sortState, setSortState] = useAtom(coreSortStateAtom({ key: dataKey }));
+  const { sessionValue: dataListStoreSession, setSessionValue: updateDataListStoreSession } =
+    useDataListStoreSession({ dataKey, dataType });
 
   const onSortChange = (newSortState: any) => {
     setPageNumber(DEFAULT_PAGE_NUMBER);
     setSortState(newSortState);
+    if (section === WorkspaceSection.Data) {
+      updateDataListStoreSession({
+        ...dataListStoreSession,
+        Sort: newSortState,
+        Page: DEFAULT_PAGE_NUMBER,
+      });
+    }
   };
 
   const allColumns = useDataTableColumns<ICircuit>({
@@ -162,11 +181,11 @@ export function BrowseCircuit({
   let facets: Facets | undefined;
   let pagination: Pagination | undefined;
 
-  if (view === CircuitView.Flat) {
+  if (view === CircuitRepresentationView.Flat) {
     dataSource = data?.data ?? [];
     facets = data?.facets;
     pagination = data?.pagination;
-  } else if (view === CircuitView.Hierarchy) {
+  } else if (view === CircuitRepresentationView.Hierarchy) {
     dataSource = hierarchyDataSource;
     pagination = hierarchyPagination;
     facets = hierarchyFacets;
@@ -267,6 +286,7 @@ export function BrowseCircuit({
 
   return (
     <>
+      <SetupDataListStoreOnMount {...{ dataType, dataKey }} />
       <div
         id="circuit-table-container"
         data-testid="circuit-table-container"
@@ -281,7 +301,7 @@ export function BrowseCircuit({
             sticky={{ offsetHeader: 75.5 }}
             isLoading={
               // eslint-disable-next-line no-nested-ternary
-              view === CircuitView.Hierarchy
+              view === CircuitRepresentationView.Hierarchy
                 ? loadingHierarchy
                 : isPlaceholderData
                   ? isFetching
@@ -307,7 +327,9 @@ export function BrowseCircuit({
             }}
             {...mainTableProps}
             view={view}
-            queryKeyHash={view === CircuitView.Hierarchy ? queryKeyHash : defaultQueryHash}
+            queryKeyHash={
+              view === CircuitRepresentationView.Hierarchy ? queryKeyHash : defaultQueryHash
+            }
             expandableConfig={expandableConfig}
           />
         </div>

--- a/src/ui/segments/explore/circuit/table.tsx
+++ b/src/ui/segments/explore/circuit/table.tsx
@@ -172,7 +172,7 @@ export function MainTable({
           controls={
             view === CircuitView.Flat && (
               <div className="w-full">
-                <Pagination {...{ dataKey, resultPagination }} />
+                <Pagination {...{ dataKey, dataType, resultPagination }} />
               </div>
             )
           }

--- a/src/ui/segments/explore/circuit/table.tsx
+++ b/src/ui/segments/explore/circuit/table.tsx
@@ -17,14 +17,14 @@ import { coreFiltersAtom } from '@/ui/segments/data-table/elements/context';
 import { OnCellClick, WrapperTable } from '@/ui/segments/data-table/table';
 import { Pagination } from '@/ui/segments/data-table/elements/pagination';
 import { BrainRegionDropdown } from '@/features/brain-region-dropdown';
-import { CircuitView } from '@/ui/segments/explore/circuit/helpers';
+import { CircuitRepresentationView } from '@/ui/segments/explore/circuit/helpers';
 import { Search } from '@/ui/segments/data-table/search';
 import { WorkspaceScope } from '@/constants';
 import { cn } from '@/utils/css-class';
 
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { RenderButtonProps } from '@/ui/segments/data-table/elements/use-row-selection';
-import type { TCircuitView } from '@/ui/segments/explore/circuit/helpers';
+import type { TCircuitRepresentationView } from '@/ui/segments/explore/circuit/helpers';
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
 import type { WorkspaceContext } from '@/types/common';
 import type { TWorkspaceScope } from '@/constants';
@@ -58,7 +58,7 @@ export type Props<T> = {
   isLoading?: boolean;
   dataSource: Array<T>;
   tableStyle?: CSSProperties | undefined;
-  view: TCircuitView | null;
+  view: TCircuitRepresentationView | null;
   queryKeyHash?: string;
   expandableConfig?: ExpandableConfig<T>;
 };
@@ -126,7 +126,7 @@ export function MainTable({
                 dataScope === WorkspaceScope.BuildSynaptomeModel) && (
                 <BrainRegionDropdown dataKey={dataKey} />
               )}
-              <CircuitViewToggle />
+              <CircuitViewToggle {...{ dataType, dataKey }} />
               <FilterControls
                 filters={filters}
                 displayControlPanel={displayControlPanel}
@@ -137,7 +137,7 @@ export function MainTable({
           </div>
         </div>
         <WrapperTable<ICircuit>
-          key={view === CircuitView.Hierarchy ? queryKeyHash : 'circuit-table'}
+          key={view === CircuitRepresentationView.Hierarchy ? queryKeyHash : 'circuit-table'}
           dataType={dataType}
           columns={columns}
           dataSource={dataSource}
@@ -170,7 +170,7 @@ export function MainTable({
           sticky={sticky}
           className={cls?.table}
           controls={
-            view === CircuitView.Flat && (
+            view === CircuitRepresentationView.Flat && (
               <div className="w-full">
                 <Pagination {...{ dataKey, dataType, resultPagination }} />
               </div>

--- a/src/ui/segments/explore/circuit/use-hierarchy.tsx
+++ b/src/ui/segments/explore/circuit/use-hierarchy.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/api/entitycore/queries/model/circuit';
 import {
   buildFilteredHierarchyTree,
-  CircuitView,
+  CircuitRepresentationView,
   collectIdsFromNode,
   filterAndEnrichTree,
   findNodeInTree,
@@ -27,7 +27,10 @@ import {
   getAllCircuitIds,
 } from '@/ui/segments/explore/circuit/helpers';
 
-import type { HierarchyOutputNode, TCircuitView } from '@/ui/segments/explore/circuit/helpers';
+import type {
+  HierarchyOutputNode,
+  TCircuitRepresentationView,
+} from '@/ui/segments/explore/circuit/helpers';
 import type { HierarchyTreeResponse } from '@/api/entitycore/types/shared/hierarchy';
 import type { TDerivationType } from '@/api/entitycore/types/entities/derivation';
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
@@ -39,7 +42,11 @@ import type {
   Pagination,
 } from '@/api/entitycore/types/shared/response';
 
-export function useFullRawHierarchy({ view = CircuitView.Flat }: { view: TCircuitView | null }) {
+export function useFullRawHierarchy({
+  view = CircuitRepresentationView.Flat,
+}: {
+  view: TCircuitRepresentationView | null;
+}) {
   const queryClient = useQueryClient();
   const { virtualLabId, projectId } = useWorkspace();
   const { data: circuitHierarchy, isLoading: isLoadingFullHierarchy } = useQuery({
@@ -109,7 +116,7 @@ export function useFullRawHierarchy({ view = CircuitView.Flat }: { view: TCircui
         },
       };
     },
-    enabled: view === CircuitView.Hierarchy,
+    enabled: view === CircuitRepresentationView.Hierarchy,
     staleTime: Infinity,
     gcTime: 3_600_000, // 1 hour
   });
@@ -121,7 +128,7 @@ export function useHierarchyDerivationTree({
   view,
   derivationType,
 }: {
-  view: TCircuitView | null;
+  view: TCircuitRepresentationView | null;
   derivationType: TDerivationType;
 }) {
   const { virtualLabId, projectId } = useWorkspace();
@@ -137,7 +144,7 @@ export function useHierarchyDerivationTree({
           context: { virtualLabId, projectId },
           derivation_type: derivationType,
         }),
-      enabled: view === CircuitView.Hierarchy,
+      enabled: view === CircuitRepresentationView.Hierarchy,
       staleTime: Infinity,
     });
 
@@ -149,11 +156,11 @@ export function useHierarchyDerivationTree({
 
 export function useHierarchy({
   scope = WorkspaceScope.Public,
-  view = CircuitView.Flat,
+  view = CircuitRepresentationView.Flat,
   dataKey,
 }: {
   scope: TWorkspaceScope | null;
-  view: TCircuitView | null;
+  view: TCircuitRepresentationView | null;
   dataKey: string;
 }) {
   const queryClient = useQueryClient();
@@ -245,7 +252,7 @@ export function useHierarchy({
       const [{ queryParameters }] = queryKey;
       if (
         get(queryParameters, 'within_brain_region_brain_region_id', null) &&
-        view === CircuitView.Hierarchy
+        view === CircuitRepresentationView.Hierarchy
       )
         return true;
       return false;
@@ -286,13 +293,13 @@ export function useHierarchyAllLevels({ entityId }: WorkspaceContext & { entityI
   let extractionParentCircuitAsParent: ICircuit | undefined;
   let rewiringParentCircuitAsDerivedFrom: ICircuit | undefined;
   const { circuitHierarchy, isLoadingFullHierarchy } = useFullRawHierarchy({
-    view: CircuitView.Hierarchy,
+    view: CircuitRepresentationView.Hierarchy,
   });
   const {
     hierarchyByDerivation: hierarchyByExtractionDerivation,
     loadingDerivation: loadingExtractionDerivation,
   } = useHierarchyDerivationTree({
-    view: CircuitView.Hierarchy,
+    view: CircuitRepresentationView.Hierarchy,
     derivationType: DerivationTypeDictionary.CircuitExtraction,
   });
 
@@ -300,7 +307,7 @@ export function useHierarchyAllLevels({ entityId }: WorkspaceContext & { entityI
     hierarchyByDerivation: hierarchyByRewiringDerivation,
     loadingDerivation: loadingRewiringDerivation,
   } = useHierarchyDerivationTree({
-    view: CircuitView.Hierarchy,
+    view: CircuitRepresentationView.Hierarchy,
     derivationType: DerivationTypeDictionary.CircuitRewiring,
   });
 


### PR DESCRIPTION
only in data section (when switch to other sections, the filters, pagination, ...) should be resetted