### PR TITLE
82/analysis pass fail summary

### DIFF
--- a/src/features/model-analysis/viewer/container/validation-result-card/validation-result-card.module.css
+++ b/src/features/model-analysis/viewer/container/validation-result-card/validation-result-card.module.css
@@ -30,7 +30,7 @@
       padding: calc(var(--spacing) * 3);
 
       svg {
-        transform: rotate(90deg);
+        transform: rotate(0);
         transition: 0.3s all;
       }
     }
@@ -40,7 +40,7 @@
     > summary {
       > h2 {
         svg {
-          transform: rotate(0);
+          transform: rotate(90deg);
         }
       }
     }


### PR DESCRIPTION
Chevrons must point to the right when the card is collapsed, and to the bottom when expanded.