### PR TITLE
remove duplicate l-r-borders in middle column in scan config

### DIFF
--- a/src/features/scan-config/components/middle.tsx
+++ b/src/features/scan-config/components/middle.tsx
@@ -48,12 +48,7 @@ export default function Middle({
   selectedSchema,
 }: MiddleProps) {
   return (
-    <div
-      className={classNames(
-        styles.scrollable,
-        'h-full overflow-y-auto border-r border-l border-gray-200 px-5'
-      )}
-    >
+    <>
       {selectedSchema.ui_element === 'block_dictionary' && (
         <BlockDictionary
           campaignId={campaignId}
@@ -83,6 +78,6 @@ export default function Middle({
           model={model}
         />
       )}
-    </div>
+    </>
   );
 }


### PR DESCRIPTION

@g-bar this fix the double border after your change this morning 
<img width="375" height="510" alt="Screenshot 2026-01-30 at 10 36 12" src="https://github.com/user-attachments/assets/d16e4e45-7c8d-4167-a229-74e84b103290" />
