### PR TITLE
Improve small scale simulator layout

### DIFF
--- a/src/features/small-microcircuit/_components/simulation-files/index.tsx
+++ b/src/features/small-microcircuit/_components/simulation-files/index.tsx
@@ -103,7 +103,7 @@ export function SimulationFiles({
   }, [loading, inputFiles, outputFiles, onSelect, selectedFile]);
 
   return (
-    <>
+    <div className="h-full overflow-y-auto">
       <h4 className="uppercase">Input files</h4>
       <div className="mt-4 mb-8 flex flex-col gap-4">
         {inputFiles.map((file) => (
@@ -135,7 +135,7 @@ export function SimulationFiles({
           <Loader className="text-neutral-3" />
         </div>
       )}
-    </>
+    </div>
   );
 }
 

--- a/src/features/small-microcircuit/index.tsx
+++ b/src/features/small-microcircuit/index.tsx
@@ -149,7 +149,7 @@ export default function SimulationCampaignConfiguration({
             }}
           />
 
-          <div className="overflow-hidden rounded-lg">
+          <div className="rounded-lg">
             <ModelPreview model={model} />
           </div>
         </div>

--- a/src/ui/layouts/data-view-layout.tsx
+++ b/src/ui/layouts/data-view-layout.tsx
@@ -60,12 +60,12 @@ export async function DataViewLayout({
     type === ExtendedEntitiesTypeDict.MemodelCircuitSimulation
   ) {
     return (
-      <div className="relative ml-5 flex h-full flex-col rounded-md border-[1px] border-[#D9D9D9] px-5 py-3">
+      <div className="ml-5 flex h-full flex-col rounded-md border-[1px] border-[#D9D9D9] px-5 py-3">
         <div className="mb-5">
           {closePage}
           {breadcrumbs}
         </div>
-        {children}
+        <div className="relative flex-1 overflow-auto">{children}</div>
       </div>
     );
   }


### PR DESCRIPTION
* Prevent list of files overflowing its container
* Make sure it's contained within root layout without overflow

Relates to [Fix spill over of files in simulations tab of small microcircuit configuration](https://github.com/openbraininstitute/prod-circuit-simulation/issues/82).