### PR TITLE
Use CDN in front of image optimization endpoint

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -97,6 +97,8 @@ const nextConfig = (phase: string): NextConfig => {
       },
     },
     images: {
+      loader: 'default',
+      path: `${cdnUri}/_next/image`,
       remotePatterns: [
         {
           protocol: 'https',


### PR DESCRIPTION
This change makes sure that optimised images are cached by CDN.

That greatly improves image loading time. Corresponding infra change: [Core web app: put CDN in front of image optimization endpoint](https://github.com/openbraininstitute/aws-terraform-deployment/pull/811).

Relates to https://github.com/openbraininstitute/prod-virtual-lab/issues/95.