### PR TITLE
Add buttons to run a notebook in a single pod instance on either AWS or Azure

### DIFF
--- a/src/services/notebooks/index.ts
+++ b/src/services/notebooks/index.ts
@@ -1,6 +1,6 @@
-import { assertApiResponse } from '@/util/utils';
 import authFetch, { getSession } from '@/auth-fetch';
 import { config } from '@/config';
+import { assertApiResponse } from '@/util/utils';
 
 export type NotebookStartResponse = {
   message: string;
@@ -24,6 +24,25 @@ export interface NotebookStartRequest {
   };
 }
 
+export interface NotebookStartInNumberedPodRequest {
+  analysis_notebook_template_id: string;
+  analysis_notebook_template_filename: string;
+  vlabId: string;
+  projectId: string;
+  session: {
+    idToken: string;
+    accessToken: string;
+    user: {
+      email: string;
+      id: string;
+      name: string;
+      username: string;
+    };
+  };
+  podNumber: number;
+  cloud: string; // either 'aws' or 'azure'
+}
+
 export interface EmptyNotebookStartRequest {
   vlabId: string;
   projectId: string;
@@ -43,7 +62,9 @@ export async function startNotebook(
   id: string,
   filename: string,
   vlabId: string,
-  projectId: string
+  projectId: string,
+  cloud?: string,
+  podNum?: number
 ): Promise<NotebookStartResponse> {
   const session = await getSession();
 
@@ -56,27 +77,61 @@ export async function startNotebook(
     });
   }
 
-  const request: NotebookStartRequest = {
-    analysis_notebook_template_id: id,
-    analysis_notebook_template_filename: filename,
-    vlabId,
-    projectId,
-    session: {
-      idToken: session.idToken,
-      accessToken: session.accessToken,
-      user: {
-        email: session.user.email ?? '',
-        id: session.user.id,
-        name: session.user.name ?? '',
-        username: session.user.username,
+  let res: Response;
+
+  if (cloud === 'azure' || cloud === 'aws') {
+    // use new service which requires pod number and cloud param
+
+    const request: NotebookStartInNumberedPodRequest = {
+      analysis_notebook_template_id: id,
+      analysis_notebook_template_filename: filename,
+      vlabId,
+      projectId,
+      session: {
+        idToken: session.idToken,
+        accessToken: session.accessToken,
+        user: {
+          email: session.user.email ?? '',
+          id: session.user.id,
+          name: session.user.name ?? '',
+          username: session.user.username,
+        },
       },
-    },
-  };
-  const res = await authFetch(`${config.NOTEBOOK_API_URL}/analysis_notebook_template/start`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(request),
-  });
+      podNumber: podNum === undefined ? 0 : podNum,
+      cloud: cloud,
+    };
+
+    res = await authFetch(
+      `${config.NOTEBOOK_API_URL}/analysis_notebook_template/start_in_numbered_pod`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+      }
+    );
+  } else {
+    const request: NotebookStartRequest = {
+      analysis_notebook_template_id: id,
+      analysis_notebook_template_filename: filename,
+      vlabId,
+      projectId,
+      session: {
+        idToken: session.idToken,
+        accessToken: session.accessToken,
+        user: {
+          email: session.user.email ?? '',
+          id: session.user.id,
+          name: session.user.name ?? '',
+          username: session.user.username,
+        },
+      },
+    };
+    res = await authFetch(`${config.NOTEBOOK_API_URL}/analysis_notebook_template/start`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+    });
+  }
 
   if (!res.ok) {
     if (res.status === 460) {

--- a/src/ui/segments/notebooks/table/ActionPopover.tsx
+++ b/src/ui/segments/notebooks/table/ActionPopover.tsx
@@ -9,6 +9,7 @@ import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity
 import { DownloadIconWhiteWithCorners } from '@/components/icons/DownloadIcon';
 import { EyeIconWhiteWithinBox } from '@/components/icons/EyeIcon';
 import { useAppNotification } from '@/components/notification';
+import { config } from '@/config';
 import { downloadArchive } from '@/services/entity-download';
 import { type NotebookStartResponse, startNotebook } from '@/services/notebooks';
 import { useWorkspace } from '@/ui/hooks/use-workspace';
@@ -24,7 +25,7 @@ export default function ActionPopover({ notebook, index }: ActionPopoverProps) {
   const { virtualLabId, projectId } = useWorkspace();
   const [loading, setLoading] = useState(false);
 
-  async function handleRunNotebook() {
+  async function handleRunNotebook(cloud?: string, podNum?: number) {
     if (loading) return;
     const asset = notebook.assets.find((n) => n.label === 'jupyter_notebook');
     if (!asset) return;
@@ -36,7 +37,9 @@ export default function ActionPopover({ notebook, index }: ActionPopoverProps) {
         notebook.id,
         asset.path,
         virtualLabId,
-        projectId
+        projectId,
+        cloud,
+        podNum
       );
       notification.success({
         message: `Notebook starting`,
@@ -124,6 +127,71 @@ export default function ActionPopover({ notebook, index }: ActionPopoverProps) {
                   Run
                 </button>
               </div>
+
+              {['local', 'preview', 'development'].includes(config.DEPLOYMENT_ENV) && (
+                <div>
+                  <div className="flex gap-4">
+                    <button
+                      disabled={loading}
+                      type="button"
+                      className="hover:text-primary-4 inline-flex items-center gap-[10px]"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleRunNotebook('aws', 0);
+                      }}
+                    >
+                      {!loading && <PlayCircleOutlined aria-label="Run" />}
+                      {loading && <LoadingOutlined />}
+                      Run in single pod 0 on AWS
+                    </button>
+                  </div>
+                  <div className="flex gap-4">
+                    <button
+                      disabled={loading}
+                      type="button"
+                      className="hover:text-primary-4 inline-flex items-center gap-[10px]"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleRunNotebook('azure', 0);
+                      }}
+                    >
+                      {!loading && <PlayCircleOutlined aria-label="Run" />}
+                      {loading && <LoadingOutlined />}
+                      Run in single pod 0 on Azure
+                    </button>
+                  </div>
+                  <div className="flex gap-4">
+                    <button
+                      disabled={loading}
+                      type="button"
+                      className="hover:text-primary-4 inline-flex items-center gap-[10px]"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleRunNotebook('aws', 1);
+                      }}
+                    >
+                      {!loading && <PlayCircleOutlined aria-label="Run" />}
+                      {loading && <LoadingOutlined />}
+                      Run in single pod 1 on AWS
+                    </button>
+                  </div>
+                  <div className="flex gap-4">
+                    <button
+                      disabled={loading}
+                      type="button"
+                      className="hover:text-primary-4 inline-flex items-center gap-[10px]"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleRunNotebook('azure', 1);
+                      }}
+                    >
+                      {!loading && <PlayCircleOutlined aria-label="Run" />}
+                      {loading && <LoadingOutlined />}
+                      Run in single pod 1 on Azure
+                    </button>
+                  </div>
+                </div>
+              )}
             </div>
           }
           style={{


### PR DESCRIPTION
This adds **only in dev** some extra buttons to test the functionality for running a notebook in a shared pod in either AWS or Azure. This will definitely not be the final UI, but is meant to make it possible to do some initial testing.

https://github.com/openbraininstitute/INFRA/issues/329
