### PR TITLE
Handle absence of sim results gracefully

### DIFF
--- a/src/features/scan-config/components/atoms/index.ts
+++ b/src/features/scan-config/components/atoms/index.ts
@@ -144,7 +144,7 @@ export const simResultBySimIdAtomFamily = readAtomFamilyWithExpiration(
       const execution = await get(simExecBySimIdAtomFamily({ simulationId, context }));
 
       if (!execution?.generated?.[0]) {
-        throw new Error('Simulation Result not found');
+        return null;
       }
 
       return getCircuitSimulationResult({ id: execution.generated[0].id, context });


### PR DESCRIPTION
This change solves a case where an absence of simulation result entity when a simulation marked as failed (due to failed config generation) was showing an error in UI (as stated in the [comment](https://github.com/openbraininstitute/prod-singlecell-simulation/issues/229#issuecomment-3852695174)).