### PR TITLE
make the plus sign white again

### DIFF
--- a/src/ui/segments/notebooks/table/ActionPopover.tsx
+++ b/src/ui/segments/notebooks/table/ActionPopover.tsx
@@ -218,7 +218,7 @@ export default function ActionPopover({ notebook, index }: ActionPopoverProps) {
           placement="bottomRight"
           arrow={false}
         >
-          <PlusOutlined className="bg-primary-8 rounded-full p-2 text-lg font-bold text-white shadow-md" />
+          <PlusOutlined className="bg-primary-8 rounded-full p-2 text-lg font-bold !text-white shadow-md" />
         </Popover>
       </div>
     </>


### PR DESCRIPTION
The plus sign in the notebook table was inheriting the color of the text of the td of the table, i.e blue. which makes it invisible.