### PR TITLE
Dedup fields that could be in both common fields and specific fields.

### DIFF
--- a/src/components/PublicProjects/tables/columns/e-model-columns.tsx
+++ b/src/components/PublicProjects/tables/columns/e-model-columns.tsx
@@ -76,7 +76,7 @@ const columns = () => {
       ),
     },
     {
-      title: 'Creation date',
+      title: 'Registration date',
       key: 'creationDate',
       width: '150px',
       render: (_value: any, record: EModelsProps, _index: number) => {

--- a/src/ui/segments/detail-view/overview/index.tsx
+++ b/src/ui/segments/detail-view/overview/index.tsx
@@ -33,6 +33,7 @@ import type {
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
 import type { EntityTypeValue } from '@/entity-configuration/domain';
 import type { AwaitedType, WorkspaceContext } from '@/types/common';
+import { TypeSummaryProps } from '@/entity-configuration/definitions/view-defs/types';
 
 export default async function Overview({
   entity,
@@ -45,10 +46,13 @@ export default async function Overview({
   ctx: WorkspaceContext;
   isWorkflow: boolean;
 }) {
-  const fields = getViewDefinitionByExtendedType(extendedType)?.summaryViewFields ?? [];
+  const commonFields = CommonSummaryViewFields;
+  const fields = removeDuplicates(
+    getViewDefinitionByExtendedType(extendedType)?.summaryViewFields ?? [],
+    commonFields
+  );
 
   if (!entity) notFound();
-  const commonFields = CommonSummaryViewFields;
 
   let singleNeuronSimulationPayload:
     | AwaitedType<ReturnType<typeof resolveSingleNeuronSimulation>>
@@ -155,4 +159,16 @@ export default async function Overview({
       )}
     </>
   );
+}
+
+/**
+ * Prevent `extraFields` from having fields already own by `commonFields`.
+ */
+function removeDuplicates(
+  extraFields: TypeSummaryProps[],
+  commonFields: TypeSummaryProps[]
+): TypeSummaryProps[] {
+  const fieldsToExclude = new Set<string>(commonFields.map((item) => item.field));
+  const fields = extraFields.filter((item) => !fieldsToExclude.has(item.field));
+  return fields;
 }

--- a/src/ui/segments/reports/obi-showcases/artifacts/columns/me-model-column.tsx
+++ b/src/ui/segments/reports/obi-showcases/artifacts/columns/me-model-column.tsx
@@ -101,7 +101,7 @@ const columns = () => {
       ),
     },
     {
-      title: 'Creation date',
+      title: 'Registration date',
       key: 'creationDate',
       width: '150px',
       render: (_value: any, record: MEModelsProps, _index: number) => {

--- a/src/ui/segments/reports/obi-showcases/artifacts/columns/synaptome-column.tsx
+++ b/src/ui/segments/reports/obi-showcases/artifacts/columns/synaptome-column.tsx
@@ -60,7 +60,7 @@ const columns = () => {
       ),
     },
     {
-      title: 'Creation Date',
+      title: 'Registration Date',
       key: 'creationDate',
       width: '150px',
       render: (_value: any, record: SynaptomeProps, _index: number) => (


### PR DESCRIPTION
Relates to ticket [333](https://github.com/openbraininstitute/prod-explore-functionality/issues/333#issuecomment-3642076287).

We now remove all the specific fields that are already present in the common fields.