### PR TITLE
Apply workspace scope filters in listing views

### DIFF
--- a/src/features/views/listing/browse-entity.tsx
+++ b/src/features/views/listing/browse-entity.tsx
@@ -38,6 +38,7 @@ import type { EntityCoreIdentifiableNamed } from '@/api/entitycore/types/shared/
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { TWorkspaceScope, TWorkspaceSection } from '@/constants';
 import type { Props as MainTableProps } from '@/ui/segments/data-table';
+import { getWorkspaceScopeFilters } from '@/utils/workspace-scope';
 
 const MainTable = dynamic(() => import('@/ui/segments/data-table'), { ssr: false }) as (
   props: MainTableProps<EntityCoreIdentifiableNamed>
@@ -114,7 +115,11 @@ export function BrowseEntityScope({
     workspace: { virtualLabId, projectId },
     queryFn: async ({ queryKey }) => {
       const [{ workspace, queryParameters }] = queryKey;
-      const filters = { ...queryParameters, ...extraQueryParams };
+      const filters = {
+        ...queryParameters,
+        ...extraQueryParams,
+        ...getWorkspaceScopeFilters(scope!, { virtualLabId, projectId }),
+      };
       return entity?.api?.query.list?.({
         withFacets: true,
         filters,

--- a/src/ui/hooks/use-query-extended-entity-type.tsx
+++ b/src/ui/hooks/use-query-extended-entity-type.tsx
@@ -15,7 +15,7 @@ import {
   selectedBrainRegionAtom,
 } from '@/features/brain-region-hierarchy/context';
 import { compactRecord } from '@/utils/dictionary';
-import { DEFAULT_PAGE_SIZE, WorkspaceScope } from '@/constants';
+import { DEFAULT_PAGE_SIZE } from '@/constants';
 import {
   coreFiltersAtom,
   coreSortStateAtom,
@@ -26,6 +26,7 @@ import {
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { WorkspaceContext } from '@/types/common';
 import type { TWorkspaceScope } from '@/constants';
+import { getWorkspaceScopeFilters } from '@/utils/workspace-scope';
 
 export type QueryContext = {
   key: string;
@@ -82,16 +83,7 @@ function useQueryParameters(
           within_brain_region_direction: BrainRegionDirection.ASCENDANTS_AND_DESCENDANTS,
         }
       : {}),
-    // eslint-disable-next-line no-nested-ternary
-    ...(context.workspaceScope === WorkspaceScope.Project
-      ? {
-          authorized_project_id: workspace?.projectId,
-        }
-      : context.workspaceScope === WorkspaceScope.Public
-        ? {
-            authorized_public: true,
-          }
-        : {}),
+    ...getWorkspaceScopeFilters(context.workspaceScope, workspace),
     ...transformFiltersToQuery(filters as any),
   });
   return queryParameters;

--- a/src/ui/segments/explore/browse-link.tsx
+++ b/src/ui/segments/explore/browse-link.tsx
@@ -29,6 +29,7 @@ import { env } from '@/env';
 
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { TWorkspaceScope } from '@/constants';
+import { getWorkspaceScopeFilters } from '@/utils/workspace-scope';
 
 function buildDataUrl({
   virtualLabId,
@@ -172,17 +173,7 @@ function buildQuery({
       within_brain_region_hierarchy_id: env.NEXT_PUBLIC_DEFAULT_BRAIN_REGION_HIERARCHY_ID,
       within_brain_region_brain_region_id: brainRegionId ?? null,
       within_brain_region_direction: BrainRegionDirection.ASCENDANTS_AND_DESCENDANTS,
-      // eslint-disable-next-line no-nested-ternary
-      ...(scope === WorkspaceScope.Project
-        ? {
-            authorized_project_id: projectId,
-            authorized_public: false,
-          }
-        : scope === WorkspaceScope.Public
-          ? {
-              authorized_public: true,
-            }
-          : {}),
+      ...getWorkspaceScopeFilters(scope, { virtualLabId, projectId }),
     },
   };
 

--- a/src/ui/segments/explore/circuit/index.tsx
+++ b/src/ui/segments/explore/circuit/index.tsx
@@ -46,6 +46,7 @@ import type { EntityCoreIdentifiableNamed } from '@/api/entitycore/types/shared/
 import type { Facets, Pagination } from '@/api/entitycore/types/shared/response';
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
 import type { TWorkspaceScope, TWorkspaceSection } from '@/constants';
+import { getWorkspaceScopeFilters } from '@/utils/workspace-scope';
 
 const CircuitTable = dynamic(() => import('@/ui/segments/explore/circuit/table'), { ssr: false });
 
@@ -142,7 +143,11 @@ export function BrowseCircuit({
       const [{ workspace, queryParameters }] = queryKey;
       return await Circuit.api.query.list?.({
         withFacets: true,
-        filters: { ...queryParameters, ...extraQueryParams },
+        filters: {
+          ...queryParameters,
+          ...extraQueryParams,
+          ...getWorkspaceScopeFilters(scope!, { virtualLabId, projectId }),
+        },
         context: workspace,
       });
     },

--- a/src/ui/segments/explore/circuit/use-hierarchy.tsx
+++ b/src/ui/segments/explore/circuit/use-hierarchy.tsx
@@ -38,6 +38,7 @@ import type {
   Facets,
   Pagination,
 } from '@/api/entitycore/types/shared/response';
+import { getWorkspaceScopeFilters } from '@/utils/workspace-scope';
 
 export function useFullRawHierarchy({ view = CircuitView.Flat }: { view: TCircuitView | null }) {
   const queryClient = useQueryClient();
@@ -195,6 +196,7 @@ export function useHierarchy({
             filters: {
               ...circuitScaleFilter,
               ...queryParameters,
+              ...getWorkspaceScopeFilters(scope!, { virtualLabId, projectId }),
               page: 1,
               page_size: DEFAULT_PAGE_SIZE,
             },

--- a/src/ui/segments/explore/helpers.ts
+++ b/src/ui/segments/explore/helpers.ts
@@ -7,8 +7,6 @@ import { getEntitiesCount } from '@/api/entitycore/queries/general/entity';
 import { ElectricalRecordingOriginDictionary } from '@/api/entitycore/types/entities/electrical-cell-recording';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 
-import { WorkspaceScope } from '@/constants';
-
 import { BoutonDensity } from '@/entity-configuration/domain/experimental/bouton-density';
 import { CellMorphology } from '@/entity-configuration/domain/experimental/cell-morphology';
 import { ElectricalCellRecording } from '@/entity-configuration/domain/experimental/electrical-cell-recording';
@@ -33,6 +31,7 @@ import { env } from '@/env';
 
 import type { TWorkspaceScope } from '@/constants';
 import type { WorkspaceContext } from '@/types/common';
+import { getWorkspaceScopeFilters } from '@/utils/workspace-scope';
 
 export const ExperimentalEntitiesTileTypes = {
   ReconstructionMorphology: CellMorphology,
@@ -117,16 +116,7 @@ export async function getAllEntitiesCountScoped({
             within_brain_region_hierarchy_id: env.NEXT_PUBLIC_DEFAULT_BRAIN_REGION_HIERARCHY_ID,
             within_brain_region_brain_region_id: brainRegionId ?? null,
             within_brain_region_direction: BrainRegionDirection.ASCENDANTS_AND_DESCENDANTS,
-            ...(scope === WorkspaceScope.Project
-              ? {
-                  authorized_project_id: projectId,
-                  authorized_public: false,
-                }
-              : scope === WorkspaceScope.Public
-                ? {
-                    authorized_public: true,
-                  }
-                : {}),
+            ...getWorkspaceScopeFilters(scope, { virtualLabId, projectId }),
           },
         }),
       ];
@@ -164,16 +154,7 @@ export async function getSimulationsCount({
             within_brain_region_hierarchy_id: env.NEXT_PUBLIC_DEFAULT_BRAIN_REGION_HIERARCHY_ID,
             within_brain_region_brain_region_id: brainRegionId ?? null,
             within_brain_region_direction: BrainRegionDirection.ASCENDANTS_AND_DESCENDANTS,
-            ...(scope === WorkspaceScope.Project
-              ? {
-                  authorized_project_id: projectId,
-                  authorized_public: false,
-                }
-              : scope === WorkspaceScope.Public
-                ? {
-                    authorized_public: true,
-                  }
-                : {}),
+            ...getWorkspaceScopeFilters(scope, { virtualLabId, projectId }),
           },
           circuitFilter: {
             within_brain_region_hierarchy_id: env.NEXT_PUBLIC_DEFAULT_BRAIN_REGION_HIERARCHY_ID,
@@ -210,16 +191,7 @@ export function getElectricalCellRecordingsCount({
       within_brain_region_hierarchy_id: env.NEXT_PUBLIC_DEFAULT_BRAIN_REGION_HIERARCHY_ID,
       within_brain_region_brain_region_id: brainRegionId ?? null,
       within_brain_region_direction: BrainRegionDirection.ASCENDANTS_AND_DESCENDANTS,
-      ...(scope === WorkspaceScope.Project
-        ? {
-            authorized_project_id: projectId,
-            authorized_public: false,
-          }
-        : scope === WorkspaceScope.Public
-          ? {
-              authorized_public: true,
-            }
-          : {}),
+      ...getWorkspaceScopeFilters(scope, { virtualLabId, projectId }),
     },
   });
 }

--- a/src/utils/workspace-scope.ts
+++ b/src/utils/workspace-scope.ts
@@ -1,0 +1,16 @@
+import { type TWorkspaceScope, WorkspaceScope } from '@/constants';
+import { WorkspaceContext } from '@/types/common';
+
+export function getWorkspaceScopeFilters(scope: TWorkspaceScope, context?: WorkspaceContext) {
+  const filters: Partial<Record<TWorkspaceScope, Record<string, unknown>>> = {
+    [WorkspaceScope.Project]: {
+      authorized_project_id: context?.projectId,
+      authorized_public: false,
+    },
+    [WorkspaceScope.Public]: {
+      authorized_public: true,
+    },
+  };
+
+  return filters[scope] ?? {};
+}


### PR DESCRIPTION
This change adds workspace scope filters to the listing queries. This fixes an issue where public entities are displayed under the "Project" listing view (which is assumed to contain only "private" entities).

Relates to [Data > Project tab > Model > Circuits: the menu on the left shows 0 circuits - but the list view has the registered circuits](https://github.com/openbraininstitute/prod-explore-functionality/issues/373).