### PR TITLE
use `ilike_search` instead of `search` only for entities that has name+description

### DIFF
--- a/src/api/entitycore/types/entities/bouton-density.ts
+++ b/src/api/entitycore/types/entities/bouton-density.ts
@@ -11,6 +11,7 @@ import type {
   BrainRegionFilter,
   StainFilter,
   MtypeFilter,
+  IlikeSearchFilter,
 } from '@/api/entitycore/types/shared/request';
 import type { IExperimentalDensity } from '@/api/entitycore/types/shared/density';
 
@@ -26,5 +27,6 @@ export type ExperimentalBoutonDensityFilter = Partial<
     BrainRegionFilter &
     StainFilter &
     MtypeFilter &
-    EntityAuthorization
+    EntityAuthorization &
+    IlikeSearchFilter
 >;

--- a/src/api/entitycore/types/entities/cell-morphology.ts
+++ b/src/api/entitycore/types/entities/cell-morphology.ts
@@ -11,6 +11,7 @@ import type {
   SubjectFilter,
   IDFilter,
   MtypeFilter,
+  IlikeSearchFilter,
 } from '@/api/entitycore/types/shared/request';
 import type {
   EntityCoreIdentifiable,
@@ -35,7 +36,8 @@ export type CellMorphologyFilter = Partial<
     PaginationFilter &
     MtypeFilter &
     SubjectFilter &
-    SharedFilter
+    SharedFilter &
+    IlikeSearchFilter
 >;
 
 interface ICellMorphologyBase extends EntityCoreIdentifiable {

--- a/src/api/entitycore/types/entities/circuit-simulation-campaign.ts
+++ b/src/api/entitycore/types/entities/circuit-simulation-campaign.ts
@@ -16,6 +16,7 @@ import type {
 import type {
   BrainRegionFilter,
   IEntityFilter,
+  IlikeSearchFilter,
   NameFilter,
   PaginationFilter,
 } from '@/api/entitycore/types/shared/request';
@@ -74,7 +75,8 @@ export interface ICircuitSimulationCampaignFilter
     BrainRegionFilter, // Entitycore API doesn't support brain_region_id filtering, to be removed
     NameFilter,
     PaginationFilter,
-    ISimulationCampaignCircuitFilter {}
+    ISimulationCampaignCircuitFilter,
+    IlikeSearchFilter {}
 
 const CreateCircuitSimulationCampaignSchema = z.object({
   name: z.string(),

--- a/src/api/entitycore/types/entities/circuit-simulation.ts
+++ b/src/api/entitycore/types/entities/circuit-simulation.ts
@@ -12,6 +12,7 @@ import type {
   SharedFilter,
   PaginationFilter,
   OwnershipFilter,
+  IlikeSearchFilter,
 } from '@/api/entitycore/types/shared/request';
 
 export interface ICircuitSimulation
@@ -33,4 +34,5 @@ export interface ICircuitSimulationFilter
     BrainRegionFilter, // Entitycore API doesn't support brain_region_id filtering, to be removed
     SharedFilter,
     PaginationFilter,
-    OwnershipFilter {}
+    OwnershipFilter,
+    IlikeSearchFilter {}

--- a/src/api/entitycore/types/entities/circuit.ts
+++ b/src/api/entitycore/types/entities/circuit.ts
@@ -11,6 +11,7 @@ import type {
   SharedFilter,
   PaginationFilter,
   IdFilter,
+  IlikeSearchFilter,
 } from '@/api/entitycore/types/shared/request';
 
 export const CircuitBuildCategory = {
@@ -103,7 +104,8 @@ export interface ICircuitFilter
     BrainRegionFilter,
     SharedFilter,
     PaginationFilter,
-    CircuitScaleFilter {}
+    CircuitScaleFilter,
+    IlikeSearchFilter {}
 
 export type SonataCircuitNetworkEdgeConfigItem = {
   edges_file: string;

--- a/src/api/entitycore/types/entities/e-model.ts
+++ b/src/api/entitycore/types/entities/e-model.ts
@@ -23,6 +23,7 @@ import type {
   MtypeFilter,
   EtypeFilter,
   PaginationFilter,
+  IlikeSearchFilter,
 } from '@/api/entitycore/types/shared/request';
 
 interface ExemplarMorphology extends Timestamps, EntityCoreIdentifiable {
@@ -64,7 +65,8 @@ export interface IEModelFilter
     BrainRegionFilter,
     SharedFilter,
     IMorphologyFilter,
-    PaginationFilter {
+    PaginationFilter,
+    IlikeSearchFilter {
   score__lte: number | null;
   score__gte: number | null;
 }

--- a/src/api/entitycore/types/entities/electrical-cell-recording.ts
+++ b/src/api/entitycore/types/entities/electrical-cell-recording.ts
@@ -6,6 +6,7 @@ import type {
   PaginationFilter,
   SharedFilter,
   IDFilter,
+  IlikeSearchFilter,
 } from '@/api/entitycore/types/shared/request';
 import type {
   EntityCoreIdentifiable,
@@ -88,7 +89,8 @@ export type ElectricalCellRecordingFilter = Partial<
     BrainRegionFilter &
     PaginationFilter &
     SharedFilter &
-    IRecordingFilter
+    IRecordingFilter &
+    IlikeSearchFilter
 >;
 
 interface IElectricalCellRecordingBase extends EntityCoreIdentifiable, EntityCoreOwnership {

--- a/src/api/entitycore/types/entities/ion-channel-modeling-campaign.ts
+++ b/src/api/entitycore/types/entities/ion-channel-modeling-campaign.ts
@@ -7,6 +7,7 @@ import type {
   ContributionFilter,
   OwnershipFilter,
   SearchFilter,
+  IlikeSearchFilter,
 } from '@/api/entitycore/types/shared/request';
 import type {
   EntityCoreIdentifiable,
@@ -68,7 +69,8 @@ export interface IonChannelModelingCampaignFilter
     ContributionFilter,
     OwnershipFilter,
     SearchFilter,
-    BrainRegionFilter {
+    BrainRegionFilter,
+    IlikeSearchFilter {
   ion_channel_modeling_config_id?: string | null;
   ion_channel_modeling_config__id__in?: string[] | null;
   ion_channel_modeling_config_name?: string | null;

--- a/src/api/entitycore/types/entities/ion-channel-recording.ts
+++ b/src/api/entitycore/types/entities/ion-channel-recording.ts
@@ -8,6 +8,7 @@ import type {
   PaginationFilter,
   SharedFilter,
   IDFilter,
+  IlikeSearchFilter,
 } from '@/api/entitycore/types/shared/request';
 import type {
   EntityCoreIdentifiable,
@@ -52,7 +53,8 @@ export type IonChannelRecordingFilter = Partial<
     BrainRegionFilter &
     PaginationFilter &
     SharedFilter &
-    IRecordingFilter
+    IRecordingFilter &
+    IlikeSearchFilter
 >;
 
 interface IIonChannelRecordingBase extends EntityCoreIdentifiable, EntityCoreOwnership {

--- a/src/api/entitycore/types/entities/ion-channel.ts
+++ b/src/api/entitycore/types/entities/ion-channel.ts
@@ -14,6 +14,7 @@ import type {
 import type {
   BrainRegionFilter,
   ContributionFilter,
+  IlikeSearchFilter,
   IMorphologyFilter,
   PaginationFilter,
   SharedFilter,
@@ -64,4 +65,5 @@ export interface IonChannelModelFilter
     IMorphologyFilter,
     PaginationFilter,
     SharedFilter,
-    SubjectFilter {}
+    SubjectFilter,
+    IlikeSearchFilter {}

--- a/src/api/entitycore/types/entities/me-model.ts
+++ b/src/api/entitycore/types/entities/me-model.ts
@@ -27,6 +27,7 @@ import type {
   EtypeFilter,
   IdFilter,
   OwnershipFilter,
+  IlikeSearchFilter,
 } from '@/api/entitycore/types/shared/request';
 
 export enum ValidationStatus {
@@ -80,7 +81,8 @@ export interface IMEModelFilter
     PaginationFilter,
     IEModelFilter,
     SharedFilter,
-    OwnershipFilter {
+    OwnershipFilter,
+    IlikeSearchFilter {
   score__lte: number | null;
   score__gte: number | null;
   validation_status: ValidationStatus;

--- a/src/api/entitycore/types/entities/neuron-density.ts
+++ b/src/api/entitycore/types/entities/neuron-density.ts
@@ -4,6 +4,7 @@ import type {
   BrainRegionFilter,
   ContributionFilter,
   EtypeFilter,
+  IlikeSearchFilter,
   MtypeFilter,
   PaginationFilter,
   SharedFilter,
@@ -26,5 +27,6 @@ export type ExperimentalNeuronDensityFilter = Partial<
     PaginationFilter &
     StainFilter &
     SubjectFilter &
-    TimestampsFilter
+    TimestampsFilter &
+    IlikeSearchFilter
 >;

--- a/src/api/entitycore/types/entities/notebook.ts
+++ b/src/api/entitycore/types/entities/notebook.ts
@@ -4,6 +4,7 @@ import type {
   PaginationFilter,
   SharedFilter,
   IDFilter,
+  IlikeSearchFilter,
 } from '@/api/entitycore/types/shared/request';
 import type {
   EntityCoreIdentifiable,
@@ -15,7 +16,12 @@ import type {
 } from '@/api/entitycore/types/shared/global';
 
 export type NotebookFilter = Partial<
-  IDFilter & TimestampsFilter & ContributionFilter & PaginationFilter & SharedFilter
+  IDFilter &
+    TimestampsFilter &
+    ContributionFilter &
+    PaginationFilter &
+    SharedFilter &
+    IlikeSearchFilter
 >;
 
 export interface INotebook

--- a/src/api/entitycore/types/entities/single-neuron-simulation.ts
+++ b/src/api/entitycore/types/entities/single-neuron-simulation.ts
@@ -22,6 +22,7 @@ import type {
   EtypeFilter,
   PaginationFilter,
   OwnershipFilter,
+  IlikeSearchFilter,
 } from '@/api/entitycore/types/shared/request';
 
 export interface ISingleNeuronSimulation
@@ -73,7 +74,8 @@ export interface ISingleNeuronSimulationFilter
     MeTypeFilter,
     MeModelFilter,
     PaginationFilter,
-    OwnershipFilter {}
+    OwnershipFilter,
+    IlikeSearchFilter {}
 
 const CreateSingleNeuronSimulationSchema = z.object({
   name: z.string(),

--- a/src/api/entitycore/types/entities/single-neuron-synaptome-simulation.ts
+++ b/src/api/entitycore/types/entities/single-neuron-synaptome-simulation.ts
@@ -23,6 +23,7 @@ import type {
   IDFilter,
   PaginationFilter,
   OwnershipFilter,
+  IlikeSearchFilter,
 } from '@/api/entitycore/types/shared/request';
 import type { SingleNeuronSynaptomeBase } from '@/api/entitycore/types/entities/single-neuron-synaptome';
 import type { IBrainRegionHierarchy } from '@/api/entitycore/types/entities/brain-region';
@@ -64,7 +65,8 @@ export interface ISingleNeuronSynaptomeSimulationFilter
     EtypeFilter,
     SynaptomeFilter,
     PaginationFilter,
-    OwnershipFilter {}
+    OwnershipFilter,
+    IlikeSearchFilter {}
 
 const CreateSingleNeuronSynaptomeSimulationSchema = z.object({
   name: z.string(),

--- a/src/api/entitycore/types/entities/single-neuron-synaptome.ts
+++ b/src/api/entitycore/types/entities/single-neuron-synaptome.ts
@@ -22,6 +22,7 @@ import type {
   EtypeFilter,
   PaginationFilter,
   OwnershipFilter,
+  IlikeSearchFilter,
 } from '@/api/entitycore/types/shared/request';
 
 export interface SingleNeuronSynaptomeBase {
@@ -51,7 +52,8 @@ export interface ISingleNeuronSynaptomeFilter
     SharedFilter,
     IMEModelFilter,
     PaginationFilter,
-    OwnershipFilter {}
+    OwnershipFilter,
+    IlikeSearchFilter {}
 
 const CreateSingleNeuronSynaptomeSchema = z.object({
   name: z.string(),

--- a/src/api/entitycore/types/entities/synapses-per-connection.ts
+++ b/src/api/entitycore/types/entities/synapses-per-connection.ts
@@ -5,6 +5,7 @@ import type {
   BrainRegionFilter,
   ContributionFilter,
   EtypeFilter,
+  IlikeSearchFilter,
   PaginationFilter,
   SharedFilter,
   StainFilter,
@@ -68,5 +69,6 @@ export type ExperimentalSynapsesPerConnectionFilter = Partial<
     PreRegionFilter &
     StainFilter &
     SubjectFilter &
-    TimestampsFilter
+    TimestampsFilter &
+    IlikeSearchFilter
 >;

--- a/src/api/entitycore/types/shared/request.ts
+++ b/src/api/entitycore/types/shared/request.ts
@@ -37,7 +37,9 @@ export type PaginationFilter = {
   page: number;
   page_size: number;
 };
-
+export type IlikeSearchFilter = {
+  ilike_search: string | null;
+};
 export type SpeciesFilter = {
   species__id: string | null;
   species_id__in: number | null;

--- a/src/entity-configuration/domain/experimental/bouton-density.ts
+++ b/src/entity-configuration/domain/experimental/bouton-density.ts
@@ -20,6 +20,7 @@ export const BoutonDensity: EntityCoreTypeConfig<IExperimentalBoutonDensity> = {
   api: {
     config: {
       allowedFacets: true,
+      ilikeSearchEnabled: true,
     },
     query: {
       list: getExperimentalBoutonDensities,

--- a/src/entity-configuration/domain/experimental/cell-morphology.ts
+++ b/src/entity-configuration/domain/experimental/cell-morphology.ts
@@ -24,6 +24,7 @@ export const CellMorphology: EntityCoreTypeConfig<ICellMorphology | ICellMorphol
   api: {
     config: {
       allowedFacets: true,
+      ilikeSearchEnabled: true,
     },
     query: {
       list: getCellMorphologies,

--- a/src/entity-configuration/domain/experimental/electrical-cell-recording.ts
+++ b/src/entity-configuration/domain/experimental/electrical-cell-recording.ts
@@ -30,6 +30,7 @@ export const ElectricalCellRecording: EntityCoreTypeConfig<IElectricalCellRecord
   api: {
     config: {
       allowedFacets: true,
+      ilikeSearchEnabled: true,
       extraRequiredListFilters: recordingOriginFilter,
     },
     query: {

--- a/src/entity-configuration/domain/experimental/ion-channel-recording.ts
+++ b/src/entity-configuration/domain/experimental/ion-channel-recording.ts
@@ -23,7 +23,11 @@ export const IonChannelRecording: EntityCoreTypeConfig<IElectricalCellRecording>
   type: EntityTypeDict.IonChannelRecording,
   slug: EntitySlug.IonChannelRecording,
   api: {
-    config: { allowedFacets: true, extraRequiredListFilters: recordingOriginFilter },
+    config: {
+      allowedFacets: true,
+      ilikeSearchEnabled: true,
+      extraRequiredListFilters: recordingOriginFilter,
+    },
     query: {
       list: (params: Parameters<typeof getIonChannelRecordings>[0]) =>
         getIonChannelRecordings({

--- a/src/entity-configuration/domain/experimental/neuron-density.ts
+++ b/src/entity-configuration/domain/experimental/neuron-density.ts
@@ -20,6 +20,7 @@ export const NeuronDensity: EntityCoreTypeConfig<IExperimentalNeuronDensity> = {
   api: {
     config: {
       allowedFacets: true,
+      ilikeSearchEnabled: true,
     },
     query: {
       list: getExperimentalNeuronDensities,

--- a/src/entity-configuration/domain/experimental/synapse-per-connection.ts
+++ b/src/entity-configuration/domain/experimental/synapse-per-connection.ts
@@ -20,6 +20,7 @@ export const SynapsePerConnection: EntityCoreTypeConfig<IExperimentalSynapsesPer
   api: {
     config: {
       allowedFacets: true,
+      ilikeSearchEnabled: true,
     },
     query: {
       list: getExperimentalSynapsesPerConnections,

--- a/src/entity-configuration/domain/model/circuit.ts
+++ b/src/entity-configuration/domain/model/circuit.ts
@@ -22,7 +22,11 @@ export const Circuit: EntityCoreTypeConfig<ICircuit> = {
   type: EntityTypeDict.Circuit,
   slug: EntitySlug.Circuit,
   api: {
-    config: { allowedFacets: true, extraRequiredListFilters: circuitScaleFilter },
+    config: {
+      allowedFacets: true,
+      ilikeSearchEnabled: true,
+      extraRequiredListFilters: circuitScaleFilter,
+    },
     query: {
       list: (...params) => {
         return getCircuits({

--- a/src/entity-configuration/domain/model/e-model.ts
+++ b/src/entity-configuration/domain/model/e-model.ts
@@ -16,7 +16,7 @@ export const Emodel: EntityCoreTypeConfig<IEModel> = {
   type: EntityTypeDict.Emodel,
   slug: EntitySlug.EModel,
   api: {
-    config: { allowedFacets: true },
+    config: { allowedFacets: true, ilikeSearchEnabled: true },
     query: {
       list: getEModels,
       one: getEModel,

--- a/src/entity-configuration/domain/model/ion-channel-model.ts
+++ b/src/entity-configuration/domain/model/ion-channel-model.ts
@@ -20,6 +20,7 @@ export const IonChannelModel: EntityCoreTypeConfig<IIonChannelModel> = {
   api: {
     config: {
       allowedFacets: true,
+      ilikeSearchEnabled: true,
     },
     query: {
       list: (...params) => {

--- a/src/entity-configuration/domain/model/me-model-circuit.ts
+++ b/src/entity-configuration/domain/model/me-model-circuit.ts
@@ -17,6 +17,7 @@ export const MEModelCircuit: EntityCoreTypeConfig<IMEModel> = {
   api: {
     config: {
       allowedFacets: true,
+      ilikeSearchEnabled: true,
     },
     query: {
       list: getMEModels,

--- a/src/entity-configuration/domain/model/me-model-with-synapses.ts
+++ b/src/entity-configuration/domain/model/me-model-with-synapses.ts
@@ -19,7 +19,11 @@ export const MEModelWithSynapsesCircuit: EntityCoreTypeConfig<ICircuit> = {
   type: EntityTypeDict.Circuit,
   slug: EntitySlug.Circuit,
   api: {
-    config: { allowedFacets: true, extraRequiredListFilters: circuitScaleFilter },
+    config: {
+      allowedFacets: true,
+      ilikeSearchEnabled: true,
+      extraRequiredListFilters: circuitScaleFilter,
+    },
     query: {
       list: (...params) => {
         return getCircuits({

--- a/src/entity-configuration/domain/model/me-model.ts
+++ b/src/entity-configuration/domain/model/me-model.ts
@@ -17,6 +17,7 @@ export const MEmodel: EntityCoreTypeConfig<IMEModel> = {
   api: {
     config: {
       allowedFacets: true,
+      ilikeSearchEnabled: true,
     },
     query: {
       list: getMEModels,

--- a/src/entity-configuration/domain/model/mirocircuit.ts
+++ b/src/entity-configuration/domain/model/mirocircuit.ts
@@ -17,6 +17,7 @@ export const Microcircuit: EntityCoreTypeConfig<ICircuit> = {
   api: {
     config: {
       allowedFacets: true,
+      ilikeSearchEnabled: true,
     },
     query: {
       list: (...params) =>

--- a/src/entity-configuration/domain/model/paired-neurons.ts
+++ b/src/entity-configuration/domain/model/paired-neurons.ts
@@ -19,7 +19,11 @@ export const PairedNeuronCircuit: EntityCoreTypeConfig<ICircuit> = {
   type: EntityTypeDict.Circuit,
   slug: EntitySlug.PairedNeuronsCircuit,
   api: {
-    config: { allowedFacets: true, extraRequiredListFilters: circuitScaleFilter },
+    config: {
+      allowedFacets: true,
+      ilikeSearchEnabled: true,
+      extraRequiredListFilters: circuitScaleFilter,
+    },
     query: {
       list: (...params) =>
         getCircuits({

--- a/src/entity-configuration/domain/model/single-neuron-circuit.ts
+++ b/src/entity-configuration/domain/model/single-neuron-circuit.ts
@@ -21,6 +21,7 @@ export const SingleNeuronCircuit: EntityCoreTypeConfig<ICircuit> = {
   api: {
     config: {
       allowedFacets: true,
+      ilikeSearchEnabled: true,
       extraRequiredListFilters: circuitScaleFilter,
     },
     query: {

--- a/src/entity-configuration/domain/model/single-neuron-synaptome.ts
+++ b/src/entity-configuration/domain/model/single-neuron-synaptome.ts
@@ -32,6 +32,7 @@ export const SingleNeuronSynaptome: EntityCoreTypeConfig<ISingleNeuronSynaptome>
   api: {
     config: {
       allowedFacets: true,
+      ilikeSearchEnabled: true,
     },
     query: {
       list: getSingleNeuronSynaptomes,

--- a/src/entity-configuration/domain/model/small-microcircuit.ts
+++ b/src/entity-configuration/domain/model/small-microcircuit.ts
@@ -21,6 +21,7 @@ export const SmallMicrocircuit: EntityCoreTypeConfig<ICircuit> = {
   api: {
     config: {
       allowedFacets: true,
+      ilikeSearchEnabled: true,
       extraRequiredListFilters: circuitScaleFilter,
     },
     query: {

--- a/src/entity-configuration/domain/notebook.ts
+++ b/src/entity-configuration/domain/notebook.ts
@@ -16,6 +16,7 @@ export const Notebook: EntityCoreTypeConfig<INotebook> = {
   api: {
     config: {
       allowedFacets: true,
+      ilikeSearchEnabled: true,
     },
     query: {
       list: getNotebooks,

--- a/src/entity-configuration/domain/simulation/memodel-circuit-simulation.ts
+++ b/src/entity-configuration/domain/simulation/memodel-circuit-simulation.ts
@@ -159,7 +159,10 @@ export const MEModelCircuitSimulation: EntityCoreTypeConfig<ICircuitSimulationCa
   type: EntityTypeDict.SimulationCampaign,
   slug: EntitySlug.MEModelCircuitSimulation,
   api: {
-    config: { allowedFacets: true },
+    config: {
+      allowedFacets: true,
+      ilikeSearchEnabled: true,
+    },
     query: {
       count: (...params) => {
         const filters = discardBrainRegionQueryParams(params[0].filters);

--- a/src/entity-configuration/domain/simulation/microcircuit-simulation.ts
+++ b/src/entity-configuration/domain/simulation/microcircuit-simulation.ts
@@ -166,7 +166,10 @@ export const MicrocircuitSimulation: EntityCoreTypeConfig<ICircuitSimulationCamp
   slug: EntitySlug.MicrocircuitSimulation,
   requiredFeatures: [microcircuitFlag.key],
   api: {
-    config: { allowedFacets: true },
+    config: {
+      allowedFacets: true,
+      ilikeSearchEnabled: true,
+    },
     query: {
       count: (...params) => {
         const filters = discardBrainRegionQueryParams(params[0].filters);

--- a/src/entity-configuration/domain/simulation/paired-neurons-simulation.ts
+++ b/src/entity-configuration/domain/simulation/paired-neurons-simulation.ts
@@ -139,7 +139,10 @@ export const PairedNeuronCircuitSimulation: EntityCoreTypeConfig<ICircuitSimulat
   type: EntityTypeDict.SimulationCampaign,
   slug: EntitySlug.PairedNeuronCircuitSimulation,
   api: {
-    config: { allowedFacets: true },
+    config: {
+      allowedFacets: true,
+      ilikeSearchEnabled: true,
+    },
     query: {
       count: (...params) => {
         const filters = discardBrainRegionQueryParams(params[0].filters);

--- a/src/entity-configuration/domain/simulation/simulation-campaign.ts
+++ b/src/entity-configuration/domain/simulation/simulation-campaign.ts
@@ -151,7 +151,10 @@ export const SimulationCampaign: EntityCoreTypeConfig<ICircuitSimulationCampaign
   type: EntityTypeDict.SimulationCampaign,
   slug: EntitySlug.SimulationCampaign,
   api: {
-    config: { allowedFacets: true },
+    config: {
+      allowedFacets: true,
+      ilikeSearchEnabled: true,
+    },
     query: {
       list: resolveSimulationCampaigns,
       one: getCircuitSimulationCampaign,

--- a/src/entity-configuration/domain/simulation/single-neuron-circuit-simulation.ts
+++ b/src/entity-configuration/domain/simulation/single-neuron-circuit-simulation.ts
@@ -139,7 +139,10 @@ export const SingeNeuronCircuitSimulation: EntityCoreTypeConfig<ICircuitSimulati
   type: EntityTypeDict.SimulationCampaign,
   slug: EntitySlug.SingleNeuronCircuitSimulation,
   api: {
-    config: { allowedFacets: true },
+    config: {
+      allowedFacets: true,
+      ilikeSearchEnabled: true,
+    },
     query: {
       count: (...params) => {
         const filters = discardBrainRegionQueryParams(params[0].filters);

--- a/src/entity-configuration/domain/simulation/single-neuron-simulation.ts
+++ b/src/entity-configuration/domain/simulation/single-neuron-simulation.ts
@@ -40,7 +40,10 @@ export const SingleNeuronSimulation: EntityCoreTypeConfig<ISingleNeuronSimulatio
   type: EntityTypeDict.SingleNeuronSimulation,
   slug: EntitySlug.SingleNeuronSimulation,
   api: {
-    config: { allowedFacets: true },
+    config: {
+      allowedFacets: true,
+      ilikeSearchEnabled: true,
+    },
     query: {
       list: getSingleNeuronSimulations,
       one: getSingleNeuronSimulation,

--- a/src/entity-configuration/domain/simulation/single-neuron-synaptome-simulation.ts
+++ b/src/entity-configuration/domain/simulation/single-neuron-synaptome-simulation.ts
@@ -56,7 +56,10 @@ export const SingleNeuronSynaptomeSimulation: EntityCoreTypeConfig<ISingleNeuron
     type: EntityTypeDict.SingleNeuronSynaptomeSimulation,
     slug: EntitySlug.SingleNeuronSynaptomeSimulation,
     api: {
-      config: { allowedFacets: true },
+      config: {
+        allowedFacets: true,
+        ilikeSearchEnabled: true,
+      },
       query: {
         list: getSingleNeuronSynaptomeSimulations,
         one: getSingleNeuronSynaptomeSimulation,

--- a/src/entity-configuration/domain/simulation/small-microcircuit-simulation.ts
+++ b/src/entity-configuration/domain/simulation/small-microcircuit-simulation.ts
@@ -167,7 +167,10 @@ export const SmallMicrocircuitSimulation: EntityCoreTypeConfig<ICircuitSimulatio
   type: EntityTypeDict.SimulationCampaign,
   slug: EntitySlug.SmallMicrocircuitSimulation,
   api: {
-    config: { allowedFacets: true },
+    config: {
+      allowedFacets: true,
+      ilikeSearchEnabled: true,
+    },
     query: {
       count: (...params) => {
         const filters = discardBrainRegionQueryParams(params[0].filters);

--- a/src/entity-configuration/domain/types.ts
+++ b/src/entity-configuration/domain/types.ts
@@ -20,7 +20,11 @@ export type EntityCoreTypeConfig<T extends EntityCoreIdentifiable> = {
   alternateTitle?: string;
   requiredFeatures?: Array<FlagKey>;
   api: {
-    config: { allowedFacets?: boolean; extraRequiredListFilters?: Record<string, any> };
+    config: {
+      allowedFacets?: boolean;
+      extraRequiredListFilters?: Record<string, any>;
+      ilikeSearchEnabled?: boolean;
+    };
     query: {
       count?: (query: any) => Promise<EntityCoreResponse<T>>;
       list?: (query: any) => Promise<EntityCoreResponse<T>>;

--- a/src/ui/hooks/use-query-extended-entity-type.tsx
+++ b/src/ui/hooks/use-query-extended-entity-type.tsx
@@ -27,6 +27,7 @@ import {
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { WorkspaceContext } from '@/types/common';
 import type { TWorkspaceScope } from '@/constants';
+import { getEntityByExtendedType } from '@/entity-configuration/domain/helpers';
 
 export type QueryContext = {
   key: string;
@@ -71,12 +72,23 @@ function useQueryParameters(
   const filters = useAtomValue(
     coreFiltersAtom({ dataType: context.extendedEntityType, key: context.key })
   );
+  const entity = getEntityByExtendedType({ type: context.extendedEntityType });
+
+  function search() {
+    if (entity && !!entity.api.config.ilikeSearchEnabled && !isEmpty(searchString)) {
+      return { ilike_search: `*${searchString}*` };
+    }
+    if (!isEmpty(searchString)) {
+      return { search: searchString };
+    }
+    return null;
+  }
 
   const queryParameters = compactRecord({
     page_size: DEFAULT_PAGE_SIZE,
     page: pageNumber,
     with_facets: true,
-    search: isEmpty(searchString) ? null : searchString,
+    ...search(),
     order_by: `${sortState.order === 'asc' ? '+' : '-'}${sortState.backendField}`,
     ...(requireBrainRegion
       ? {


### PR DESCRIPTION
1. add type IlikeSearchFilter to entities that already have name+description
2. add `ilikeSearchEnabled` to `EntityCoreTypeConfig` to specify what are entities that support the field
3. update query-builder (src/ui/hooks/use-query-extended-entity-type.tsx) to use `ilike_search` for entities that enable the feature, fallback to `search` field
