### PR TITLE
Fix image optimization endpoint URL when no CDN is used

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -98,7 +98,7 @@ const nextConfig = (phase: string): NextConfig => {
     },
     images: {
       loader: 'default',
-      path: `${cdnUri}/_next/image`,
+      path: `${cdnUri ?? ''}/_next/image`,
       remotePatterns: [
         {
           protocol: 'https',


### PR DESCRIPTION
This changes makes sure the image optimazation URL is correct when no CDN is used.