### PR TITLE
Workaround to fix the initial zoom for neurons without dendrites

### DIFF
--- a/src/ui/segments/workflows/simulate/single-neuron/shared/steps/webgl-neuron-selector/painter/camera.ts
+++ b/src/ui/segments/workflows/simulate/single-neuron/shared/steps/webgl-neuron-selector/painter/camera.ts
@@ -22,23 +22,35 @@ export function makeCamera({
     },
     near: 1,
   });
-  const distanceMax = computeDistance(camera, bbox, 1.1);
+  camera.screenHeight = camera.screenWidth;
   const distance = computeDistance(camera, bboxDendrites, 1.1);
-  const distanceMin = computeDistance(camera, bboxSoma, 3);
-  const zoomMin = Math.min(0.5, distance / distanceMax);
-  const zoomMax = Math.min(1000, distance / distanceMin);
+  const distanceMax = ensureBigger(distance, computeDistance(camera, bbox, 1.5));
+  const distanceMin = ensureSmaller(computeDistance(camera, bboxSoma, 3), distance);
+  const zoomMin = distance / distanceMax;
+  const zoomMax = distance / distanceMin;
   camera.transfo.distance = distance;
   return { camera, zoomMin, zoomMax };
 }
 
+function ensureSmaller(value: number, limit: number) {
+  if (value < limit) return value;
+  return limit * 0.9;
+}
+
+function ensureBigger(value: number, limit: number) {
+  if (value > limit) return value;
+  return limit * 1.1;
+}
+
 function computeDistance(camera: TgdCamera, bbox: BoundingBox, scale: number) {
-  camera.fitSpaceAtTarget(
+  const width =
     2 *
-      scale *
-      Math.max(1, Math.abs(bbox.center[0] - bbox.min[0]), Math.abs(bbox.center[0] - bbox.max[0])),
+    scale *
+    Math.max(1, Math.abs(bbox.center[0] - bbox.min[0]), Math.abs(bbox.center[0] - bbox.max[0]));
+  const height =
     2 *
-      scale *
-      Math.max(1, Math.abs(bbox.center[1] - bbox.min[1]), Math.abs(bbox.center[1] - bbox.max[1]))
-  );
+    scale *
+    Math.max(1, Math.abs(bbox.center[1] - bbox.min[1]), Math.abs(bbox.center[1] - bbox.max[1]));
+  camera.fitSpaceAtTarget(width, height);
   return camera.transfo.distance;
 }

--- a/src/ui/segments/workflows/simulate/single-neuron/shared/steps/webgl-neuron-selector/painter/structure.ts
+++ b/src/ui/segments/workflows/simulate/single-neuron/shared/steps/webgl-neuron-selector/painter/structure.ts
@@ -107,6 +107,10 @@ export class Structure {
         this.segments.set(item.name, item);
         this.addToSection(item);
         this.items.push(item);
+        bbox.min = computeMin(bbox.min, start, item.radius);
+        bbox.max = computeMax(bbox.max, start, item.radius);
+        bbox.min = computeMin(bbox.min, end, item.radius);
+        bbox.max = computeMax(bbox.max, end, item.radius);
         if (isSoma) {
           somaCounts++;
           somaCenter.add(start);
@@ -119,10 +123,6 @@ export class Structure {
           isBBoxSomaEmpty = false;
         } else {
           distanceFromSoma += section.length[segmentIndex];
-          bbox.min = computeMin(bbox.min, start, item.radius);
-          bbox.max = computeMax(bbox.max, start, item.radius);
-          bbox.min = computeMin(bbox.min, end, item.radius);
-          bbox.max = computeMax(bbox.max, end, item.radius);
           if (
             [
               StructureItemType.Dendrite,


### PR DESCRIPTION
The default behaviour is to have an initial zoom that displays the bounding box of the soma and the dendrites (not the axon). But in cases like the following, where there are no dendrite, we need to have an initial zoom that shows the whole neuron.

<img width="1508" height="1778" alt="image" src="https://github.com/user-attachments/assets/35e54b1c-14c7-4f57-b095-208262066cb2" />
