### PR TITLE
Hotfix: migrate on-the-fly circuit simulation configs

### DIFF
--- a/src/entity-configuration/domain/simulation/paired-neurons-simulation.ts
+++ b/src/entity-configuration/domain/simulation/paired-neurons-simulation.ts
@@ -27,6 +27,7 @@ import type {
   ICircuitSimulationCampaignFilter,
 } from '@/api/entitycore/types/entities/circuit-simulation-campaign';
 import type { WorkspaceContext } from '@/types/common';
+import { migrateConfig } from './utils';
 
 const SCALE = CircuitScaleDictionary.PairNeuron;
 
@@ -120,6 +121,8 @@ export async function resolveSimulationByCampaignId({
     asRawResponse: true,
   });
   const config = await rawConfig.json();
+
+  migrateConfig(config);
 
   return {
     campaign,

--- a/src/entity-configuration/domain/simulation/simulation-campaign.ts
+++ b/src/entity-configuration/domain/simulation/simulation-campaign.ts
@@ -25,6 +25,7 @@ import type {
   ICircuitSimulationCampaignFilter,
 } from '@/api/entitycore/types/entities/circuit-simulation-campaign';
 import type { WorkspaceContext, AwaitedType } from '@/types/common';
+import { migrateConfig } from './utils';
 
 // NOTE: this is due entitycore do not support yet
 async function resolveSimulationCampaigns({
@@ -115,6 +116,8 @@ export async function resolveSimulationByCampaignId({
     asRawResponse: true,
   });
   const config = await rawConfig.json();
+
+  migrateConfig(config);
 
   return {
     campaign,

--- a/src/entity-configuration/domain/simulation/single-neuron-circuit-simulation.ts
+++ b/src/entity-configuration/domain/simulation/single-neuron-circuit-simulation.ts
@@ -27,6 +27,7 @@ import type {
   ICircuitSimulationCampaignFilter,
 } from '@/api/entitycore/types/entities/circuit-simulation-campaign';
 import type { WorkspaceContext } from '@/types/common';
+import { migrateConfig } from './utils';
 
 const SCALE = CircuitScaleDictionary.Single;
 
@@ -120,6 +121,8 @@ export async function resolveSimulationByCampaignId({
     asRawResponse: true,
   });
   const config = await rawConfig.json();
+
+  migrateConfig(config);
 
   return {
     campaign,

--- a/src/entity-configuration/domain/simulation/small-microcircuit-simulation.ts
+++ b/src/entity-configuration/domain/simulation/small-microcircuit-simulation.ts
@@ -28,6 +28,7 @@ import type {
   ICircuitSimulationCampaignFilter,
 } from '@/api/entitycore/types/entities/circuit-simulation-campaign';
 import type { WorkspaceContext } from '@/types/common';
+import { migrateConfig } from './utils';
 
 export async function resolveExecutions({
   context,
@@ -149,6 +150,8 @@ export async function resolveSimulationByCampaignId({
     asRawResponse: true,
   });
   const config = await rawConfig.json();
+
+  migrateConfig(config);
 
   return {
     campaign,

--- a/src/entity-configuration/domain/simulation/utils.ts
+++ b/src/entity-configuration/domain/simulation/utils.ts
@@ -1,0 +1,9 @@
+import { get, set } from 'es-toolkit/compat';
+
+// TODO Remove this after the data is migrated
+export function migrateConfig(config: any) {
+  if (get(config, 'form.type') === 'SimulationsForm') {
+    set(config, 'form.type', 'CircuitSimulationScanConfig');
+    set(config, 'form.initialize.type', 'CircuitSimulationScanConfig.Initialize');
+  }
+}


### PR DESCRIPTION
This is a temporary fix to address an issue with circuit simulations where an updated OBI-ONE JSON schema failed to be validated agains older configs rendering the circuit simulation pages unusable.