### PR TITLE
Update staging Keycloak URL

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,7 +2,7 @@ API_ORIGIN="https://staging.openbraininstitute.org"
 
 NEXTAUTH_URL=http://localhost:3000
 
-KEYCLOAK_ISSUER=https://staging.openbraininstitute.org/auth/realms/SBO
+KEYCLOAK_ISSUER=https://staging.cell-a.openbraininstitute.org/auth/realms/SBO
 KEYCLOAK_CLIENT_ID=obp-core-web-app-dev
 KEYCLOAK_CLIENT_SECRET=dummy-secret
 


### PR DESCRIPTION
According to the latest infra changes the Keycloak should be accessed with `https://staging.cell-a.openbraininstitute.org/auth`.