### PR TITLE
Remove unused status for single cell simulations

### DIFF
--- a/src/api/entitycore/types/entities/single-neuron-simulation.ts
+++ b/src/api/entitycore/types/entities/single-neuron-simulation.ts
@@ -1,29 +1,26 @@
-import z from "zod";
+import z from 'zod';
 
-import type { IBrainRegionHierarchy } from "@/api/entitycore/types/entities/brain-region";
-import type { INestedMEModel } from "@/api/entitycore/types/entities/me-model";
+import type { IBrainRegionHierarchy } from '@/api/entitycore/types/entities/brain-region';
+import type { INestedMEModel } from '@/api/entitycore/types/entities/me-model';
 import type {
   EntityAuthorization,
   EntityCoreBaseAsset,
   EntityCoreIdentifiable,
   EntityCoreType,
   Timestamps,
-} from "@/api/entitycore/types/shared/global";
-import {
-  type ISingleNeuronSimulationBase,
-  SingleNeuronSimulationStatus,
-} from "@/api/entitycore/types/shared/neuron-simulation";
+} from '@/api/entitycore/types/shared/global';
+import type { ISingleNeuronSimulationBase } from '@/api/entitycore/types/shared/neuron-simulation';
 import type {
-  ContributionFilter,
+  BrainRegionFilter,
   BrainRegionHierarchyFilter,
-  SharedFilter,
-  MtypeFilter,
+  ContributionFilter,
   EtypeFilter,
   IlikeSearchFilter,
+  MtypeFilter,
   OwnershipFilter,
   PaginationFilter,
-  BrainRegionFilter,
-} from "@/api/entitycore/types/shared/request";
+  SharedFilter,
+} from '@/api/entitycore/types/shared/request';
 
 export interface ISingleNeuronSimulation
   extends EntityCoreIdentifiable,
@@ -81,7 +78,6 @@ export interface ISingleNeuronSimulationFilter
 const CreateSingleNeuronSimulationSchema = z.object({
   name: z.string(),
   description: z.string(),
-  status: z.nativeEnum(SingleNeuronSimulationStatus),
   seed: z.number().int(),
   injection_location: z.array(z.string()),
   recording_location: z.array(z.string()),
@@ -89,6 +85,4 @@ const CreateSingleNeuronSimulationSchema = z.object({
   me_model_id: z.string().uuid(),
 });
 
-export type TCreateSingleNeuronSimulation = z.infer<
-  typeof CreateSingleNeuronSimulationSchema
->;
+export type TCreateSingleNeuronSimulation = z.infer<typeof CreateSingleNeuronSimulationSchema>;

--- a/src/api/entitycore/types/entities/single-neuron-synaptome-simulation.ts
+++ b/src/api/entitycore/types/entities/single-neuron-synaptome-simulation.ts
@@ -1,20 +1,16 @@
-import z from "zod";
+import z from 'zod';
 
-import type { IBrainRegionHierarchy } from "@/api/entitycore/types/entities/brain-region";
-import type { MeTypeFilter } from "@/api/entitycore/types/entities/single-neuron-simulation";
-import type { SingleNeuronSynaptomeBase } from "@/api/entitycore/types/entities/single-neuron-synaptome";
+import type { IBrainRegionHierarchy } from '@/api/entitycore/types/entities/brain-region';
+import type { MeTypeFilter } from '@/api/entitycore/types/entities/single-neuron-simulation';
+import type { SingleNeuronSynaptomeBase } from '@/api/entitycore/types/entities/single-neuron-synaptome';
 import type {
   EntityAuthorization,
   EntityCoreBaseAsset,
   EntityCoreIdentifiable,
   EntityCoreType,
   Timestamps,
-} from "@/api/entitycore/types/shared/global";
-import {
-  type ISingleNeuronSimulationBase,
-  type SimulationStatusFilter,
-  SingleNeuronSimulationStatus,
-} from "@/api/entitycore/types/shared/neuron-simulation";
+} from '@/api/entitycore/types/shared/global';
+import type { ISingleNeuronSimulationBase } from '@/api/entitycore/types/shared/neuron-simulation';
 import type {
   BrainRegionFilter,
   BrainRegionHierarchyFilter,
@@ -28,8 +24,8 @@ import type {
   PaginationFilter,
   SharedFilter,
   TimestampsFilter,
-} from "@/api/entitycore/types/shared/request";
-import type { Prettify } from "@/utils/type";
+} from '@/api/entitycore/types/shared/request';
+import type { Prettify } from '@/utils/type';
 
 export interface ISingleNeuronSynaptomeSimulation
   extends ISingleNeuronSimulationBase,
@@ -38,9 +34,7 @@ export interface ISingleNeuronSynaptomeSimulation
     EntityCoreType,
     EntityCoreBaseAsset {
   brain_region: IBrainRegionHierarchy;
-  synaptome: Prettify<
-    SingleNeuronSynaptomeBase & EntityCoreIdentifiable & Timestamps
-  >;
+  synaptome: Prettify<SingleNeuronSynaptomeBase & EntityCoreIdentifiable & Timestamps>;
 }
 
 interface SynaptomeFilter {
@@ -63,7 +57,6 @@ export interface ISingleNeuronSynaptomeSimulationFilter
     CreatorFilter,
     SharedFilter,
     TimestampsFilter,
-    SimulationStatusFilter,
     MeTypeFilter,
     MtypeFilter,
     EtypeFilter,
@@ -75,7 +68,6 @@ export interface ISingleNeuronSynaptomeSimulationFilter
 const CreateSingleNeuronSynaptomeSimulationSchema = z.object({
   name: z.string(),
   description: z.string(),
-  status: z.nativeEnum(SingleNeuronSimulationStatus),
   seed: z.number().int(),
   injection_location: z.array(z.string()),
   recording_location: z.array(z.string()),

--- a/src/api/entitycore/types/shared/neuron-simulation.ts
+++ b/src/api/entitycore/types/shared/neuron-simulation.ts
@@ -1,23 +1,15 @@
-import { EntityCoreIdentifiable, EntityCoreOwnership } from '@/api/entitycore/types/shared/global';
-
-export enum SingleNeuronSimulationStatus {
-  started = 'started',
-  failure = 'failure',
-  success = 'success',
-}
+import type {
+  EntityCoreIdentifiable,
+  EntityCoreOwnership,
+} from '@/api/entitycore/types/shared/global';
 
 export interface ISingleNeuronSimulationBase extends EntityCoreIdentifiable, EntityCoreOwnership {
   name: string;
   description: string;
   seed: number;
-  status: SingleNeuronSimulationStatus;
   injection_location: Array<string>;
   recording_location: Array<string>;
 }
-
-export type SimulationStatusFilter = {
-  status: SingleNeuronSimulationStatus | null;
-};
 
 export interface ICircuitSimulationBase extends EntityCoreIdentifiable, EntityCoreOwnership {
   name: string;

--- a/src/entity-configuration/definitions/fields-defs/enums.ts
+++ b/src/entity-configuration/definitions/fields-defs/enums.ts
@@ -71,7 +71,6 @@ export enum EntityCoreFields {
   SimulationSeed = 'simulation_seed',
   InjectionLocation = 'injection_location',
   RecordingLocation = 'recording_location',
-  SimulationStatus = 'simulation_status',
   SimulationResponse = 'simulation_response',
   SimulationStimulus = 'simulation_stimulus',
   SimulationModel = 'me_model',

--- a/src/entity-configuration/definitions/fields-defs/experiment.tsx
+++ b/src/entity-configuration/definitions/fields-defs/experiment.tsx
@@ -6,10 +6,7 @@ import type {
   ISingleNeuronSynaptomeSimulation,
 } from '@/api/entitycore/types';
 import type { ICircuitSimulationCampaign } from '@/api/entitycore/types/entities/circuit-simulation-campaign';
-import {
-  CoreFieldFilterTypeEnum,
-  EntityCoreFields,
-} from '@/entity-configuration/definitions/fields-defs/enums';
+import { EntityCoreFields } from '@/entity-configuration/definitions/fields-defs/enums';
 import {
   EmptyPreview,
   renderArray,
@@ -61,19 +58,6 @@ export const FieldsDefinition: Partial<FieldsDefinitionRegistry<EntityCoreObject
     },
     style: { width: 184, align: 'left' },
     isFilterable: false,
-    isDisplayable: true,
-  },
-  [EntityCoreFields.SimulationStatus]: {
-    className: 'text-center',
-    title: 'Status',
-    filter: CoreFieldFilterTypeEnum.CheckList,
-    render: (r) => renderEmptyOrValue('status' in r ? r.status : undefined),
-    vocabulary: {
-      plural: 'Statuses',
-      singular: 'Status',
-    },
-    style: { width: 184, align: 'left' },
-    isFilterable: true,
     isDisplayable: true,
   },
   [EntityCoreFields.SimulationStimulus]: {

--- a/src/entity-configuration/definitions/view-defs/simulation/single-neuron-simulation.ts
+++ b/src/entity-configuration/definitions/view-defs/simulation/single-neuron-simulation.ts
@@ -1,9 +1,9 @@
+import { EntityCoreFields } from '@/entity-configuration/definitions/fields-defs/enums';
 import {
   DataTypeGroup,
   type ViewDefinitionConfig,
 } from '@/entity-configuration/definitions/view-defs/types';
 import { EntitySlug } from '@/entity-configuration/domain/slug';
-import { EntityCoreFields } from '@/entity-configuration/definitions/fields-defs/enums';
 
 export const viewDefForSingleNeuronSimulation: ViewDefinitionConfig = {
   title: 'Simulation',
@@ -15,7 +15,6 @@ export const viewDefForSingleNeuronSimulation: ViewDefinitionConfig = {
     EntityCoreFields.SimulationModel,
     EntityCoreFields.SimulationStimulus,
     EntityCoreFields.SimulationResponse,
-    EntityCoreFields.SimulationStatus,
     EntityCoreFields.InjectionLocation,
     EntityCoreFields.RecordingLocation,
     EntityCoreFields.BrainRegion,
@@ -28,7 +27,6 @@ export const viewDefForSingleNeuronSimulation: ViewDefinitionConfig = {
   ],
   miniDetailView: [
     { field: EntityCoreFields.SimulationModel },
-    { field: EntityCoreFields.SimulationStatus },
     { field: EntityCoreFields.InjectionLocation },
     { field: EntityCoreFields.RecordingLocation },
     { field: EntityCoreFields.BrainRegion },

--- a/src/ui/segments/workflows/simulate/single-neuron/shared/runner.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/shared/runner.tsx
@@ -28,7 +28,6 @@ import type {
   ISingleNeuronSimulation,
   ISingleNeuronSynaptomeSimulation,
 } from '@/api/entitycore/types';
-import { SingleNeuronSimulationStatus } from '@/api/entitycore/types/shared/neuron-simulation';
 import { runSingleNeuronSimulation } from '@/api/small-scale-simulator';
 import { tryCatch } from '@/api/utils';
 import { config } from '@/config';
@@ -115,7 +114,6 @@ export const createSingleNeuronSimulationAtom = atom(
     const basePayload = {
       name,
       description,
-      status: SingleNeuronSimulationStatus.success,
       seed: experimentalSetupConfiguration.seed,
       injection_location: [singleNeuronSimulationConfig.current_injection.inject_to],
       recording_location: singleNeuronSimulationConfig.record_from.map(


### PR DESCRIPTION
It's hardcoded in the simulation entity creation and just displayed in the list view - so doesn't have a real use.

With the recent entitycore update the status has been also removed from the schema.