### PR TITLE
specify imports order in biome and place style files at the end

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -80,7 +80,44 @@
     "enabled": true,
     "actions": {
       "source": {
-        "organizeImports": "on"
+        "organizeImports": {
+          "level": "on",
+          "options": {
+            "groups": [
+              ":PACKAGE:",
+              ":BLANK_LINE:",
+              {
+                "type": true,
+                "source": [":PACKAGE:"]
+              },
+              ":BLANK_LINE:",
+              {
+                "type": true,
+                "source": [
+                  "@/**",
+                  "!**/*.css",
+                  "!**/*.module.css",
+                  "!**/*.scss",
+                  "!**/*.module.scss",
+                  "!**/*.less"
+                ]
+              },
+              ":BLANK_LINE:",
+              ["@/**", "!**/*.css", "!**/*.scss", "!**/*.less"],
+              ":BLANK_LINE:",
+              ":PATH:",
+              ":BLANK_LINE:",
+              {
+                "type": true,
+                "source": [":PATH:"]
+              },
+              ":BLANK_LINE:",
+              "*.css",
+              "*.scss",
+              "*.less"
+            ]
+          }
+        }
       }
     }
   }

--- a/src/features/scan-config/components/left.tsx
+++ b/src/features/scan-config/components/left.tsx
@@ -1,8 +1,9 @@
 import { Fragment } from 'react';
+
 import type { IMEModel } from '@/api/entitycore/types';
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
+
 import { RootElement } from '@/features/scan-config/components/root-element';
-import styles from '@/features/scan-config/scan-config.module.css';
 import {
   type AtomsMap,
   type ConfigSchema,
@@ -10,9 +11,12 @@ import {
   type TabType,
 } from '@/features/scan-config/types';
 import { useAIConfig } from '@/services/ai-agent';
+
 import type { Config } from './components';
 import GenerateConfigButton from './generate-config-button';
 import { useValidateSchema } from './hooks';
+
+import styles from '@/features/scan-config/scan-config.module.css';
 
 export default function Left({
   schema,

--- a/src/features/scan-config/components/simulations.tsx
+++ b/src/features/scan-config/components/simulations.tsx
@@ -5,9 +5,10 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { match } from 'ts-pattern';
 
+import type { ICircuitSimulation } from '@/api/entitycore/types/entities/circuit-simulation';
+
 import { requestOfflineTokenConsent } from '@/api/auth-manager';
 import { CircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit';
-import type { ICircuitSimulation } from '@/api/entitycore/types/entities/circuit-simulation';
 import { EntitycoreExecutionStatus } from '@/api/entitycore/types/entities/execution';
 import ApiError from '@/api/error';
 import { runSimulation } from '@/api/launch-system';
@@ -23,7 +24,6 @@ import { FileViewer } from '@/features/scan-config/components/file-viewer';
 import { type File, SimulationFiles } from '@/features/scan-config/components/simulation-files';
 import { SimulationStatusBadge } from '@/features/scan-config/components/simulation-status';
 import errorRegistry from '@/features/scan-config/error-registry';
-import styles from '@/features/scan-config/scan-config.module.css';
 import { useLastTruthyValue } from '@/hooks/hooks';
 import { messages } from '@/i18n/en/simulation';
 import { useConsent } from '@/services/consent';
@@ -33,6 +33,8 @@ import { executionStatusColorMap } from '@/ui/segments/activity-execution/color-
 import { classNames } from '@/util/utils';
 import { getErrorMessage } from '@/utils/error';
 import { log } from '@/utils/logger';
+
+import styles from '@/features/scan-config/scan-config.module.css';
 
 const USER_CANCELLED = 'user_cancelled';
 
@@ -55,13 +57,19 @@ export default function SimulationsTab({
   const notification = useAppNotification();
   const { waitForConsent } = useConsent();
   const context = useMemo(() => ({ virtualLabId, projectId }), [projectId, virtualLabId]);
-  const simulationsAtom = simulationsByCampaignIdAtomFamily({ campaignId, context });
+  const simulationsAtom = simulationsByCampaignIdAtomFamily({
+    campaignId,
+    context,
+  });
   const simulations = useAtomValue(simulationsAtom);
 
   const modelAtom = modelAtomFamily({ id: simulations[0].entity_id, context });
   const model = useAtomValue(modelAtom);
 
-  const simExecStatusMapAtom = simExecStatusMapAtomFamily({ context, campaignId });
+  const simExecStatusMapAtom = simExecStatusMapAtomFamily({
+    context,
+    campaignId,
+  });
   const fetchRemoteSimExecStatuseMap = useSetAtom(
     simExecRemoteStatusMapAtomFamily({ campaignId, context })
   );
@@ -224,7 +232,9 @@ export default function SimulationsTab({
               if (msg.status !== 'done') return;
               const simulation = simulations.find((s) => s.id === simId);
               if (!simulation) return;
-              notification.success({ message: `Simulation ${simulation?.name} done` });
+              notification.success({
+                message: `Simulation ${simulation?.name} done`,
+              });
             })
             .otherwise(() => null);
         },

--- a/src/features/scan-config/index.tsx
+++ b/src/features/scan-config/index.tsx
@@ -2,7 +2,10 @@
 
 import { LoadingOutlined } from '@ant-design/icons';
 import { Suspense, useState } from 'react';
+
 import type { Config } from '@/features/scan-config/components/components';
+import type { TabType } from '@/features/scan-config/types';
+
 import { useConfigAtom } from '@/features/scan-config/components/hooks/config-atom';
 import {
   resetConfig,
@@ -11,15 +14,16 @@ import {
 } from '@/features/scan-config/components/hooks/schema';
 import ModelPreview from '@/features/scan-config/components/model-preview';
 import TabsSelector from '@/features/scan-config/components/tabs-selector';
-import styles from '@/features/scan-config/scan-config.module.css';
-import type { TabType } from '@/features/scan-config/types';
 import { useAgentState, useAIConfig } from '@/services/ai-agent';
 import { ButtonCopyId } from '@/ui/molecules/button-copy-id';
 import { cn } from '@/utils/css-class';
+
 import { useEntries, useModel, useSchemaName } from './components/hooks';
 import Left from './components/left';
 import Middle from './components/middle';
 import SimulationsTab from './components/simulations';
+
+import styles from '@/features/scan-config/scan-config.module.css';
 
 export default function ScanConfiguration({
   modelId,
@@ -50,7 +54,10 @@ export default function ScanConfiguration({
   const [isEditingKey, setIsEditingKey] = useState(false);
   const [newKey, setNewKey] = useState('');
 
-  const { model } = useModel({ id: modelId, context: { virtualLabId, projectId } });
+  const { model } = useModel({
+    id: modelId,
+    context: { virtualLabId, projectId },
+  });
 
   const schemaName = useSchemaName({ model });
   const schema = useObioneJsonSchema(schemaName);


### PR DESCRIPTION
biome goes top→down and stops at the first group that matches the order in biome.json, 
and with current config, sometimes biome cann't distinguish between package/path-aliases imports