### PR TITLE
fix image not being displayed for private project in simulation designer

### DIFF
--- a/src/features/scan-config/components/hooks/circuit.ts
+++ b/src/features/scan-config/components/hooks/circuit.ts
@@ -32,6 +32,7 @@ export function useCircuitImageURL(circuitId: string) {
       }
       try {
         const resp = await downloadAsset({
+          ctx: context,
           entityType: EntityTypeDict.Circuit,
           entityId: circuit.id,
           id: asset.id,
@@ -50,7 +51,7 @@ export function useCircuitImageURL(circuitId: string) {
       }
     };
     action();
-  }, [circuit, circuitId, error]);
+  }, [circuit, circuitId, context, error]);
 
   return url;
 }


### PR DESCRIPTION
this fixes https://github.com/openbraininstitute/prod-circuit-simulation/issues/116

project-id was not passed as a header.