### PR TITLE
Provide correct projectId to synaptome model component

### DIFF
--- a/src/ui/segments/detail-view/overview/index.tsx
+++ b/src/ui/segments/detail-view/overview/index.tsx
@@ -149,7 +149,7 @@ export default async function Overview({
             meModel={singleNeuronSynaptomeSimulationPayload.memodel}
             synaptome={singleNeuronSynaptomeSimulationPayload.synaptome}
             virtualLabId={ctx.virtualLabId}
-            projectId={ctx.virtualLabId}
+            projectId={ctx.projectId}
           />
         )}
       {circuitTypes.includes(extendedType) && <CircuitViz circuit={entity as ICircuit} />}


### PR DESCRIPTION
Relates to [Data > Simulations > Synaptome > detail view - view details button - redirects to 404](https://github.com/openbraininstitute/prod-explore-functionality/issues/410).