### PR TITLE
store credit left in local storage to avoid issue on refresh

### DIFF
--- a/src/services/ai-agent/hooks/chat.ts
+++ b/src/services/ai-agent/hooks/chat.ts
@@ -49,7 +49,7 @@ export function useServiceAiAgentChat(threadId: string) {
   const initialMessages = assistant.initialMessages.useValue();
   const { accessToken } = assistant.useContext();
   const activeTools = useAIActiveTools();
-  const [rateLimitRemaining, setRateLimitRemaining] = React.useState(getStoredRateLimit);
+  const [rateLimitRemaining, setRateLimitRemaining] = React.useState(() => getStoredRateLimit());
   const chat = useChat({
     api: serviceAiAgentUrl(['qa/chat_streamed', threadId]),
     id: threadId,


### PR DESCRIPTION
Free credits are displayed as "0" free credits when we open a new entity in the chat. When asking for another question, that number is back to the proper value coming from the header.
The issue is also happening when refreshing.

Example:
- ask for litterature search -> shows "29 free credits left"
- ask for a morphology in thalamus -> shows "28 free credits left"
- click on the entity to view it -> shows "0 free credits left". Should show "28 free credits left"