### PR TITLE
Conditionally disable analytics with a cookie

### DIFF
--- a/src/components/Matomo/index.tsx
+++ b/src/components/Matomo/index.tsx
@@ -1,10 +1,15 @@
 'use client';
 
-import { Suspense, useEffect, useState } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
+import { Suspense, useEffect, useState } from 'react';
 
-import { init, push } from '@/util/matomo';
 import { useConfig } from '@/config';
+import { init, push } from '@/util/matomo';
+
+const DISABLE_ANALYTICS_COOKIE_NAME = 'disable_analytics';
+
+const hasDisableCookie = () =>
+  typeof document !== 'undefined' && document.cookie.includes(`${DISABLE_ANALYTICS_COOKIE_NAME}=1`);
 
 function Matomo() {
   const config = useConfig();
@@ -17,27 +22,30 @@ function Matomo() {
 
   const searchParamsString = searchParams?.toString();
 
+  const isAnalyticsDisabled =
+    hasDisableCookie() || !MATOMO_URL || !MATOMO_SITE_ID || !MATOMO_CDN_URL;
+
   useEffect(() => {
-    if (MATOMO_URL && MATOMO_SITE_ID && MATOMO_CDN_URL && !initialized) {
-      init({
-        url: MATOMO_URL,
-        cdnUrl: MATOMO_CDN_URL,
-        siteId: MATOMO_SITE_ID,
-        disableCookies: true,
-      });
-    }
+    if (isAnalyticsDisabled || initialized) return;
+
+    init({
+      url: MATOMO_URL,
+      cdnUrl: MATOMO_CDN_URL,
+      siteId: MATOMO_SITE_ID,
+      disableCookies: true,
+    });
 
     return () => {
       setInitialized(true);
     };
-  }, [initialized, setInitialized, MATOMO_URL, MATOMO_CDN_URL, MATOMO_SITE_ID]);
+  }, [initialized, MATOMO_URL, MATOMO_CDN_URL, MATOMO_SITE_ID, isAnalyticsDisabled]);
 
   useEffect(() => {
-    if (!pathname) return;
+    if (isAnalyticsDisabled || !pathname) return;
     const url = `${pathname}${searchParamsString ? '?' + decodeURIComponent(searchParamsString) : ''}`;
     push(['setCustomUrl', url]);
     push(['trackPageView']);
-  }, [pathname, searchParamsString]);
+  }, [pathname, searchParamsString, isAnalyticsDisabled]);
 
   return null;
 }


### PR DESCRIPTION
When Selenium tests are run in production any impact on analytics is unwanted.
This PR introduces additional logic to disable analytics when a `disable_analytics` cookie is set to `1`.

FYI, @ayimaok 