### PR TITLE
Allow multiple sim executions per each simulation config

### DIFF
--- a/src/features/small-microcircuit/_components/atoms/index.ts
+++ b/src/features/small-microcircuit/_components/atoms/index.ts
@@ -42,10 +42,19 @@ const simExecBySimIdAtomFamily = readAtomFamilyWithExpiration(
 export const simExecRemoteStatusMapAtomFamily = atomFamilyWithExpiration(
   ({ simulationIds, context }: { simulationIds: string[]; context: WorkspaceContext }) =>
     atomWithRefresh<Promise<SimExecStatusMap>>(async () => {
-      const executions = await resolveExecutions({ context, allSimIds: simulationIds });
+      const simExecutions = await resolveExecutions({ context, allSimIds: simulationIds });
 
-      return executions.reduce(
-        (map, simExec) => map.set(simExec.used[0].id, simExec.status),
+      const executionsGrouped = simExecutions.reduce<Map<string, ICircuitSimulationExecution[]>>(
+        (map, exec) => map.set(exec.used[0].id, [...(map.get(exec.used[0].id) ?? []), exec]),
+        new Map()
+      );
+
+      Array.from(executionsGrouped.values()).forEach((executions) =>
+        executions.sort((a, b) => b.creation_date.localeCompare(a.creation_date))
+      );
+
+      return Array.from(executionsGrouped.keys()).reduce(
+        (map, simId) => map.set(simId, executionsGrouped.get(simId)![0].status),
         new Map()
       );
     }),

--- a/src/features/small-microcircuit/_components/simulations.tsx
+++ b/src/features/small-microcircuit/_components/simulations.tsx
@@ -90,7 +90,9 @@ export default function SimulationsTab({
 
   const selectableSimulationIds = useMemo(() => {
     return simulations
-      .filter((simulation) => ['created', undefined].includes(statusMap?.get(simulation.id)))
+      .filter((simulation) =>
+        [undefined, 'created', 'error'].includes(statusMap?.get(simulation.id))
+      )
       .map((s) => s.id);
   }, [simulations, statusMap]);
 


### PR DESCRIPTION
This change:
* Allows to re-run a failed simulation
* Use the most recent execution to determine the status of a simulation