### PR TITLE
Settings for Atlas viewer only in debug mode

### DIFF
--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/brain-atlas-viewer-gltf.tsx
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/brain-atlas-viewer-gltf.tsx
@@ -1,12 +1,11 @@
-import React from 'react';
 import { CameraFilled } from '@ant-design/icons';
+import React from 'react';
 
-import { usePainter, useVisibleRegions } from './hooks';
-// Temporary disabled
-// import { Settings } from './settings/settings';
-
-import { classNames } from '@/util/utils';
 import { useAccessToken } from '@/hooks/useAccessToken';
+import { classNames } from '@/util/utils';
+
+import { useAtlasViewerSettingsValues, usePainter, useVisibleRegions } from './hooks';
+import { Settings } from './settings/settings';
 
 import styles from './brain-atlas-viewer-gltf.module.css';
 
@@ -20,8 +19,7 @@ export function BrainAtlasViewerGltf({ className, dataKey, onLoading }: BrainAtl
   const [showResetCamera, setShowResetCamera] = React.useState(false);
   const accessToken = useAccessToken();
   const painter = usePainter();
-  // Temporary disabled
-  // const [values, setValues] = useAtlasViewerSettingsValues(painter);
+  const [values, setValues] = useAtlasViewerSettingsValues(painter);
   const { region, regions } = useVisibleRegions(dataKey);
   React.useEffect(() => {
     if (accessToken) {
@@ -57,10 +55,7 @@ export function BrainAtlasViewerGltf({ className, dataKey, onLoading }: BrainAtl
           <CameraFilled /> <div>Reset camera</div>
         </button>
       </header>
-      {/*
-      We disable this feature for now (dec 11th, 2025) until we agree
-      on settings ranges.
-      <Settings values={values} onChange={setValues} /> */}
+      <Settings values={values} onChange={setValues} />
     </div>
   );
 }

--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/hooks.tsx
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/hooks.tsx
@@ -1,24 +1,26 @@
 /* eslint-disable no-param-reassign */
-import React from 'react';
+
+import { TgdColor, TgdVec4 } from '@tolokoban/tgd';
 import compact from 'es-toolkit/compat/compact';
 import find from 'es-toolkit/compat/find';
 import { useAtom, useAtomValue } from 'jotai';
 import { atomWithStorage, unwrap } from 'jotai/utils';
-import { TgdColor, TgdVec4 } from '@tolokoban/tgd';
+import React from 'react';
 
-import { brainRegionAtlasAtom } from '../context';
-import { Painter } from './painter';
-import { SettingsDefinitions } from './settings';
-import { VisibleRegion } from './types';
-
+import { useAppNotification } from '@/components/notification';
 import {
   brainRegionBasicCellGroupsRegionsHierarchyAtom,
   brainRegionRootHierarchyAtom,
   ROOT_BRAIN_REGION_ID,
   useBrainRegionHierarchy,
 } from '@/features/brain-region-hierarchy/context';
-import { IBrainRegionHierarchy } from '@/api/entitycore/types/entities/brain-region';
-import { useAppNotification } from '@/components/notification';
+
+import { brainRegionAtlasAtom } from '../context';
+import { Painter } from './painter';
+
+import type { IBrainRegionHierarchy } from '@/api/entitycore/types/entities/brain-region';
+import type { SettingsDefinitions } from './settings';
+import type { VisibleRegion } from './types';
 
 export function usePainter(): Painter {
   const notif = useAppNotification();
@@ -53,8 +55,12 @@ export function useVisibleRegions(dataKey: string): {
     React.useMemo(() => unwrap(brainRegionBasicCellGroupsRegionsHierarchyAtom), [])
   );
   return React.useMemo(() => {
-    const rootBrainRegion = find(rootBrainRegions?.options, { value: ROOT_BRAIN_REGION_ID })?.data;
-    const currentBrainRegion = find(brainRegions?.options, { value: brainRegionNode.id })?.data;
+    const rootBrainRegion = find(rootBrainRegions?.options, {
+      value: ROOT_BRAIN_REGION_ID,
+    })?.data;
+    const currentBrainRegion = find(brainRegions?.options, {
+      value: brainRegionNode.id,
+    })?.data;
     const regions = compact(
       brainRegionNode ? [currentBrainRegion, rootBrainRegion] : [rootBrainRegion]
     );
@@ -85,6 +91,20 @@ export function getAtlasViewerDefaultSettings(): SettingsDefinitions {
       min: 0,
       max: 2,
       value: 1,
+    },
+    minSizeInPixels: {
+      label: 'Minimal size (pixel)',
+      value: 5,
+      min: 0,
+      max: 20,
+      step: 1,
+    },
+    radiusMultiplier: {
+      label: 'Radius multiplier',
+      value: 1,
+      min: 0.1,
+      max: 2,
+      step: 0.1,
     },
     specularExponent: {
       label: 'Specular exponent',

--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.tsx
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.tsx
@@ -111,11 +111,15 @@ export class Painter {
           const specularIntensity = uniforms.specularIntensity?.value ?? 0;
           const specularExponent = uniforms.specularExponent?.value ?? 10;
           const light = uniforms.light?.value ?? 1;
+          const minSizeInPixels = uniforms.minSizeInPixels?.value ?? 5;
+          const radiusMultiplier = uniforms.radiusMultiplier?.value ?? 1;
           pointCloudPainter.shadowIntensity = shadowIntensity;
           pointCloudPainter.shadowThickness = shadowThickness;
           pointCloudPainter.specularExponent = specularExponent;
           pointCloudPainter.specularIntensity = specularIntensity;
           pointCloudPainter.light = light;
+          pointCloudPainter.minSizeInPixels = minSizeInPixels;
+          pointCloudPainter.radiusMultiplier = radiusMultiplier;
         }
       });
       context.paint();

--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/settings/settings.tsx
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/settings/settings.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
+import { IconGear } from '@/components/ai-assistant/icons/gear';
+import { Button } from '@/ui/molecules/button';
+import { classNames } from '@/util/utils';
+
 import { getAtlasViewerDefaultSettings } from '../hooks';
 import Slider from './slider';
 
-import { classNames } from '@/util/utils';
-import { IconGear } from '@/components/ai-assistant/icons/gear';
-
-import { Button } from '@/ui/molecules/button';
 import styles from './settings.module.css';
 
 export type SettingsValues = Record<
@@ -48,6 +48,7 @@ export function Settings({ className, values, onChange }: SettingsProps) {
     const defaultSettings = getAtlasViewerDefaultSettings();
     onChange(defaultSettings);
   };
+  if (!globalThis.localStorage.getItem('debug:atlas-viewer')) return;
 
   return (
     <div className={classNames(className, styles.settings, show ? styles.show : styles.hide)}>

--- a/src/ui/segments/workflows/simulate/single-neuron/shared/steps/webgl-neuron-selector/painter/painters/synapses.ts
+++ b/src/ui/segments/workflows/simulate/single-neuron/shared/steps/webgl-neuron-selector/painter/painters/synapses.ts
@@ -1,7 +1,7 @@
 import {
-  TgdContext,
-  TgdPainterPointsCloud,
+  type TgdContext,
   TgdPainterGroup,
+  TgdPainterPointsCloud,
   TgdTexture2D,
   tgdCanvasCreateFill,
 } from '@tolokoban/tgd';


### PR DESCRIPTION
The settings that allow to tweak the look of the altas meshes and points clouds are only shown when the local storage item `debug:atlas-viewer` exists and is not empty.

<img width="271" height="154" alt="image" src="https://github.com/user-attachments/assets/2ddde0ca-e8fb-49eb-9147-81c683a46025" />

<img width="927" height="545" alt="image" src="https://github.com/user-attachments/assets/67f0af67-d408-4f6d-ba35-fdadcf185245" />
