### PR TITLE
create universal cell morphology to be used when no filter needed

### DIFF
--- a/src/api/entitycore/types/extended-entity-type.ts
+++ b/src/api/entitycore/types/extended-entity-type.ts
@@ -20,6 +20,7 @@ export const ExtendedEntitiesTypeDict = {
   NGVUnit: 'ngv_unit', // this is temporary
   MEModelWithSynapses: 'me_model_with_synapses',
   ComputationallySynthesizedCellMorphology: 'computationally_synthesized_cell_morphology',
+  UniversalCellMorphology: 'universal_cell_morphology',
 } as const;
 
 export type TExtendedEntitiesTypeDict =

--- a/src/entity-configuration/definitions/view-defs/experimental/index.ts
+++ b/src/entity-configuration/definitions/view-defs/experimental/index.ts
@@ -1,15 +1,18 @@
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import { viewDefForCellMorphology } from '@/entity-configuration/definitions/view-defs/experimental/cell-morphology';
+import { viewDefForElectricalCellRecording } from '@/entity-configuration/definitions/view-defs/experimental/electrical-cell-recording';
+import { viewDefForEMCellMesh } from '@/entity-configuration/definitions/view-defs/experimental/em-cell-mesh';
+import { viewDefForExperimentalBoutonDensity } from '@/entity-configuration/definitions/view-defs/experimental/experimental-bouton-density';
+import { viewDefForExperimentalNeuronDensity } from '@/entity-configuration/definitions/view-defs/experimental/experimental-neuron-density';
+import { viewDefForExperimentalSynapsesPerConnection } from '@/entity-configuration/definitions/view-defs/experimental/experimental-synapses-per-connection';
+import { viewDefForIonChannelRecording } from '@/entity-configuration/definitions/view-defs/experimental/ion-channel-recording';
+import { viewDefForCellMorphology as universalViewDefForCellMorphology } from '@/entity-configuration/definitions/view-defs/experimental/universal-cell-morphology';
+
 import type { ViewDefinitionConfig } from '@/entity-configuration/definitions/view-defs/types';
-import { viewDefForCellMorphology } from './cell-morphology';
-import { viewDefForElectricalCellRecording } from './electrical-cell-recording';
-import { viewDefForEMCellMesh } from './em-cell-mesh';
-import { viewDefForExperimentalBoutonDensity } from './experimental-bouton-density';
-import { viewDefForExperimentalNeuronDensity } from './experimental-neuron-density';
-import { viewDefForExperimentalSynapsesPerConnection } from './experimental-synapses-per-connection';
-import { viewDefForIonChannelRecording } from './ion-channel-recording';
 
 export const ViewsDefinition: { [key: string]: ViewDefinitionConfig } = {
   [ExtendedEntitiesTypeDict.CellMorphology]: viewDefForCellMorphology,
+  [ExtendedEntitiesTypeDict.UniversalCellMorphology]: universalViewDefForCellMorphology,
   [ExtendedEntitiesTypeDict.ElectricalCellRecording]: viewDefForElectricalCellRecording,
   [ExtendedEntitiesTypeDict.IonChannelRecording]: viewDefForIonChannelRecording,
   [ExtendedEntitiesTypeDict.ExperimentalNeuronDensity]: viewDefForExperimentalNeuronDensity,

--- a/src/entity-configuration/definitions/view-defs/experimental/universal-cell-morphology.ts
+++ b/src/entity-configuration/definitions/view-defs/experimental/universal-cell-morphology.ts
@@ -1,0 +1,1 @@
+export * from './cell-morphology';

--- a/src/entity-configuration/domain/experimental/universal-cell-morphology.ts
+++ b/src/entity-configuration/domain/experimental/universal-cell-morphology.ts
@@ -1,0 +1,42 @@
+import {
+  createCellMorphology,
+  deleteCellMorphology,
+  getCellMorphologies,
+  getCellMorphology,
+} from '@/api/entitycore/queries/experimental/cell-morphology';
+import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import { CellMorphology as CellMorphologyConfig } from '@/entity-configuration/domain/experimental/cell-morphology';
+
+import type {
+  ICellMorphology,
+  ICellMorphologyExpanded,
+} from '@/api/entitycore/types/entities/cell-morphology';
+import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
+
+export const UniversalCellMorphology: EntityCoreTypeConfig<
+  ICellMorphology | ICellMorphologyExpanded
+> = {
+  ...CellMorphologyConfig,
+  extendedType: ExtendedEntitiesTypeDict.UniversalCellMorphology,
+  api: {
+    config: {
+      allowedFacets: true,
+      ilikeSearchEnabled: true,
+    },
+    query: {
+      list: (...params) => {
+        return getCellMorphologies({
+          ...params,
+          context: params[0].context,
+          withFacets: params[0].withFacets,
+          filters: {
+            ...params[0].filters,
+          },
+        });
+      },
+      one: getCellMorphology,
+      delete: deleteCellMorphology,
+      create: createCellMorphology,
+    },
+  },
+} as const;

--- a/src/entity-configuration/domain/index.ts
+++ b/src/entity-configuration/domain/index.ts
@@ -5,14 +5,15 @@ import { EmCellMesh } from '@/entity-configuration/domain/experimental/em-cell-m
 import { IonChannelRecording } from '@/entity-configuration/domain/experimental/ion-channel-recording';
 import { NeuronDensity } from '@/entity-configuration/domain/experimental/neuron-density';
 import { SynapsesPerConnection } from '@/entity-configuration/domain/experimental/synapses-per-connection';
+import { UniversalCellMorphology } from '@/entity-configuration/domain/experimental/universal-cell-morphology';
 import { CircuitExtractionCampaign } from '@/entity-configuration/domain/extraction/extraction-campaign';
 import { Circuit } from '@/entity-configuration/domain/model/circuit';
+import { ComputationallySynthesizedCellMorphology } from '@/entity-configuration/domain/model/computationally-synthesized-morphology';
 import { Emodel } from '@/entity-configuration/domain/model/e-model';
 import { IonChannelModel } from '@/entity-configuration/domain/model/ion-channel-model';
 import { MEmodel } from '@/entity-configuration/domain/model/me-model';
 import { MEModelCircuit } from '@/entity-configuration/domain/model/me-model-circuit';
 import { MEModelWithSynapsesCircuit } from '@/entity-configuration/domain/model/me-model-with-synapses';
-import { ComputationallySynthesizedCellMorphology } from '@/entity-configuration/domain/model/computationally-synthesized-morphology';
 import { Microcircuit } from '@/entity-configuration/domain/model/mirocircuit';
 import { PairedNeuronCircuit } from '@/entity-configuration/domain/model/paired-neurons';
 import { SingleNeuronCircuit } from '@/entity-configuration/domain/model/single-neuron-circuit';
@@ -31,6 +32,10 @@ import { SingeNeuronCircuitSimulation } from '@/entity-configuration/domain/simu
 import { SmallMicrocircuitSimulation } from '@/entity-configuration/domain/simulation/small-microcircuit-simulation';
 
 import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
+
+export const UniversalTypesCoreConfiguration = {
+  UniversalCellMorphology,
+} as const;
 
 export const EntityCoreExperimentalConfiguration = {
   CellMorphology,
@@ -73,6 +78,7 @@ const EntityCoreExtractionConfiguration = {
 };
 
 export const EntityCoreConfiguration = {
+  ...UniversalTypesCoreConfiguration,
   ...EntityCoreExperimentalConfiguration,
   ...EntityCoreModelConfiguration,
   ...EntityCoreSimulationConfiguration,

--- a/src/entity-configuration/domain/model/circuit.ts
+++ b/src/entity-configuration/domain/model/circuit.ts
@@ -34,8 +34,8 @@ export const Circuit: EntityCoreTypeConfig<ICircuit> = {
           context: params[0].context,
           withFacets: params[0].withFacets,
           filters: {
-            ...circuitScaleFilter,
             ...params[0].filters,
+            ...circuitScaleFilter,
           },
         });
       },

--- a/src/features/views/listing/browse-entity.tsx
+++ b/src/features/views/listing/browse-entity.tsx
@@ -93,7 +93,7 @@ export function BrowseEntityScope({
   const { virtualLabId, projectId } = useWorkspace();
   const { mdv, setMdv } = useMiniDetailView();
   const { scope } = useScope({ defaultScope, clearOnDefault: false });
-
+  const scopeFilter = getWorkspaceScopeFilters(scope, { virtualLabId, projectId });
   const { dataKey } = makeDataKey({
     virtualLabId,
     projectId,
@@ -172,11 +172,11 @@ export function BrowseEntityScope({
       const filters = {
         ...queryParameters,
         ...extraQueryParams,
-        ...getWorkspaceScopeFilters(scope, { virtualLabId, projectId }),
+        ...scopeFilter,
       };
       return entity?.api?.query.list?.({
-        withFacets: true,
         filters,
+        withFacets: true,
         context: workspace,
       });
     },

--- a/src/ui/segments/workflows/build/memodel/m-model.tsx
+++ b/src/ui/segments/workflows/build/memodel/m-model.tsx
@@ -2,12 +2,11 @@
 
 import { ReloadOutlined } from '@ant-design/icons';
 import { Image } from 'antd';
-import kebabCase from 'es-toolkit/compat/kebabCase';
-
+import { kebabCase } from 'es-toolkit/compat';
 import { useRouter } from 'next/navigation';
+
 import { EntityTypeDict, type ICellMorphology } from '@/api/entitycore/types';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
-import type { EntityCoreResource } from '@/api/entitycore/types/shared/global';
 import { config } from '@/config';
 import { WorkspaceSection } from '@/constants';
 import {
@@ -23,6 +22,8 @@ import { Button } from '@/ui/molecules/button';
 import { label, useBuildMeModelSessionState } from '@/ui/segments/workflows/build/memodel/helpers';
 import { WorkflowScopeTabs } from '@/ui/segments/workflows/elements/scope-selector';
 import { cn } from '@/utils/css-class';
+
+import type { EntityCoreResource } from '@/api/entitycore/types/shared/global';
 
 type Props = {
   sessionId: string;
@@ -45,7 +46,7 @@ export function MModel({ sessionId }: Props) {
       section={WorkspaceSection.BuildWorkflow}
       requireMiniDetailView={false}
       classNames={{ container: 'max-h-full' }}
-      dataType={ExtendedEntitiesTypeDict.CellMorphology}
+      dataType={ExtendedEntitiesTypeDict.UniversalCellMorphology}
       miniViewProps={{ section: WorkspaceSection.BuildWorkflow }}
       allowDownload={false}
       allowDelete={false}


### PR DESCRIPTION
- as main entitycore types are growing, we have create sub-types under `extended-types-dictionnary`, keeping the main one is important when needed to use it rather the filtered one
- in this case `build —> me-model`, require to use the cell-morphology without filtering, so creating a universal extended type

this will maintain separation of concerns and keep things usable in different scenarios 