### PR TITLE
Hotfix: client config context

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,7 @@ import { DM_Serif_Text, Gabarito, Titillium_Web } from 'next/font/google';
 import { ReactNode, Suspense } from 'react';
 
 import MatomoAnalyticsConsent from '@/components/Matomo';
-import { config, ConfigProvider, getClientEnvInjectionConfig } from '@/config';
+import { ConfigProvider, getClientEnvInjectionConfig } from '@/config';
 
 import '@/styles/globals.css';
 
@@ -32,6 +32,8 @@ type RootLayoutProps = {
 };
 
 export default async function RootLayout({ children }: RootLayoutProps) {
+  const config = getClientEnvInjectionConfig();
+
   return (
     <html
       lang="en"
@@ -40,9 +42,9 @@ export default async function RootLayout({ children }: RootLayoutProps) {
     >
       <head>
         <script
-          // eslint-disable-next-line react/no-danger
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: <false positive>
           dangerouslySetInnerHTML={{
-            __html: `window.__ENV__=${JSON.stringify(getClientEnvInjectionConfig())};`,
+            __html: `window.__ENV__=${JSON.stringify(config)};`,
           }}
         />
       </head>

--- a/src/config/client.ts
+++ b/src/config/client.ts
@@ -36,9 +36,9 @@ export const clientConfig = new Proxy({} as ClientConfig, {
   },
 });
 
-export function getClientEnvInjectionConfig() {
+export function getClientEnvInjectionConfig(): ClientConfig {
   const clientEnvKeys = Object.keys(baseClientSchema.shape);
   return Object.fromEntries(
     clientEnvKeys.map((key) => [key, clientConfig[key as keyof typeof clientConfig]])
-  );
+  ) as ClientConfig;
 }


### PR DESCRIPTION
* Provide client config object instead of proxy object as a React context