### PR TITLE
Use gl_FragDepth to prevent z-fighting when points are far

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@tanstack/react-query": "^5.84.1",
     "@tanstack/react-query-devtools": "^5.84.1",
     "@tanstack/react-virtual": "^3.13.12",
-    "@tolokoban/tgd": "^2.0.69",
+    "@tolokoban/tgd": "^2.0.74",
     "ajv": "^8.17.1",
     "antd": "^5.13.3",
     "chroma-js": "^3.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,8 +150,8 @@ importers:
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tolokoban/tgd':
-        specifier: ^2.0.69
-        version: 2.0.69
+        specifier: ^2.0.74
+        version: 2.0.74
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
@@ -4643,8 +4643,8 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@tolokoban/tgd@2.0.69':
-    resolution: {integrity: sha512-Kp9eYED20fgNvKvAdOmw//ExqxEz8frJr9liB0ZTjeRHaujj+//gxxIL8hdO0E6ayTBSYh7bMpkANtQkvww6dA==}
+  '@tolokoban/tgd@2.0.74':
+    resolution: {integrity: sha512-0AVc8wHCn7q2tO1dBu+Ua87QuXF6197HRZGlMfL6qRsMv9Y9AYhyGaYXJqi3IFfbIce0PRULKOk7ZkyIASzTAA==}
 
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
@@ -17190,7 +17190,7 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.0
 
-  '@tolokoban/tgd@2.0.69':
+  '@tolokoban/tgd@2.0.74':
     dependencies:
       '@loaders.gl/core': 4.3.4
       '@loaders.gl/draco': 4.3.4(@loaders.gl/core@4.3.4)

--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/camera.ts
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/camera.ts
@@ -25,10 +25,10 @@ export function setCamera(context: TgdContext, eventChange: GenericEvent<TgdCame
     transfo: { ...restTransfo },
   });
   const controller = new TgdControllerCameraOrbit(context, {
-    inertiaOrbit: 1000,
-    speedZoom: 1,
-    minZoom: 0.5,
-    maxZoom: 20,
+    inertiaOrbit: 500,
+    speedZoom: 0.9,
+    minZoom: 0.7,
+    maxZoom: 3,
   });
   controller.eventChange.addListener((camera) => eventChange.dispatch(camera));
   return () => {

--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.tsx
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.tsx
@@ -147,10 +147,20 @@ export class Painter {
       this.pointCloudId = annotationValue;
       if (annotationValue !== -1) {
         const dataPoint = await getPointCouldData(annotationValue, accessToken);
+        const shadowThickness = 1;
+        const shadowIntensity = 0.5;
         const painter = new TgdPainterPointsCloud(context, {
           dataPoint,
-          minSizeInPixels: 2,
+          minSizeInPixels: 5,
           texture: new TgdTexture2D(context).loadBitmap(tgdCanvasCreateFill(1, 1, color)),
+          fragCode: [
+            'vec2 coords = 2.0 * (gl_PointCoord - vec2(.5));',
+            'float len = 1.0 - dot(coords, coords);',
+            'if (len < 0.0) discard;',
+            'gl_FragDepth = gl_FragCoord.z - len * 1e-5;',
+            `float light = smoothstep(0.0, ${shadowThickness.toFixed(6)}, len) * ${shadowIntensity} + ${(1 - shadowIntensity).toFixed(6)};`,
+            'return color * vec4(vec3(light), 1.0);',
+          ],
         });
         group.add(painter);
         this.pointCloudPainter = painter;


### PR DESCRIPTION
James Ibister noticed that there is a flickering in the points clouds of the Atlas Viewer, especially when looked from far.

It was like this:
<img width="440" height="258" alt="image" src="https://github.com/user-attachments/assets/d7cd8051-d7d6-41d7-a5b4-9053247ed11a" />

Now, it's like this:
<img width="474" height="285" alt="image" src="https://github.com/user-attachments/assets/966ffbe2-9229-4a10-8018-452a3269ea27" />

When the points are far, they start to merge together, preventing the flickering effect.

From near, we can still see the points:
![Uploading image.png…]()
