### PR TITLE
Add missing error boundary for atlas viewer

### DIFF
--- a/src/features/brain-atlas-viewer/index.tsx
+++ b/src/features/brain-atlas-viewer/index.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { ReactNode, useMemo, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { match } from 'ts-pattern';
 
 import { withErrorConfig } from '@/components/GenericErrorFallback';
 import { Loader } from '@/components/loader';
 import { BrainAtlasViewerGltf } from '@/features/brain-atlas-viewer/brain-atlas-viewer-gltf';
 import { FullScreen } from '@/features/brain-atlas-viewer/full-screen';
-import { ErrorBoundary } from 'react-error-boundary';
 
 export function AtlasViewer({ dataKey, children }: { dataKey: string; children?: ReactNode }) {
   const [isFullScreen, setIsFullScreen] = useState(false);


### PR DESCRIPTION
Relates to [Show WebGL error within Data brain visualiser rather than whole page, with (or link to) details of how to fix](https://github.com/openbraininstitute/prod-explore-functionality/issues/423).