### PR TITLE
refactor: extended type was duplicated, keep only one source type

### DIFF
--- a/src/api/entitycore/queries/assets/index.ts
+++ b/src/api/entitycore/queries/assets/index.ts
@@ -1,11 +1,11 @@
-import kebabCase from 'es-toolkit/compat/kebabCase';
+import { kebabCase } from 'es-toolkit/compat';
 
-import { TEntityTypeDict } from '@/api/entitycore/types/entity-type';
-import { getEntityCoreContext } from '@/api/entitycore/utils';
-import { compactRecord } from '@/utils/dictionary';
 import { authApiClient } from '@/api/apiClient';
+import { getEntityCoreContext } from '@/api/entitycore/utils';
 import { config } from '@/config';
+import { compactRecord } from '@/utils/dictionary';
 
+import type { TEntityTypeDict } from '@/api/entitycore/types/entity-type';
 import type {
   AssetLabel,
   DirectoryListContent,
@@ -65,7 +65,7 @@ export async function getAsset({
 }
 
 export async function downloadAsset(params: {
-  ctx?: WorkspaceContext;
+  ctx?: WorkspaceContext | null;
   entityType: TEntityTypeDict;
   entityId: string;
   assetPath?: string;
@@ -105,7 +105,7 @@ export async function downloadAsset<T>({
   assetPath = '',
   signal,
 }: {
-  ctx?: WorkspaceContext;
+  ctx?: WorkspaceContext | null;
   entityType: TEntityTypeDict;
   entityId: string;
   assetPath?: string;
@@ -160,7 +160,9 @@ export async function createJsonAsset({
 }): Promise<IAsset> {
   const stringified = JSON.stringify(payload);
   const jsonBlob = new Blob([stringified], { type: 'application/json' });
-  const jsonFile = new File([jsonBlob], `${path}.json`, { type: 'application/json' });
+  const jsonFile = new File([jsonBlob], `${path}.json`, {
+    type: 'application/json',
+  });
   const formData = new FormData();
 
   if (jsonFile) formData.append('file', jsonFile);

--- a/src/api/entitycore/queries/experimental/cell-morphology.ts
+++ b/src/api/entitycore/queries/experimental/cell-morphology.ts
@@ -1,13 +1,14 @@
 import z from 'zod';
+
+import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
+
 import type {
   CellMorphologyFilter,
   ExpandCellMorphologyParm,
   ICellMorphology,
   ICellMorphologyExpanded,
 } from '@/api/entitycore/types/entities/cell-morphology';
-
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
-import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/cell-morphology';

--- a/src/api/entitycore/queries/general/entity.ts
+++ b/src/api/entitycore/queries/general/entity.ts
@@ -1,9 +1,10 @@
+import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
+import { compactRecord } from '@/utils/dictionary';
+
 import type { EntityCountResponse, IEntity } from '@/api/entitycore/types/entities/entity';
 import type { TEntityTypeWithBrainRegionDict } from '@/api/entitycore/types/entity-type';
 import type { BrainRegionHierarchyFilter } from '@/api/entitycore/types/shared/request';
-import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import type { WorkspaceContext } from '@/types/common';
-import { compactRecord } from '@/utils/dictionary';
 
 const baseUri = '/entity';
 

--- a/src/api/entitycore/utils.ts
+++ b/src/api/entitycore/utils.ts
@@ -1,8 +1,10 @@
 import { find, snakeCase } from 'es-toolkit/compat';
+
 import { authApiClient } from '@/api/apiClient';
+import { config as appConfig } from '@/config';
+
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { EntityCoreBaseAsset, IAsset } from '@/api/entitycore/types/shared/global';
-import { config as appConfig } from '@/config';
 import type { KebabCase } from '@/utils/type';
 
 export const getEntityCoreContext = (

--- a/src/app/app/entity/[id]/page.tsx
+++ b/src/app/app/entity/[id]/page.tsx
@@ -1,14 +1,14 @@
-import { redirect, notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 
-import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
-import { CircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit';
-import { getCircuit } from '@/api/entitycore/queries/model/circuit';
 import { getEntity } from '@/api/entitycore/queries/general/entity';
-import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
-import { resolveWorkspace } from '@/ui/segments/app-setup/helpers';
-import { getUserGroups } from '@/api/virtual-lab-svc/queries/user';
-import { EntityTypeDict, TEntityTypeDict } from '@/api/entitycore/types';
+import { getCircuit } from '@/api/entitycore/queries/model/circuit';
+import { EntityTypeDict, type TEntityTypeDict } from '@/api/entitycore/types';
+import { CircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit';
+import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { tryCatch } from '@/api/utils';
+import { getUserGroups } from '@/api/virtual-lab-svc/queries/user';
+import { resolveWorkspace } from '@/ui/segments/app-setup/helpers';
+import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
 
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { WorkspaceContext } from '@/types/common';
@@ -35,6 +35,7 @@ export default async function EntityDetail({ params }: { params: Promise<{ id: s
   const { id } = await params;
 
   const { data: entity, error: entityError } = await tryCatch(() => getEntity({ id }));
+
   if (!entity || entityError) notFound();
 
   let entityType: TExtendedEntitiesTypeDict = entity.type;

--- a/src/app/app/virtual-lab/[virtualLabId]/[projectId]/data/view/[type]/[id]/[section]/page.tsx
+++ b/src/app/app/virtual-lab/[virtualLabId]/[projectId]/data/view/[type]/[id]/[section]/page.tsx
@@ -6,8 +6,8 @@ import { getEntityByExtendedType } from '@/entity-configuration/domain/helpers';
 import { retrieveEntity } from '@/entity-configuration/domain/requests';
 import { detailPageSectionRenderer } from '@/features/details-page';
 
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { TDetailViewSectionDict } from '@/entity-configuration/definitions/types';
-import type { EntityCoreExtendedType } from '@/entity-configuration/domain/helpers';
 import type { ServerSideComponentProp, WorkspaceContext } from '@/types/common';
 
 export default async function Page({
@@ -19,13 +19,15 @@ export default async function Page({
   const { virtualLabId, projectId, section, type, id } = await params;
   const context = { virtualLabId, projectId };
 
-  const entityType = getEntityByExtendedType({ type: snakeCase(type) as EntityCoreExtendedType });
+  const entityType = getEntityByExtendedType({
+    type: snakeCase(type) as TExtendedEntitiesTypeDict,
+  });
 
   if (!entityType || !entityType.detailViewSections?.includes(section)) notFound();
 
   const { data: entity, error } = await tryCatch(
     retrieveEntity({
-      type: snakeCase(type) as EntityCoreExtendedType,
+      type: snakeCase(type) as TExtendedEntitiesTypeDict,
       ctx: context,
       id,
     })

--- a/src/app/app/virtual-lab/[virtualLabId]/[projectId]/data/view/[type]/[id]/layout.tsx
+++ b/src/app/app/virtual-lab/[virtualLabId]/[projectId]/data/view/[type]/[id]/layout.tsx
@@ -3,7 +3,7 @@ import { snakeCase } from 'es-toolkit/compat';
 import { DataViewLayout } from '@/ui/layouts/data-view-layout';
 
 import type { ReactNode } from 'react';
-import type { EntityCoreExtendedType } from '@/entity-configuration/domain/helpers';
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { ServerSideComponentProp, WorkspaceContext } from '@/types/common';
 
 interface Params {
@@ -20,7 +20,7 @@ export default async function Layout({
   const awaitedParams = await params;
 
   const { virtualLabId, projectId, id } = awaitedParams;
-  const type = snakeCase(awaitedParams.type) as EntityCoreExtendedType;
+  const type = snakeCase(awaitedParams.type) as TExtendedEntitiesTypeDict;
 
   return (
     <DataViewLayout context={{ virtualLabId, projectId }} id={id} type={type}>

--- a/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/(data)/view/[type]/[id]/[section]/page.tsx
+++ b/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/(data)/view/[type]/[id]/[section]/page.tsx
@@ -6,8 +6,8 @@ import { getEntityByExtendedType } from '@/entity-configuration/domain/helpers';
 import { retrieveEntity } from '@/entity-configuration/domain/requests';
 import { detailPageSectionRenderer } from '@/features/details-page';
 
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { TDetailViewSectionDict } from '@/entity-configuration/definitions/types';
-import type { EntityCoreExtendedType } from '@/entity-configuration/domain/helpers';
 import type { ServerSideComponentProp, WorkspaceContext } from '@/types/common';
 
 export default async function Page({
@@ -19,7 +19,9 @@ export default async function Page({
   const { virtualLabId, projectId, section, type, id } = await params;
   const context = { virtualLabId, projectId };
 
-  const entityType = getEntityByExtendedType({ type: snakeCase(type) as EntityCoreExtendedType });
+  const entityType = getEntityByExtendedType({
+    type: snakeCase(type) as TExtendedEntitiesTypeDict,
+  });
 
   if (!entityType || !entityType.detailViewSections?.includes(section)) {
     return notFound();
@@ -27,7 +29,7 @@ export default async function Page({
 
   const { data: entity, error } = await tryCatch(
     retrieveEntity({
-      type: snakeCase(type) as EntityCoreExtendedType,
+      type: snakeCase(type) as TExtendedEntitiesTypeDict,
       ctx: context,
       id,
     })

--- a/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/(data)/view/[type]/[id]/layout.tsx
+++ b/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/(data)/view/[type]/[id]/layout.tsx
@@ -1,10 +1,10 @@
 import { snakeCase } from 'es-toolkit/compat';
-import { ReactNode } from 'react';
 
-import { EntityCoreExtendedType } from '@/entity-configuration/domain/helpers';
 import { DataViewLayout } from '@/ui/layouts/data-view-layout';
 
-import type { WorkspaceContext, ServerSideComponentProp } from '@/types/common';
+import type { ReactNode } from 'react';
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import type { ServerSideComponentProp, WorkspaceContext } from '@/types/common';
 
 interface Params {
   id: string;
@@ -20,7 +20,7 @@ export default async function Layout({
   const awaitedParams = await params;
 
   const { virtualLabId, projectId, id } = awaitedParams;
-  const type = snakeCase(awaitedParams.type) as EntityCoreExtendedType;
+  const type = snakeCase(awaitedParams.type) as TExtendedEntitiesTypeDict;
   return (
     <DataViewLayout context={{ virtualLabId, projectId }} id={id} type={type}>
       {children}

--- a/src/entity-configuration/domain/helpers.ts
+++ b/src/entity-configuration/domain/helpers.ts
@@ -3,22 +3,20 @@ import { filter, find, set } from 'es-toolkit/compat';
 import { EntityCoreConfiguration } from '@/entity-configuration/domain';
 
 import type { TEntityTypeDict } from '@/api/entitycore/types';
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { EntityCoreIdentifiable } from '@/api/entitycore/types/shared/global';
 import type { TEntityTypeGroup } from '@/entity-configuration/domain/group';
 import type { EntitySlugValue } from '@/entity-configuration/domain/slug';
 import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
 
-export type EntityCoreExtendedType =
-  (typeof EntityCoreConfiguration)[keyof typeof EntityCoreConfiguration]['extendedType'];
-
-export const circuitTypes: EntityCoreExtendedType[] = [
+export const circuitTypes: TExtendedEntitiesTypeDict[] = [
   'circuit',
   'small_micro_circuit',
   'paired_neuron_circuit',
   'micro_circuit',
 ];
 
-export const getEntityByExtendedType = ({ type }: { type?: EntityCoreExtendedType }) =>
+export const getEntityByExtendedType = ({ type }: { type?: TExtendedEntitiesTypeDict }) =>
   find(EntityCoreConfiguration, { extendedType: type });
 
 export type TEntityByExtendedTypeConfig = ReturnType<typeof getEntityByExtendedType>;

--- a/src/entity-configuration/domain/requests.ts
+++ b/src/entity-configuration/domain/requests.ts
@@ -1,7 +1,6 @@
-import {
-  EntityCoreExtendedType,
-  getEntityByExtendedType,
-} from '@/entity-configuration/domain/helpers';
+import { getEntityByExtendedType } from '@/entity-configuration/domain/helpers';
+
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { AwaitedType, WorkspaceContext } from '@/types/common';
 
 export async function retrieveEntity({
@@ -9,7 +8,7 @@ export async function retrieveEntity({
   id,
   ctx,
 }: {
-  type: EntityCoreExtendedType;
+  type: TExtendedEntitiesTypeDict;
   id: string;
   ctx: WorkspaceContext;
 }) {

--- a/src/entity-configuration/domain/simulation/memodel-circuit-simulation.ts
+++ b/src/entity-configuration/domain/simulation/memodel-circuit-simulation.ts
@@ -1,7 +1,8 @@
-import flatMap from 'es-toolkit/compat/flatMap';
-import keyBy from 'es-toolkit/compat/keyBy';
+import { flatMap, keyBy } from 'es-toolkit/compat';
+
 import { getMEModels } from '@/api/entitycore/queries';
 import { downloadAsset } from '@/api/entitycore/queries/assets';
+import { getCircuit } from '@/api/entitycore/queries/model/circuit';
 import { getCircuitSimulations } from '@/api/entitycore/queries/simulation/circuit-simulation';
 import {
   createSimulationCampaign,
@@ -20,10 +21,12 @@ import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity
 import { AssetLabel } from '@/api/entitycore/types/shared/global';
 import { getAssetElement } from '@/api/entitycore/utils';
 import { EntityTypeGroup } from '@/entity-configuration/domain/group';
+import { getExtendedSimMap } from '@/entity-configuration/domain/simulation/utils';
 import { EntitySlug } from '@/entity-configuration/domain/slug';
+
+import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
 import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
 import type { WorkspaceContext } from '@/types/common';
-import { getExtendedSimMap } from './utils';
 
 const ENTITY_TYPE = SimulationCampaignEntityTypeDict.memodel;
 
@@ -65,7 +68,6 @@ async function resolveSimulationCampaigns({
   context: WorkspaceContext | undefined;
   filters?: Partial<ICircuitSimulationCampaignFilter>;
 }) {
-  // eslint-disable-next-line no-param-reassign
   filters = discardBrainRegionQueryParams(filters);
   const source = await getCircuitSimulationCampaigns({
     context,
@@ -132,7 +134,10 @@ export async function resolveSimulationByCampaignId({
     throw new Error(`No campaign with id ${id} found`);
   }
 
-  const source = await getCircuitSimulations({ context, filters: { simulation_campaign_id: id } });
+  const source = await getCircuitSimulations({
+    context,
+    filters: { simulation_campaign_id: id },
+  });
 
   const simulation = source.data.at(0);
   const assets = campaign?.assets ?? [];
@@ -142,6 +147,9 @@ export async function resolveSimulationByCampaignId({
   });
 
   if (!configAsset) throw Error('No campaign config asset found');
+
+  let entity: ICircuit | null = null;
+  if (simulation?.entity_id) entity = await getCircuit({ id: simulation?.entity_id, context });
 
   const rawConfig = await downloadAsset({
     entityId: campaign.id,
@@ -155,14 +163,23 @@ export async function resolveSimulationByCampaignId({
   return {
     campaign,
     simulation,
+    entity,
     config,
   };
 }
 
-export const MEModelCircuitSimulation: EntityCoreTypeConfig<ICircuitSimulationCampaign> = {
+type TResolvedSimulationByCampaign = Awaited<ReturnType<typeof resolveSimulationByCampaignId>>;
+type TResolvedSimulationByCampaigns = Awaited<ReturnType<typeof resolveSimulationCampaigns>>;
+
+export const MEModelCircuitSimulation: EntityCoreTypeConfig<
+  ICircuitSimulationCampaign,
+  TResolvedSimulationByCampaign,
+  TResolvedSimulationByCampaigns
+> = {
   group: EntityTypeGroup.Simulations,
   title: 'Single neuron (beta)',
   extendedType: ExtendedEntitiesTypeDict.MemodelCircuitSimulation,
+  discriminator: { key: 'entity__type', value: [ENTITY_TYPE] },
   type: EntityTypeDict.SimulationCampaign,
   slug: EntitySlug.MEModelCircuitSimulation,
   api: {

--- a/src/entity-configuration/domain/simulation/microcircuit-simulation.ts
+++ b/src/entity-configuration/domain/simulation/microcircuit-simulation.ts
@@ -1,5 +1,4 @@
-import flatMap from 'es-toolkit/compat/flatMap';
-import keyBy from 'es-toolkit/compat/keyBy';
+import { flatMap, keyBy } from 'es-toolkit/compat';
 
 import { downloadAsset } from '@/api/entitycore/queries/assets';
 import { getCircuits } from '@/api/entitycore/queries/model/circuit';
@@ -11,23 +10,24 @@ import {
 } from '@/api/entitycore/queries/simulation/circuit-simulation-campaign';
 import { getCircuitSimulationExecutions } from '@/api/entitycore/queries/simulation/circuit-simulation-execution';
 import { discardBrainRegionQueryParams } from '@/api/entitycore/transformers';
-import type { ICircuitFilter } from '@/api/entitycore/types/entities/circuit';
 import { CircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit';
-import type {
-  ICircuitSimulationCampaign,
-  ICircuitSimulationCampaignFilter,
-} from '@/api/entitycore/types/entities/circuit-simulation-campaign';
 import { EntityTypeDict } from '@/api/entitycore/types/entity-type';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { AssetLabel } from '@/api/entitycore/types/shared/global';
 import { getAssetElement } from '@/api/entitycore/utils';
 import { DetailViewSectionsDict } from '@/entity-configuration/definitions/types';
 import { EntityTypeGroup } from '@/entity-configuration/domain/group';
+import { getExtendedSimMap } from '@/entity-configuration/domain/simulation/utils';
 import { EntitySlug } from '@/entity-configuration/domain/slug';
-import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
 import { microcircuitFlag } from '@/features/feature-flags';
+
+import type { ICircuitFilter } from '@/api/entitycore/types/entities/circuit';
+import type {
+  ICircuitSimulationCampaign,
+  ICircuitSimulationCampaignFilter,
+} from '@/api/entitycore/types/entities/circuit-simulation-campaign';
+import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
 import type { WorkspaceContext } from '@/types/common';
-import { getExtendedSimMap } from './utils';
 
 export async function resolveExecutions({
   context,
@@ -71,7 +71,6 @@ async function resolveSimulationCampaigns({
   filters?: Partial<ICircuitSimulationCampaignFilter>;
   circuitScaleFilter?: Partial<ICircuitFilter>;
 }) {
-  // eslint-disable-next-line no-param-reassign
   filters = discardBrainRegionQueryParams(filters);
   const source = await getCircuitSimulationCampaigns({
     context,
@@ -111,7 +110,10 @@ async function resolveSimulationCampaigns({
 
   const circuits = await getCircuits({
     context,
-    filters: { id__in: source.data.map((l) => l.entity_id), ...circuitScaleFilter },
+    filters: {
+      id__in: source.data.map((l) => l.entity_id),
+      ...circuitScaleFilter,
+    },
   });
   const circuitMap = keyBy(circuits.data, 'id');
   const result = enrichedData.map((entity) => ({
@@ -139,7 +141,10 @@ export async function resolveSimulationByCampaignId({
     throw new Error(`No campaign with id ${id} found`);
   }
 
-  const source = await getCircuitSimulations({ context, filters: { simulation_campaign_id: id } });
+  const source = await getCircuitSimulations({
+    context,
+    filters: { simulation_campaign_id: id },
+  });
 
   const simulation = source.data.at(0);
   const assets = campaign?.assets ?? [];
@@ -165,12 +170,19 @@ export async function resolveSimulationByCampaignId({
     config,
   };
 }
+type TResolvedSimulationByCampaign = Awaited<ReturnType<typeof resolveSimulationByCampaignId>>;
+type TResolvedSimulationByCampaigns = Awaited<ReturnType<typeof resolveSimulationCampaigns>>;
 
-export const MicrocircuitSimulation: EntityCoreTypeConfig<ICircuitSimulationCampaign> = {
+export const MicrocircuitSimulation: EntityCoreTypeConfig<
+  ICircuitSimulationCampaign,
+  TResolvedSimulationByCampaign,
+  TResolvedSimulationByCampaigns
+> = {
   group: EntityTypeGroup.Simulations,
   title: 'Microcircuit',
   extendedType: ExtendedEntitiesTypeDict.MicrocircuitSimulation,
   type: EntityTypeDict.SimulationCampaign,
+  discriminator: { key: 'scale', value: [SCALE] },
   slug: EntitySlug.MicrocircuitSimulation,
   requiredFeatures: [microcircuitFlag.key],
   api: {
@@ -202,10 +214,6 @@ export const MicrocircuitSimulation: EntityCoreTypeConfig<ICircuitSimulationCamp
       create: createSimulationCampaign,
     },
     expandRow: async (record, _context) => record,
-  },
-  explore: {
-    basePrefix: 'simulate',
-    routePrefix: 'simulate',
   },
   asset: {
     extension: 'application/json',

--- a/src/entity-configuration/domain/simulation/paired-neurons-simulation.ts
+++ b/src/entity-configuration/domain/simulation/paired-neurons-simulation.ts
@@ -1,7 +1,7 @@
-import flatMap from 'es-toolkit/compat/flatMap';
-import keyBy from 'es-toolkit/compat/keyBy';
+import { flatMap, keyBy } from 'es-toolkit/compat';
+
 import { downloadAsset } from '@/api/entitycore/queries/assets';
-import { getCircuits } from '@/api/entitycore/queries/model/circuit';
+import { getCircuit, getCircuits } from '@/api/entitycore/queries/model/circuit';
 import { getCircuitSimulations } from '@/api/entitycore/queries/simulation/circuit-simulation';
 import {
   createSimulationCampaign,
@@ -9,12 +9,7 @@ import {
   getCircuitSimulationCampaigns,
 } from '@/api/entitycore/queries/simulation/circuit-simulation-campaign';
 import { discardBrainRegionQueryParams } from '@/api/entitycore/transformers';
-import type { ICircuitFilter } from '@/api/entitycore/types/entities/circuit';
 import { CircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit';
-import type {
-  ICircuitSimulationCampaign,
-  ICircuitSimulationCampaignFilter,
-} from '@/api/entitycore/types/entities/circuit-simulation-campaign';
 import { EntityTypeDict } from '@/api/entitycore/types/entity-type';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { AssetLabel } from '@/api/entitycore/types/shared/global';
@@ -22,10 +17,17 @@ import { getAssetElement } from '@/api/entitycore/utils';
 import { DetailViewSectionsDict } from '@/entity-configuration/definitions/types';
 import { EntityTypeGroup } from '@/entity-configuration/domain/group';
 import { EntitySlug } from '@/entity-configuration/domain/slug';
-import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
-import type { WorkspaceContext } from '@/types/common';
+
 import { resolveExecutions } from './small-microcircuit-simulation';
 import { getExtendedSimMap, migrateConfig } from './utils';
+
+import type { ICircuit, ICircuitFilter } from '@/api/entitycore/types/entities/circuit';
+import type {
+  ICircuitSimulationCampaign,
+  ICircuitSimulationCampaignFilter,
+} from '@/api/entitycore/types/entities/circuit-simulation-campaign';
+import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
+import type { WorkspaceContext } from '@/types/common';
 
 const SCALE = CircuitScaleDictionary.PairNeuron;
 
@@ -41,7 +43,6 @@ async function resolveSimulationCampaigns({
   filters?: Partial<ICircuitSimulationCampaignFilter>;
   circuitScaleFilter?: Partial<ICircuitFilter>;
 }) {
-  // eslint-disable-next-line no-param-reassign
   filters = discardBrainRegionQueryParams(filters);
 
   const source = await getCircuitSimulationCampaigns({
@@ -81,7 +82,10 @@ async function resolveSimulationCampaigns({
 
   const circuits = await getCircuits({
     context,
-    filters: { id__in: source.data.map((l) => l.entity_id), ...circuitScaleFilter },
+    filters: {
+      id__in: source.data.map((l) => l.entity_id),
+      ...circuitScaleFilter,
+    },
   });
   const circuitMap = keyBy(circuits.data, 'id');
   const result = enrichedData.map((entity) => ({
@@ -101,7 +105,7 @@ export async function resolveSimulationByCampaignId({
   context,
 }: {
   id: string;
-  context: WorkspaceContext | undefined;
+  context?: WorkspaceContext | undefined | null;
 }) {
   const campaign = await getCircuitSimulationCampaign({ id, context });
 
@@ -109,7 +113,10 @@ export async function resolveSimulationByCampaignId({
     throw new Error(`No campaign with id ${id} found`);
   }
 
-  const source = await getCircuitSimulations({ context, filters: { simulation_campaign_id: id } });
+  const source = await getCircuitSimulations({
+    context,
+    filters: { simulation_campaign_id: id },
+  });
 
   const simulation = source.data.at(0);
   const assets = campaign?.assets ?? [];
@@ -119,6 +126,9 @@ export async function resolveSimulationByCampaignId({
   });
 
   if (!configAsset) throw Error('No campaign config asset found');
+
+  let entity: ICircuit | null = null;
+  if (simulation?.entity_id) entity = await getCircuit({ id: simulation?.entity_id, context });
 
   const rawConfig = await downloadAsset({
     entityId: campaign.id,
@@ -134,14 +144,23 @@ export async function resolveSimulationByCampaignId({
   return {
     campaign,
     simulation,
+    entity,
     config,
   };
 }
 
-export const PairedNeuronCircuitSimulation: EntityCoreTypeConfig<ICircuitSimulationCampaign> = {
+type TResolvedSimulationByCampaign = Awaited<ReturnType<typeof resolveSimulationByCampaignId>>;
+type TResolvedSimulationByCampaigns = Awaited<ReturnType<typeof resolveSimulationCampaigns>>;
+
+export const PairedNeuronCircuitSimulation: EntityCoreTypeConfig<
+  ICircuitSimulationCampaign,
+  TResolvedSimulationByCampaign,
+  TResolvedSimulationByCampaigns
+> = {
   group: EntityTypeGroup.Simulations,
   title: 'Paired neurons (beta)',
   extendedType: ExtendedEntitiesTypeDict.PairedNeuronCircuitSimulation,
+  discriminator: { key: 'scale', value: [SCALE] },
   type: EntityTypeDict.SimulationCampaign,
   slug: EntitySlug.PairedNeuronCircuitSimulation,
   api: {
@@ -170,6 +189,7 @@ export const PairedNeuronCircuitSimulation: EntityCoreTypeConfig<ICircuitSimulat
           },
         }),
       one: getCircuitSimulationCampaign,
+      resolve: resolveSimulationByCampaignId,
       create: createSimulationCampaign,
     },
     expandRow: async (record, _context) => record,

--- a/src/entity-configuration/domain/simulation/simulation-campaign.ts
+++ b/src/entity-configuration/domain/simulation/simulation-campaign.ts
@@ -10,7 +10,7 @@ import {
 } from '@/api/entitycore/queries/simulation/circuit-simulation-campaign';
 import { getCircuitSimulationExecutions } from '@/api/entitycore/queries/simulation/circuit-simulation-execution';
 import { discardBrainRegionQueryParams } from '@/api/entitycore/transformers';
-import { CircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit';
+import { CircuitScaleDictionary, type ICircuit } from '@/api/entitycore/types/entities/circuit';
 import { EntityTypeDict } from '@/api/entitycore/types/entity-type';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { ActivityStatus } from '@/api/entitycore/types/shared/activity';
@@ -102,9 +102,11 @@ async function resolveSimulationCampaigns({
 export async function resolveSimulationByCampaignId({
   id,
   context,
+  populate = ['entity', 'config'],
 }: {
   id: string;
-  context: WorkspaceContext | undefined;
+  context?: WorkspaceContext | null;
+  populate?: Array<string>;
 }) {
   const campaign = await getCircuitSimulationCampaign({ id, context });
 
@@ -133,6 +135,7 @@ export async function resolveSimulationByCampaignId({
       return {
         campaign,
         simulation,
+        entity: circuit,
         config: null,
       };
     }
@@ -140,20 +143,28 @@ export async function resolveSimulationByCampaignId({
     throw Error('No campaign config asset found');
   }
 
-  const rawConfig = await downloadAsset({
-    entityId: campaign?.id,
-    entityType: EntityTypeDict.SimulationCampaign,
-    id: configAsset?.id,
-    ctx: context,
-    asRawResponse: true,
-  });
-  const config = await rawConfig.json();
+  let config = null;
+  let entity: ICircuit | null = null;
 
-  migrateConfig(config);
+  if (simulation?.entity_id && populate.includes('entity'))
+    entity = await getCircuit({ id: simulation?.entity_id, context });
+
+  if (populate.includes('config')) {
+    const rawConfig = await downloadAsset({
+      entityId: campaign?.id,
+      entityType: EntityTypeDict.SimulationCampaign,
+      id: configAsset?.id,
+      ctx: context,
+      asRawResponse: true,
+    });
+    config = await rawConfig.json();
+    migrateConfig(config);
+  }
 
   return {
     campaign,
     simulation,
+    entity,
     config,
   };
 }
@@ -186,7 +197,14 @@ export function getStatusCountMap(simCampaign: ICircuitSimulationCampaign) {
 
 export type ExtendedCampaignsType = AwaitedType<ReturnType<typeof resolveSimulationCampaigns>>;
 
-export const SimulationCampaign: EntityCoreTypeConfig<ICircuitSimulationCampaign> = {
+type TResolvedSimulationByCampaign = Awaited<ReturnType<typeof resolveSimulationByCampaignId>>;
+type TResolvedSimulationByCampaigns = Awaited<ReturnType<typeof resolveSimulationCampaigns>>;
+
+export const SimulationCampaign: EntityCoreTypeConfig<
+  ICircuitSimulationCampaign,
+  TResolvedSimulationByCampaign,
+  TResolvedSimulationByCampaigns
+> = {
   group: EntityTypeGroup.Simulations,
   title: 'Simulation campaign',
   extendedType: ExtendedEntitiesTypeDict.SimulationCampaign,
@@ -201,6 +219,7 @@ export const SimulationCampaign: EntityCoreTypeConfig<ICircuitSimulationCampaign
     query: {
       list: resolveSimulationCampaigns,
       one: getCircuitSimulationCampaign,
+      resolve: resolveSimulationByCampaignId,
       create: createSimulationCampaign,
     },
   },

--- a/src/entity-configuration/domain/simulation/single-neuron-circuit-simulation.ts
+++ b/src/entity-configuration/domain/simulation/single-neuron-circuit-simulation.ts
@@ -2,7 +2,7 @@ import flatMap from 'es-toolkit/compat/flatMap';
 import keyBy from 'es-toolkit/compat/keyBy';
 
 import { downloadAsset } from '@/api/entitycore/queries/assets';
-import { getCircuits } from '@/api/entitycore/queries/model/circuit';
+import { getCircuit, getCircuits } from '@/api/entitycore/queries/model/circuit';
 import { getCircuitSimulations } from '@/api/entitycore/queries/simulation/circuit-simulation';
 import {
   createSimulationCampaign,
@@ -22,7 +22,7 @@ import { EntitySlug } from '@/entity-configuration/domain/slug';
 import { resolveExecutions } from './small-microcircuit-simulation';
 import { getExtendedSimMap, migrateConfig } from './utils';
 
-import type { ICircuitFilter } from '@/api/entitycore/types/entities/circuit';
+import type { ICircuit, ICircuitFilter } from '@/api/entitycore/types/entities/circuit';
 import type {
   ICircuitSimulationCampaign,
   ICircuitSimulationCampaignFilter,
@@ -44,7 +44,6 @@ async function resolveSimulationCampaigns({
   filters?: Partial<ICircuitSimulationCampaignFilter>;
   circuitScaleFilter?: Partial<ICircuitFilter>;
 }) {
-  // eslint-disable-next-line no-param-reassign
   filters = discardBrainRegionQueryParams(filters);
 
   const source = await getCircuitSimulationCampaigns({
@@ -129,6 +128,9 @@ export async function resolveSimulationByCampaignId({
 
   if (!configAsset) throw Error('No campaign config asset found');
 
+  let entity: ICircuit | null = null;
+  if (simulation?.entity_id) entity = await getCircuit({ id: simulation?.entity_id, context });
+
   const rawConfig = await downloadAsset({
     entityId: campaign.id,
     entityType: EntityTypeDict.SimulationCampaign,
@@ -143,11 +145,19 @@ export async function resolveSimulationByCampaignId({
   return {
     campaign,
     simulation,
+    entity,
     config,
   };
 }
 
-export const SingeNeuronCircuitSimulation: EntityCoreTypeConfig<ICircuitSimulationCampaign> = {
+type TResolvedSimulationByCampaign = Awaited<ReturnType<typeof resolveSimulationByCampaignId>>;
+type TResolvedSimulationByCampaigns = Awaited<ReturnType<typeof resolveSimulationCampaigns>>;
+
+export const SingeNeuronCircuitSimulation: EntityCoreTypeConfig<
+  ICircuitSimulationCampaign,
+  TResolvedSimulationByCampaign,
+  TResolvedSimulationByCampaigns
+> = {
   group: EntityTypeGroup.Simulations,
   title: 'Synaptome (beta)',
   extendedType: ExtendedEntitiesTypeDict.SingleNeuronCircuitSimulation,

--- a/src/entity-configuration/domain/simulation/single-neuron-simulation.ts
+++ b/src/entity-configuration/domain/simulation/single-neuron-simulation.ts
@@ -5,13 +5,14 @@ import {
   getSingleNeuronSimulationIOResult,
   getSingleNeuronSimulations,
 } from '@/api/entitycore/queries/simulation/single-neuron-simulation';
-import type { ISingleNeuronSimulation } from '@/api/entitycore/types';
 import { EntityTypeDict } from '@/api/entitycore/types/entity-type';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { AssetLabel } from '@/api/entitycore/types/shared/global';
 import { DetailViewSectionsDict } from '@/entity-configuration/definitions/types';
 import { EntityTypeGroup } from '@/entity-configuration/domain/group';
 import { EntitySlug } from '@/entity-configuration/domain/slug';
+
+import type { ISingleNeuronSimulation } from '@/api/entitycore/types';
 import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
 import type { WorkspaceContext } from '@/types/common';
 

--- a/src/entity-configuration/domain/simulation/single-neuron-synaptome-simulation.ts
+++ b/src/entity-configuration/domain/simulation/single-neuron-synaptome-simulation.ts
@@ -6,16 +6,17 @@ import {
   getSingleNeuronSynaptomeSimulationIOResult,
   getSingleNeuronSynaptomeSimulations,
 } from '@/api/entitycore/queries/simulation/single-neuron-synaptome-simulation';
-import type {
-  ISingleNeuronSynaptome,
-  ISingleNeuronSynaptomeSimulation,
-} from '@/api/entitycore/types';
 import { EntityTypeDict } from '@/api/entitycore/types/entity-type';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { AssetLabel } from '@/api/entitycore/types/shared/global';
 import { DetailViewSectionsDict } from '@/entity-configuration/definitions/types';
 import { EntityTypeGroup } from '@/entity-configuration/domain/group';
 import { EntitySlug } from '@/entity-configuration/domain/slug';
+
+import type {
+  ISingleNeuronSynaptome,
+  ISingleNeuronSynaptomeSimulation,
+} from '@/api/entitycore/types';
 import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
 import type { WorkspaceContext } from '@/types/common';
 

--- a/src/entity-configuration/domain/simulation/small-microcircuit-simulation.ts
+++ b/src/entity-configuration/domain/simulation/small-microcircuit-simulation.ts
@@ -1,7 +1,7 @@
-import flatMap from 'es-toolkit/compat/flatMap';
-import keyBy from 'es-toolkit/compat/keyBy';
+import { flatMap, keyBy } from 'es-toolkit/compat';
+
 import { downloadAsset } from '@/api/entitycore/queries/assets';
-import { getCircuits } from '@/api/entitycore/queries/model/circuit';
+import { getCircuit, getCircuits } from '@/api/entitycore/queries/model/circuit';
 import { getCircuitSimulations } from '@/api/entitycore/queries/simulation/circuit-simulation';
 import {
   createSimulationCampaign,
@@ -10,12 +10,7 @@ import {
 } from '@/api/entitycore/queries/simulation/circuit-simulation-campaign';
 import { getCircuitSimulationExecutions } from '@/api/entitycore/queries/simulation/circuit-simulation-execution';
 import { discardBrainRegionQueryParams } from '@/api/entitycore/transformers';
-import type { ICircuitFilter } from '@/api/entitycore/types/entities/circuit';
 import { CircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit';
-import type {
-  ICircuitSimulationCampaign,
-  ICircuitSimulationCampaignFilter,
-} from '@/api/entitycore/types/entities/circuit-simulation-campaign';
 import { EntityTypeDict } from '@/api/entitycore/types/entity-type';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { AssetLabel } from '@/api/entitycore/types/shared/global';
@@ -23,9 +18,16 @@ import { getAssetElement } from '@/api/entitycore/utils';
 import { DetailViewSectionsDict } from '@/entity-configuration/definitions/types';
 import { EntityTypeGroup } from '@/entity-configuration/domain/group';
 import { EntitySlug } from '@/entity-configuration/domain/slug';
+
+import { getExtendedSimMap, migrateConfig } from './utils';
+
+import type { ICircuit, ICircuitFilter } from '@/api/entitycore/types/entities/circuit';
+import type {
+  ICircuitSimulationCampaign,
+  ICircuitSimulationCampaignFilter,
+} from '@/api/entitycore/types/entities/circuit-simulation-campaign';
 import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
 import type { WorkspaceContext } from '@/types/common';
-import { getExtendedSimMap, migrateConfig } from './utils';
 
 export async function resolveExecutions({
   context,
@@ -132,7 +134,7 @@ export async function resolveSimulationByCampaignId({
   context,
 }: {
   id: string;
-  context: WorkspaceContext | undefined;
+  context?: WorkspaceContext | null;
 }) {
   const campaign = await getCircuitSimulationCampaign({ id, context });
 
@@ -154,6 +156,9 @@ export async function resolveSimulationByCampaignId({
 
   if (!configAsset) throw Error('No campaign config asset found');
 
+  let entity: ICircuit | null = null;
+  if (simulation?.entity_id) entity = await getCircuit({ id: simulation?.entity_id, context });
+
   const rawConfig = await downloadAsset({
     entityId: campaign.id,
     entityType: EntityTypeDict.SimulationCampaign,
@@ -168,14 +173,23 @@ export async function resolveSimulationByCampaignId({
   return {
     campaign,
     simulation,
+    entity,
     config,
   };
 }
 
-export const SmallMicrocircuitSimulation: EntityCoreTypeConfig<ICircuitSimulationCampaign> = {
+type TResolvedSimulationByCampaign = Awaited<ReturnType<typeof resolveSimulationByCampaignId>>;
+type TResolvedSimulationByCampaigns = Awaited<ReturnType<typeof resolveSimulationCampaigns>>;
+
+export const SmallMicrocircuitSimulation: EntityCoreTypeConfig<
+  ICircuitSimulationCampaign,
+  TResolvedSimulationByCampaign,
+  TResolvedSimulationByCampaigns
+> = {
   group: EntityTypeGroup.Simulations,
   title: 'Small microcircuit (beta)',
   extendedType: ExtendedEntitiesTypeDict.SmallMicrocircuitSimulation,
+  discriminator: { key: 'scale', value: [SCALE] },
   type: EntityTypeDict.SimulationCampaign,
   slug: EntitySlug.SmallMicrocircuitSimulation,
   api: {
@@ -204,6 +218,7 @@ export const SmallMicrocircuitSimulation: EntityCoreTypeConfig<ICircuitSimulatio
           },
         }),
       one: getCircuitSimulationCampaign,
+      resolve: resolveSimulationByCampaignId,
       create: createSimulationCampaign,
     },
     expandRow: async (record, _context) => record,

--- a/src/entity-configuration/domain/types.ts
+++ b/src/entity-configuration/domain/types.ts
@@ -14,9 +14,14 @@ import type { EntitySlugValue } from '@/entity-configuration/domain/slug';
 import type { FlagKey } from '@/features/feature-flags/flags';
 import type { WorkspaceContext } from '@/types/common';
 
-export type EntityCoreTypeConfig<T extends EntityCoreIdentifiable> = {
+export type EntityCoreTypeConfig<
+  T extends EntityCoreIdentifiable,
+  S = null, // single endpoint
+  L = null, // List endpoint
+> = {
   group: TEntityTypeGroup;
   extendedType: TExtendedEntitiesTypeDict;
+  discriminator?: { key: string; value: Array<string> };
   type: TEntityTypeDict;
   slug: EntitySlugValue;
   title: string;
@@ -31,9 +36,20 @@ export type EntityCoreTypeConfig<T extends EntityCoreIdentifiable> = {
       ilikeSearchEnabled?: boolean;
     };
     query: {
-      list?: (query: any) => Promise<EntityCoreResponse<T>>;
-      count?: (query: any) => Promise<EntityCoreResponse<T>>;
-      one: (query: { id: string; context?: WorkspaceContext | null }) => Promise<T>;
+      list?: (query: any) => Promise<EntityCoreResponse<T> | L>;
+      count?: (query: any) => Promise<EntityCoreResponse<T> | L>;
+      one: (
+        query: {
+          id: string;
+          context?: WorkspaceContext | null;
+        } & Record<string, any>
+      ) => Promise<T>;
+      resolve?: (
+        query: {
+          id: string;
+          context?: WorkspaceContext | null;
+        } & Record<string, any>
+      ) => Promise<S>;
       create?: (body: any) => Promise<T>;
       delete?: (query: { id: string; context: WorkspaceContext | null }) => Promise<void>;
     };

--- a/src/features/details-page/index.tsx
+++ b/src/features/details-page/index.tsx
@@ -4,15 +4,16 @@ import {
   DetailViewSectionsDict,
   type TDetailViewSectionDict,
 } from '@/entity-configuration/definitions/types';
-import type { TEntityByExtendedTypeConfig } from '@/entity-configuration/domain/helpers';
-import type { TRetrieveEntityOutput } from '@/entity-configuration/domain/requests';
-import type { WorkspaceContext } from '@/types/common';
 import Analysis from '@/ui/segments/detail-view/analysis';
 import Configuration from '@/ui/segments/detail-view/configuration';
 import Overview from '@/ui/segments/detail-view/overview';
 import RelatedArtifacts from '@/ui/segments/detail-view/related-artifacts';
 import RelatedPublications from '@/ui/segments/detail-view/related-publications';
 import Results from '@/ui/segments/detail-view/results';
+
+import type { TEntityByExtendedTypeConfig } from '@/entity-configuration/domain/helpers';
+import type { TRetrieveEntityOutput } from '@/entity-configuration/domain/requests';
+import type { WorkspaceContext } from '@/types/common';
 
 export function detailPageSectionRenderer({
   entity,

--- a/src/features/entities/me-model/detail-view/simulation.tsx
+++ b/src/features/entities/me-model/detail-view/simulation.tsx
@@ -2,15 +2,15 @@
 
 import { LoadingOutlined } from '@ant-design/icons';
 import { ErrorBoundary } from '@sentry/nextjs';
-import { useEffect, useState } from 'react';
-import { useParams } from 'next/navigation';
 import { Spin } from 'antd';
+import { useParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
-import SimulationDetail from '@/features/entities/neuron-simulation/simulation-results/simulation-details';
-import { withErrorConfig } from '@/components/GenericErrorFallback';
 import { getSingleNeuronSimulations } from '@/api/entitycore/queries';
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { tryCatch } from '@/api/utils';
+import { withErrorConfig } from '@/components/GenericErrorFallback';
+import SimulationDetail from '@/features/entities/neuron-simulation/simulation-results/simulation-details';
 
 import type { ISingleNeuronSimulation } from '@/api/entitycore/types';
 import type { WorkspaceContext } from '@/types/common';
@@ -42,7 +42,7 @@ export default function Results({ modelId }: Props) {
     }
 
     getSimulations();
-  }, [modelId, error, virtualLabId, projectId]);
+  }, [modelId, virtualLabId, projectId]);
 
   if (loading) {
     return (

--- a/src/ui/segments/action-menu.tsx
+++ b/src/ui/segments/action-menu.tsx
@@ -16,14 +16,14 @@ import NextLink from 'next/link';
 import { notFound, useRouter } from 'next/navigation';
 
 import { deleteCellMorphology } from '@/api/entitycore/queries/experimental/cell-morphology';
-import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import {
+  ExtendedEntitiesTypeDict,
+  type TExtendedEntitiesTypeDict,
+} from '@/api/entitycore/types/extended-entity-type';
 import { useAppNotification } from '@/components/notification';
 import { config } from '@/config';
 import { WorkspaceScope, WorkspaceSection } from '@/constants';
-import {
-  type EntityCoreExtendedType,
-  getEntityByExtendedType,
-} from '@/entity-configuration/domain/helpers';
+import { getEntityByExtendedType } from '@/entity-configuration/domain/helpers';
 import { useCopyToClipboard } from '@/hooks/useCopyClipboard';
 import { downloadArchive } from '@/services/entity-download';
 import Action from '@/ui/molecules/side-menu-action';
@@ -47,7 +47,7 @@ export default function ActionMenu({
 }: {
   entity: EntityTypeValue;
   ctx: WorkspaceContext;
-  type: EntityCoreExtendedType;
+  type: TExtendedEntitiesTypeDict;
   parentLink: string;
   isPublicEntity: boolean;
 }) {

--- a/src/ui/segments/data-table/elements/context.tsx
+++ b/src/ui/segments/data-table/elements/context.tsx
@@ -1,34 +1,33 @@
 'use client';
 
-import { atomFamily, atomWithDefault, atomWithReset, atomWithStorage } from 'jotai/utils';
-import { use, useCallback, useEffect, useMemo, createContext } from 'react';
 import { isNil, noop } from 'es-toolkit/compat';
-import { Atom, atom, useSetAtom } from 'jotai';
+import { type Atom, atom, useSetAtom } from 'jotai';
+import { atomFamily, atomWithDefault, atomWithReset, atomWithStorage } from 'jotai/utils';
+import { createContext, use, useCallback, useEffect, useMemo } from 'react';
 import { match } from 'ts-pattern';
 
-import { createSuperJsonStorage, memoryStorage } from '@/ui/hooks/use-storage-atom-with-validation';
-import { EntityCoreFields } from '@/entity-configuration/definitions/fields-defs/enums';
-import { ViewsDefinitionRegistry } from '@/entity-configuration/definitions/view-defs';
-import { circuitRepresentationViewAtom } from '@/ui/segments/explore/circuit/helpers';
 import {
   DEFAULT_PAGE_NUMBER,
-  TWorkspaceScope,
-  TWorkspaceSection,
+  type TWorkspaceScope,
+  type TWorkspaceSection,
   WorkspaceSection,
 } from '@/constants';
+import { EntityCoreFields } from '@/entity-configuration/definitions/fields-defs/enums';
 import { SortOrder } from '@/entity-configuration/definitions/types';
+import { ViewsDefinitionRegistry } from '@/entity-configuration/definitions/view-defs';
+import { createSuperJsonStorage, memoryStorage } from '@/ui/hooks/use-storage-atom-with-validation';
 import {
   makeDataListStateSnapshotAtomsInitialValue,
   makeTypeDefaultFilters,
 } from '@/ui/segments/data-table/elements/helpers';
+import { circuitRepresentationViewAtom } from '@/ui/segments/explore/circuit/helpers';
 
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { TCoreFilter, TSortState } from '@/entity-configuration/definitions/types';
-import type { EntityCoreExtendedType } from '@/entity-configuration/domain/helpers';
 
 type DataAtomBinding = {
   key: string;
-  dataType: EntityCoreExtendedType;
+  dataType: TExtendedEntitiesTypeDict;
   dataScope: TWorkspaceScope;
 };
 
@@ -43,7 +42,7 @@ export const activeColumnsAtom = atomFamily(
 );
 
 export const coreActiveColumnsAtom = atomFamily(
-  ({ dataType }: { key: string; dataType: EntityCoreExtendedType }) =>
+  ({ dataType }: { key: string; dataType: TExtendedEntitiesTypeDict }) =>
     atomWithDefault<Promise<string[]> | string[]>(async () => {
       const { columns } = { ...ViewsDefinitionRegistry[dataType] };
       return ['index', ...(columns || [])];

--- a/src/ui/segments/detail-view/analysis.tsx
+++ b/src/ui/segments/detail-view/analysis.tsx
@@ -1,23 +1,22 @@
 import { notFound } from 'next/navigation';
+
 import {
-  circuitTypes,
-  EntityCoreExtendedType,
-  getEntityByExtendedType,
-} from '@/entity-configuration/domain/helpers';
-
-import { EntityTypeValue } from '@/entity-configuration/domain';
-
-import Overview from '@/ui/segments/explore/circuit/elements/overview';
+  ExtendedEntitiesTypeDict,
+  type TExtendedEntitiesTypeDict,
+} from '@/api/entitycore/types/extended-entity-type';
+import { circuitTypes, getEntityByExtendedType } from '@/entity-configuration/domain/helpers';
 import Analysis from '@/features/model-analysis/explorer/container';
-import { ICircuit } from '@/api/entitycore/types/entities/circuit';
-import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import Overview from '@/ui/segments/explore/circuit/elements/overview';
+
+import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
+import type { TRetrieveEntityOutput } from '@/entity-configuration/domain/requests';
 
 export default async function Configuration({
   entity,
   extendedType,
 }: {
-  entity: EntityTypeValue;
-  extendedType: EntityCoreExtendedType;
+  entity: TRetrieveEntityOutput;
+  extendedType: TExtendedEntitiesTypeDict;
 }) {
   const entityType = getEntityByExtendedType({ type: extendedType });
   if (!entityType) notFound();

--- a/src/ui/segments/detail-view/configuration.tsx
+++ b/src/ui/segments/detail-view/configuration.tsx
@@ -1,42 +1,41 @@
+import { isNil } from 'es-toolkit/compat';
 import { notFound } from 'next/navigation';
-import isNil from 'es-toolkit/compat/isNil';
 
-import {
-  EntityCoreExtendedType,
-  getEntityByExtendedType,
-  applyEntityExpansions,
-} from '@/entity-configuration/domain/helpers';
-
-import EModelConfig from '@/features/entities/e-model/detail-view/wrapper';
-import { EntityTypeValue } from '@/entity-configuration/domain';
-import { WorkspaceContext, AwaitedType } from '@/types/common';
-import {
-  IEModel,
-  IMEModel,
-  ICellMorphology,
-  ICellMorphologyExpanded,
-  ISingleNeuronSimulation,
-  ISingleNeuronSynaptomeSimulation,
-} from '@/api/entitycore/types';
 import { getCellMorphology } from '@/api/entitycore/queries';
-import MEModelConfig from '@/features/entities/me-model/detail-view/configuration';
-import SynaptomeConfig from '@/features/entities/single-neuron-synaptome/detail-view/configuration';
-import SynapseGroupList from '@/features/entities/single-neuron-synaptome/detail-view/elements/list-synapses-configuration';
-import { SingleNeuronSynaptome as singleNeuronSynaptomeEntity } from '@/entity-configuration/domain/model/single-neuron-synaptome';
 import { getSingleNeuronSynaptome } from '@/api/entitycore/queries/model/single-neuron-synaptome';
 import { tryCatch } from '@/api/utils';
+import SimulationConfigurationTab from '@/components/simulate/SimulationDetails/configuration-tab';
+import {
+  applyEntityExpansions,
+  getEntityByExtendedType,
+} from '@/entity-configuration/domain/helpers';
+import { SingleNeuronSynaptome as singleNeuronSynaptomeEntity } from '@/entity-configuration/domain/model/single-neuron-synaptome';
 import {
   singleNeuronSimulationApiQueryExpand,
   singleNeuronSynaptomeSimulationApiQueryExpand,
 } from '@/entity-configuration/domain/simulation';
-import SimulationConfigurationTab from '@/components/simulate/SimulationDetails/configuration-tab';
-import { SimulationPayload } from '@/types/small-scale-simulator/single-neuron';
+import EModelConfig from '@/features/entities/e-model/detail-view/wrapper';
+import MEModelConfig from '@/features/entities/me-model/detail-view/configuration';
+import SynaptomeConfig from '@/features/entities/single-neuron-synaptome/detail-view/configuration';
+import SynapseGroupList from '@/features/entities/single-neuron-synaptome/detail-view/elements/list-synapses-configuration';
 
+import type {
+  ICellMorphology,
+  ICellMorphologyExpanded,
+  IEModel,
+  IMEModel,
+  ISingleNeuronSimulation,
+  ISingleNeuronSynaptomeSimulation,
+} from '@/api/entitycore/types';
 import type {
   ISingleNeuronSynaptome,
   TSingleNeuronSynaptomeConfiguration,
 } from '@/api/entitycore/types/entities/single-neuron-synaptome';
-import { Prettify } from '@/utils/type';
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import type { TRetrieveEntityOutput } from '@/entity-configuration/domain/requests';
+import type { AwaitedType, WorkspaceContext } from '@/types/common';
+import type { SimulationPayload } from '@/types/small-scale-simulator/single-neuron';
+import type { Prettify } from '@/utils/type';
 
 type ExpandType = Prettify<{
   memodel: IMEModel;
@@ -89,8 +88,8 @@ export default async function Configuration({
   extendedType,
   ctx,
 }: {
-  entity: EntityTypeValue;
-  extendedType: EntityCoreExtendedType;
+  entity: TRetrieveEntityOutput;
+  extendedType: TExtendedEntitiesTypeDict;
   ctx: WorkspaceContext;
 }) {
   const entityType = getEntityByExtendedType({ type: extendedType });

--- a/src/ui/segments/detail-view/overview/index.tsx
+++ b/src/ui/segments/detail-view/overview/index.tsx
@@ -2,14 +2,17 @@ import { includes } from 'es-toolkit/compat';
 import { notFound } from 'next/navigation';
 
 import { getMEModel } from '@/api/entitycore/queries';
-import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import {
+  ExtendedEntitiesTypeDict,
+  type TExtendedEntitiesTypeDict,
+} from '@/api/entitycore/types/extended-entity-type';
 import { tryCatch } from '@/api/utils';
 import {
   CommonSummaryViewFields,
   getViewDefinitionByExtendedType,
 } from '@/entity-configuration/definitions/view-defs';
 import { resolveExtractionByCampaignId } from '@/entity-configuration/domain/extraction/extraction-campaign';
-import { circuitTypes, type EntityCoreExtendedType } from '@/entity-configuration/domain/helpers';
+import { circuitTypes } from '@/entity-configuration/domain/helpers';
 import {
   resolveSimulationByCampaignId,
   resolveSingleNeuronSimulation,
@@ -42,7 +45,7 @@ import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
 import type { IonChannelModel } from '@/api/entitycore/types/entities/ion-channel';
 import type { IIonChannelRecording } from '@/api/entitycore/types/entities/ion-channel-recording';
 import type { TypeSummaryProps } from '@/entity-configuration/definitions/view-defs/types';
-import type { EntityTypeValue } from '@/entity-configuration/domain';
+import type { TRetrieveEntityOutput } from '@/entity-configuration/domain/requests';
 import type { AwaitedType, WorkspaceContext } from '@/types/common';
 
 export default async function Overview({
@@ -51,8 +54,8 @@ export default async function Overview({
   ctx,
   isWorkflow,
 }: {
-  entity?: EntityTypeValue;
-  extendedType: EntityCoreExtendedType;
+  entity?: TRetrieveEntityOutput;
+  extendedType: TExtendedEntitiesTypeDict;
   ctx: WorkspaceContext;
   isWorkflow: boolean;
 }) {

--- a/src/ui/segments/detail-view/per-type-publications.tsx
+++ b/src/ui/segments/detail-view/per-type-publications.tsx
@@ -1,21 +1,22 @@
+import { CloseCircleTwoTone, LoadingOutlined } from '@ant-design/icons';
 import { useQuery } from '@tanstack/react-query';
 import { Empty, List } from 'antd';
 import { useParams } from 'next/navigation';
 import { useState } from 'react';
-import { CloseCircleTwoTone, LoadingOutlined } from '@ant-design/icons';
 
-import { Card } from '@/ui/segments/explore/circuit/elements/publication-item/card';
 import { getScientificArtifactPublicationLinks } from '@/api/entitycore/queries/general/scientific-artifact-publication-link';
-import type { WorkspaceContext } from '@/types/common';
+import { Card } from '@/ui/segments/explore/circuit/elements/publication-item/card';
 import { keyBuilder } from '@/ui/use-query-keys/data';
+
 import type { TPublicationTypeDictionary } from '@/api/entitycore/types/entities/scientific-artifact-publication-link';
-import { EntityTypeValue } from '@/entity-configuration/domain';
+import type { TRetrieveEntityOutput } from '@/entity-configuration/domain/requests';
+import type { WorkspaceContext } from '@/types/common';
 
 export function PerTypePublications({
   entity,
   type,
 }: {
-  entity: EntityTypeValue;
+  entity: TRetrieveEntityOutput;
   type: TPublicationTypeDictionary;
 }) {
   const { virtualLabId, projectId } = useParams<WorkspaceContext>();

--- a/src/ui/segments/detail-view/related-artifacts/index.tsx
+++ b/src/ui/segments/detail-view/related-artifacts/index.tsx
@@ -1,25 +1,27 @@
-import { notFound } from 'next/navigation';
 import { includes } from 'es-toolkit/compat';
-import ICMRelatedArtifacts from './ion-channel-model';
-import {
-  EntityCoreExtendedType,
-  getEntityByExtendedType,
-} from '@/entity-configuration/domain/helpers';
+import { notFound } from 'next/navigation';
 
+import {
+  ExtendedEntitiesTypeDict,
+  type TExtendedEntitiesTypeDict,
+} from '@/api/entitycore/types/extended-entity-type';
+import { getEntityByExtendedType } from '@/entity-configuration/domain/helpers';
 import MEModelResults from '@/features/entities/me-model/detail-view/simulation';
 import SynaptomeResults from '@/features/entities/single-neuron-synaptome/detail-view/simulation';
 import { RelatedCircuits } from '@/ui/segments/explore/circuit/elements/related-circuits';
-import { EntityTypeValue } from '@/entity-configuration/domain';
-import { ICircuit } from '@/api/entitycore/types/entities/circuit';
-import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
-import { IonChannelModel } from '@/api/entitycore/types/entities/ion-channel';
+
+import ICMRelatedArtifacts from './ion-channel-model';
+
+import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
+import type { IonChannelModel } from '@/api/entitycore/types/entities/ion-channel';
+import type { TRetrieveEntityOutput } from '@/entity-configuration/domain/requests';
 
 export default async function RelatedArtifacts({
   entity,
   extendedType,
 }: {
-  entity: EntityTypeValue;
-  extendedType: EntityCoreExtendedType;
+  entity: TRetrieveEntityOutput;
+  extendedType: TExtendedEntitiesTypeDict;
 }) {
   const entityType = getEntityByExtendedType({ type: extendedType });
   if (!entityType) notFound();

--- a/src/ui/segments/detail-view/related-publications.tsx
+++ b/src/ui/segments/detail-view/related-publications.tsx
@@ -2,20 +2,21 @@
 
 import { notFound } from 'next/navigation';
 
-import { PerTypePublications } from './per-type-publications';
-
 import { PublicationTypeDictionary } from '@/api/entitycore/types/entities/scientific-artifact-publication-link';
 import { getEntityByExtendedType } from '@/entity-configuration/domain/helpers';
 import Tabs, { Tab } from '@/ui/molecules/tabbed-page';
-import type { EntityCoreExtendedType } from '@/entity-configuration/domain/helpers';
-import type { EntityTypeValue } from '@/entity-configuration/domain';
+
+import { PerTypePublications } from './per-type-publications';
+
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import type { TRetrieveEntityOutput } from '@/entity-configuration/domain/requests';
 
 export default function RelatedPublications({
   entity,
   extendedType,
 }: {
-  entity: EntityTypeValue;
-  extendedType: EntityCoreExtendedType;
+  entity: TRetrieveEntityOutput;
+  extendedType: TExtendedEntitiesTypeDict;
 }) {
   const entityType = getEntityByExtendedType({ type: extendedType });
   if (!entityType) notFound();

--- a/src/ui/segments/detail-view/results.tsx
+++ b/src/ui/segments/detail-view/results.tsx
@@ -1,17 +1,19 @@
 import { notFound } from 'next/navigation';
-import {
-  EntityCoreExtendedType,
-  getEntityByExtendedType,
-} from '@/entity-configuration/domain/helpers';
 
-import { EntityTypeValue } from '@/entity-configuration/domain';
-import { WorkspaceContext, AwaitedType } from '@/types/common';
-import { ISingleNeuronSimulation, ISingleNeuronSynaptomeSimulation } from '@/api/entitycore/types';
+import SimulationResults from '@/components/simulate/SimulationDetails/recording-tab';
+import { getEntityByExtendedType } from '@/entity-configuration/domain/helpers';
 import {
   singleNeuronSimulationApiQueryExpand,
   singleNeuronSynaptomeSimulationApiQueryExpand,
 } from '@/entity-configuration/domain/simulation';
-import SimulationResults from '@/components/simulate/SimulationDetails/recording-tab';
+
+import type {
+  ISingleNeuronSimulation,
+  ISingleNeuronSynaptomeSimulation,
+} from '@/api/entitycore/types';
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import type { EntityTypeValue } from '@/entity-configuration/domain';
+import type { AwaitedType, WorkspaceContext } from '@/types/common';
 
 export default async function Results({
   entity,
@@ -19,7 +21,7 @@ export default async function Results({
   ctx,
 }: {
   entity: EntityTypeValue;
-  extendedType: EntityCoreExtendedType;
+  extendedType: TExtendedEntitiesTypeDict;
   ctx: WorkspaceContext;
 }) {
   const entityType = getEntityByExtendedType({ type: extendedType });


### PR DESCRIPTION
- this refactors the duplicate of the extended types 
`TExtendedEntitiesTypeDict` and `EntityCoreExtendedType`
we keep only `TExtendedEntitiesTypeDict`
- add resolve api query to entity configuration, this is used for entities that need to fetch multiple resources to conclude the desired type