### PR TITLE
Simplify BlockDictionary logic

### DIFF
--- a/src/features/scan-config/components/block-dictionary.tsx
+++ b/src/features/scan-config/components/block-dictionary.tsx
@@ -7,7 +7,7 @@ import {
   type ConfigValue,
 } from '@/features/scan-config/components/components';
 import { isRootBlock } from '@/features/scan-config/components/hooks/schema';
-import { isAtom } from '@/features/scan-config/components/utils';
+import { isAtom, isPlainObject } from '@/features/scan-config/components/utils';
 import type {
   AtomsMap,
   Block,
@@ -21,11 +21,8 @@ type Props = {
   schema: ConfigSchema;
   blockDictionarySchema: BlockDictionaryT;
   selectedRootElement: string;
-  selectedCategory: string;
   atomsMap: AtomsMap;
   setAtomsMap: (v: AtomsMap) => void;
-  selectedBlock: string;
-  setSelectedBlock: (s: string) => void;
   selectedEntry: string;
   setSelectedEntry: (entry: string) => void;
   campaignId: string;
@@ -44,8 +41,6 @@ export default function BlockDictionary({
   selectedRootElement,
   atomsMap,
   setAtomsMap,
-  selectedBlock,
-  setSelectedBlock,
   selectedEntry,
   setSelectedEntry,
   campaignId,
@@ -55,6 +50,10 @@ export default function BlockDictionary({
   allEntries,
   onNewBlockClick,
 }: Props) {
+  const selectedBlock = isPlainObject(config[selectedRootElement])
+    ? config[selectedRootElement][selectedEntry]?.type
+    : undefined;
+
   const selectedBlockSchema: Block | undefined =
     blockDictionarySchema.additionalProperties.oneOf.find(
       (o: Block) => o.properties?.type.const === selectedBlock
@@ -86,7 +85,6 @@ export default function BlockDictionary({
 
               if (onNewBlockClick) onNewBlockClick();
 
-              setSelectedBlock(o.properties?.type.const ?? '');
               const initial: Record<string, ConfigValue> = {};
               if (o.properties)
                 Object.entries(o.properties).forEach(([subkey, subValue]) => {

--- a/src/features/scan-config/components/left.tsx
+++ b/src/features/scan-config/components/left.tsx
@@ -25,7 +25,6 @@ export default function Left({
   selectedEntry,
   setSelectedEntry,
   setEditing,
-  setSelectedBlock,
   readOnly,
   setCampaignId,
   setLoading,
@@ -49,7 +48,6 @@ export default function Left({
   selectedEntry: string;
   setSelectedEntry: (selectedEntry: string) => void;
   setEditing: React.Dispatch<React.SetStateAction<boolean>>;
-  setSelectedBlock: React.Dispatch<React.SetStateAction<string>>;
   readOnly?: boolean;
   setCampaignId: React.Dispatch<React.SetStateAction<string>>;
   setLoading: React.Dispatch<React.SetStateAction<boolean>>;
@@ -101,7 +99,6 @@ export default function Left({
                         selectedEntry={selectedEntry}
                         setSelectedEntry={setSelectedEntry}
                         setEditing={setEditing}
-                        setSelectedBlock={setSelectedBlock}
                         readOnly={readOnly}
                         allEntries={allEntries}
                         newKey={newKey}

--- a/src/features/scan-config/components/middle.tsx
+++ b/src/features/scan-config/components/middle.tsx
@@ -20,8 +20,6 @@ type MiddleProps = {
   editing: boolean;
   atomsMap: AtomsMap;
   setAtomsMap: (v: AtomsMap) => void;
-  selectedBlock: string;
-  setSelectedBlock: (s: string) => void;
   selectedEntry: string;
   setSelectedEntry: (entry: string) => void;
   campaignId: string;
@@ -39,8 +37,6 @@ export default function Middle({
   selectedRootElement,
   atomsMap,
   setAtomsMap,
-  selectedBlock,
-  setSelectedBlock,
   selectedEntry,
   setSelectedEntry,
   campaignId,
@@ -66,11 +62,8 @@ export default function Middle({
           model={model}
           allEntries={allEntries}
           schema={schema}
-          selectedCategory={selectedBlock}
           atomsMap={atomsMap}
           setAtomsMap={setAtomsMap}
-          setSelectedBlock={setSelectedBlock}
-          selectedBlock={selectedBlock}
           selectedEntry={selectedEntry}
           setSelectedEntry={setSelectedEntry}
           schemaName={schemaName}
@@ -83,7 +76,6 @@ export default function Middle({
       {selectedSchema.ui_element === 'root_block' && isAtom(atomsMap[selectedRootElement]) && (
         <BlockUI
           schemaName={schemaName}
-          key={selectedBlock}
           disabled={!!campaignId || loading}
           config={config}
           blockSchema={selectedSchema}

--- a/src/features/scan-config/components/root-element.tsx
+++ b/src/features/scan-config/components/root-element.tsx
@@ -35,7 +35,6 @@ export function RootElement({
   selectedEntry,
   setSelectedEntry,
   setEditing,
-  setSelectedBlock,
   readOnly,
   allEntries,
   newKey,
@@ -57,7 +56,6 @@ export function RootElement({
   selectedEntry: string;
   setSelectedEntry: (selectedEntry: string) => void;
   setEditing: React.Dispatch<React.SetStateAction<boolean>>;
-  setSelectedBlock: React.Dispatch<React.SetStateAction<string>>;
   readOnly?: boolean;
   allEntries: Set<string>;
   newKey: string;
@@ -69,7 +67,6 @@ export function RootElement({
 
   const handleHeaderClick = (subkey: string, subValue: unknown) => {
     if (isPlainObject(subValue)) {
-      setSelectedBlock(typeof subValue.type === 'string' ? subValue.type : '');
       setSelectedEntry(subkey);
     }
     setEditing(true);
@@ -153,7 +150,6 @@ export function RootElement({
         onClick={() => {
           if (selectedRootElement === rootElement && !isRootBlock(schema, rootElement)) {
             setEditing(false);
-            setSelectedBlock('');
             setSelectedEntry('');
             setSelectedRootElement('');
             return;
@@ -161,7 +157,6 @@ export function RootElement({
 
           setSelectedRootElement(rootElement);
           setSelectedEntry('');
-          setSelectedBlock('');
 
           if (rootElementSchema.ui_element === 'root_block') setEditing(true);
           else setEditing(false);
@@ -275,7 +270,6 @@ export function RootElement({
                         onClick={(e) => {
                           e.stopPropagation();
 
-                          setSelectedBlock('');
                           setEditing(false);
 
                           const selectedTabAtoms = atomsMap[selectedRootElement];
@@ -352,7 +346,7 @@ export function RootElement({
                 type="button"
                 onClick={() => {
                   setEditing(true);
-                  setSelectedBlock('');
+                  setSelectedEntry('');
                 }}
               >
                 Add {rootElementSchema.singular_name ?? rootElementSchema.title ?? 'element'}

--- a/src/features/scan-config/index.tsx
+++ b/src/features/scan-config/index.tsx
@@ -13,7 +13,7 @@ import { useAtomsMap, useObioneJsonSchema } from '@/features/scan-config/compone
 import ModelPreview from '@/features/scan-config/components/model-preview';
 import TabsSelector from '@/features/scan-config/components/tabs-selector';
 import styles from '@/features/scan-config/scan-config.module.css';
-import type { Block, TabType } from '@/features/scan-config/types';
+import type { TabType } from '@/features/scan-config/types';
 import { ButtonCopyId } from '@/ui/molecules/button-copy-id';
 import { cn } from '@/utils/css-class';
 import { useEntries, useModel, useSchemaName } from './components/hooks';
@@ -43,7 +43,6 @@ export default function ScanConfiguration({
   const [tab, setTab] = useState<TabType>(defaultTab);
   const [selectedRootElement, setSelectedRootElement] = useState<string>('info');
   const [editing, setEditing] = useState(true);
-  const [selectedBlock, setSelectedBlock] = useState('');
   const [selectedEntry, setSelectedEntry] = useState('');
   const [loading, setLoading] = useState(false);
   const [campaignId, setCampaignId] = useState(initialCampaignId ?? '');
@@ -99,7 +98,6 @@ export default function ScanConfiguration({
             selectedEntry={selectedEntry}
             setSelectedEntry={setSelectedEntry}
             setEditing={setEditing}
-            setSelectedBlock={setSelectedBlock}
             readOnly={readOnly}
             setCampaignId={setCampaignId}
             setLoading={setLoading}
@@ -124,11 +122,9 @@ export default function ScanConfiguration({
                 schemaName={schemaName}
                 schema={schema}
                 selectedRootElement={selectedRootElement}
-                selectedBlock={selectedBlock}
                 editing={editing}
                 atomsMap={atomsMap}
                 setAtomsMap={setAtomsMap}
-                setSelectedBlock={setSelectedBlock}
                 selectedEntry={selectedEntry}
                 setSelectedEntry={setSelectedEntry}
                 campaignId={campaignId}


### PR DESCRIPTION
Encapsulates the logic for rendering Block dictionaries, it should be much more readable.
Also got rid of the unnecessary `selectedCategory` since it can be inferred from the 'selectedEntry'.