### PR TITLE
Fix sim result selection, simplify the logic

### DIFF
--- a/src/features/scan-config/components/file-viewer/index.tsx
+++ b/src/features/scan-config/components/file-viewer/index.tsx
@@ -19,16 +19,8 @@ type FileViewerProps = {
 
 export function FileViewer({ file, context, loading = false, className = '' }: FileViewerProps) {
   const [displayFile, setDisplayFile] = useState<File | undefined>(file);
-  const [isFilePreloading, setIsFilePreloading] = useState(false);
 
-  useEffect(() => {
-    if (file && file !== displayFile) {
-      setIsFilePreloading(true);
-    } else if (!file) {
-      setDisplayFile(undefined);
-      setIsFilePreloading(false);
-    }
-  }, [file, displayFile]);
+  const isFilePreloading = file && file !== displayFile;
 
   const fileName =
     displayFile?.assetPath?.split('/').at(-1) ?? displayFile?.asset.path.split('/').at(-1);
@@ -58,14 +50,7 @@ export function FileViewer({ file, context, loading = false, className = '' }: F
                 </div>
               }
             >
-              <FilePreloader
-                file={file}
-                context={context}
-                onLoaded={() => {
-                  setDisplayFile(file);
-                  setIsFilePreloading(false);
-                }}
-              />
+              <FilePreloader file={file} context={context} onLoaded={() => setDisplayFile(file)} />
             </Suspense>
           </div>
         )}

--- a/src/features/scan-config/components/simulation-files/index.tsx
+++ b/src/features/scan-config/components/simulation-files/index.tsx
@@ -70,7 +70,9 @@ export function SimulationFiles({
     );
 
     const voltageReportFile = outputFiles.find(
-      (file) => file.asset.label === AssetLabel.voltage_report
+      (file) =>
+        file.asset.label === AssetLabel.voltage_report &&
+        file.asset.content_type === 'application/nwb'
     );
 
     if (!selectedFile) {


### PR DESCRIPTION
The logic to auto-select simulation results has got issues when the react compiler was enabled. This PR simplifies it as well as makes it follow the Rules of React to be react compiler compatible.

Also auto-selected format has been fixed to NWB.

Relates to [[Single neuron beta] DEV (and now in Staging) - not possible to see 'interactive details' of the simulation](https://github.com/openbraininstitute/prod-singlecell-simulation/issues/251).