### PR TITLE
Preview deployments: while sanitising branch name, replace dots with hyphens

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           BRANCH_NAME="${{ github.head_ref }}"
           DOMAIN_SAFE_BRANCH="${BRANCH_NAME//\//-}"
+          DOMAIN_SAFE_BRANCH="${DOMAIN_SAFE_BRANCH//./-}"
           echo "branch-name=$BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "domain-safe-branch=$DOMAIN_SAFE_BRANCH" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
To make sure the preview link is correct (matches Amplify's behaviour), e.g.: `upgrade-to-1.0.0` becomes `upgrade-to-1-0-0.preview.xxx.yyy`