### PR TITLE
fix for prod-singlecell-simulation issue #246. 3d morph disappear when switching tab

### DIFF
--- a/src/ui/segments/workflows/simulate/single-neuron/shared/steps/webgl-neuron-selector/painter/manager.ts
+++ b/src/ui/segments/workflows/simulate/single-neuron/shared/steps/webgl-neuron-selector/painter/manager.ts
@@ -465,6 +465,15 @@ export function usePainterManager(morphology: Morphology) {
     refPainter.current = new PainterManager();
     refPainter.current.morphology = morphology;
   }
+
+  // Update morphology when it changes (even if object reference changes)
+  React.useEffect(() => {
+    if (refPainter.current) {
+      refPainter.current.morphology = morphology;
+    }
+  }, [morphology]);
+
+  // Cleanup only on unmount
   React.useEffect(() => {
     return () => {
       const painterManager = refPainter.current;
@@ -472,7 +481,7 @@ export function usePainterManager(morphology: Morphology) {
 
       painterManager.delete();
     };
-  });
+  }, []); // Empty dependency array - only run on mount/unmount
   return refPainter.current;
 }
 


### PR DESCRIPTION
This is a fix for https://github.com/openbraininstitute/prod-singlecell-simulation/issues/246

- Added an empty dependency array to the cleanup effect so it only runs on component unmount.
- Added a separate effect to update the morphology when it changes, even if the object reference changes.