### PR TITLE
Fix table sorting

### DIFF
--- a/src/features/views/listing/browse-entity.tsx
+++ b/src/features/views/listing/browse-entity.tsx
@@ -5,7 +5,14 @@ import { get, uniqBy } from 'es-toolkit/compat';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { RESET } from 'jotai/utils';
 import dynamic from 'next/dynamic';
-import { type ComponentProps, type ReactElement, type ReactNode, useEffect, useMemo } from 'react';
+import {
+  type ComponentProps,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+} from 'react';
 
 import { ApiError } from '@/api/error';
 import { DEFAULT_PAGE_NUMBER, WorkspaceSection } from '@/constants';
@@ -113,11 +120,14 @@ export function BrowseEntityScope({
     section,
   });
 
-  const onSortChange = (newSortState: TSortState) => {
-    setPageNumber(DEFAULT_PAGE_NUMBER);
-    setSortState(newSortState);
-    runStorageSync({ Sort: newSortState, Page: DEFAULT_PAGE_NUMBER });
-  };
+  const onSortChange = useCallback(
+    (newSortState: TSortState) => {
+      setPageNumber(DEFAULT_PAGE_NUMBER);
+      setSortState(newSortState);
+      runStorageSync({ Sort: newSortState, Page: DEFAULT_PAGE_NUMBER });
+    },
+    [setPageNumber, setSortState, runStorageSync]
+  );
 
   const allColumns = useDataTableColumns<EntityCoreIdentifiableNamed>({
     dataType,

--- a/src/ui/segments/data-table/elements/context.tsx
+++ b/src/ui/segments/data-table/elements/context.tsx
@@ -4,6 +4,7 @@ import { isNil, noop } from 'es-toolkit/compat';
 import { type Atom, atom, useSetAtom } from 'jotai';
 import { atomFamily, atomWithDefault, atomWithReset, atomWithStorage } from 'jotai/utils';
 import { createContext, use, useCallback, useEffect, useMemo } from 'react';
+import superjson from 'superjson';
 import { match } from 'ts-pattern';
 
 import {
@@ -74,12 +75,7 @@ export const coreSortStateAtom = atomFamily(
       backendField: EntityCoreFields.RegistrationDate,
       order: SortOrder.DESC,
     };
-
-    const writableAtom = atom<TSortState, [TSortState], void>(initialState, (_, set, update) => {
-      set(writableAtom, update);
-    });
-
-    return writableAtom;
+    return atom<TSortState>(initialState);
   },
   (a, b) => a.key === b.key
 );
@@ -161,22 +157,34 @@ export const DataListSnapshotSyncAtomFamily = atomFamily(
         const view = get(circuitRepresentationViewAtom);
         return { filters, page, search, sort, view };
       },
-      (get, set, action: TDataListStoreParamsSyncAction) => {
-        const storageAtom = DataListStateSnapshotStorageAtomFamily({ dataKey, dataType });
+      (_get, set, action: TDataListStoreParamsSyncAction) => {
+        const readStorage = (): TDataLisStateSnapshot => {
+          if (typeof window === 'undefined') {
+            return makeDataListStateSnapshotAtomsInitialValue({ dataType });
+          }
+          const raw = sessionStorage.getItem(dataKey);
+          if (!raw) return makeDataListStateSnapshotAtomsInitialValue({ dataType });
+          try {
+            return superjson.parse<TDataLisStateSnapshot>(raw);
+          } catch {
+            return makeDataListStateSnapshotAtomsInitialValue({ dataType });
+          }
+        };
+
+        const writeStorage = (value: TDataLisStateSnapshot) => {
+          if (typeof window !== 'undefined') {
+            sessionStorage.setItem(dataKey, superjson.stringify(value));
+          }
+        };
 
         return match({ type: action.type })
           .with({ type: DataListStateSnapshotSyncAction.SYNC }, ({ type: t }) => {
             if (t === DataListStateSnapshotSyncAction.SYNC) {
-              const attribute = action.attribute || {};
-              const oldValue = get(storageAtom);
-              set(storageAtom, {
-                ...oldValue,
-                ...attribute,
-              });
+              writeStorage({ ...readStorage(), ...(action.attribute || {}) });
             }
           })
           .with({ type: DataListStateSnapshotSyncAction.RESTORE }, () => {
-            const stored = get(storageAtom);
+            const stored = readStorage();
             set(coreFiltersAtom({ key: dataKey, dataType }), stored.Filters);
             set(corePageNumberAtom(dataKey), stored.Page);
             set(coreSearchStringAtom(dataKey), stored.Search);
@@ -241,6 +249,17 @@ export function useDataListStateSnapshotActions({
     [updateSync]
   );
 
+  const restore = useCallback(
+    () => updateSync({ type: DataListStateSnapshotSyncAction.RESTORE }),
+    [updateSync]
+  );
+
+  const sync = useCallback(
+    (attribute: Partial<TDataLisStateSnapshot>) =>
+      updateSync({ type: DataListStateSnapshotSyncAction.SYNC, attribute }),
+    [updateSync]
+  );
+
   useEffect(() => {
     if (registerReset) {
       registerReset(dataKey, reset);
@@ -254,10 +273,5 @@ export function useDataListStateSnapshotActions({
       sync: noop,
     };
   }
-  return {
-    restore: () => updateSync({ type: DataListStateSnapshotSyncAction.RESTORE }),
-    reset,
-    sync: (attribute: Partial<TDataLisStateSnapshot>) =>
-      updateSync({ type: DataListStateSnapshotSyncAction.SYNC, attribute }),
-  };
+  return { restore, reset, sync };
 }

--- a/src/ui/segments/data-table/elements/use-data-table-columns.tsx
+++ b/src/ui/segments/data-table/elements/use-data-table-columns.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { isString } from 'es-toolkit/compat';
-import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { fieldsDefinitionRegistry, getFieldDefinition } from '@/entity-configuration/definitions';
@@ -121,12 +121,18 @@ export function useDataTableColumns<T>({
     );
   }, [keys]);
 
+  // Use a ref so columnOrderBy always reads the latest sortState,
+  // even when Ant Design caches the column header cell and the onClick closure goes stale.
+  const sortStateRef = useRef(sortState);
+  sortStateRef.current = sortState;
+
   const columnOrderBy = useCallback(
     (field: EntityCoreFields, backendField: EntityCoreFields) => {
+      const current = sortStateRef.current;
       let order: TSortOrder | null = SortOrder.ASC;
 
-      if (sortState?.order && field === sortState.field) {
-        order = sortState.order === SortOrder.DESC ? SortOrder.ASC : SortOrder.DESC;
+      if (current?.order && field === current.field) {
+        order = current.order === SortOrder.DESC ? SortOrder.ASC : SortOrder.DESC;
       }
 
       setSortState?.({
@@ -135,7 +141,7 @@ export function useDataTableColumns<T>({
         order,
       });
     },
-    [setSortState, sortState]
+    [setSortState]
   );
 
   const updateColumnWidths = useCallback((resizeInit: ResizeInit, clientX: number) => {
@@ -264,9 +270,8 @@ export function useDataTableColumns<T>({
               },
             };
           },
-          defaultSortOrder: 'descend',
           sortOrder: getOrderDirection(key),
-          sortDirections: ['ascend', 'descend', 'descend'],
+          sortDirections: ['ascend', 'descend'],
           align: term?.style?.align,
         });
         return acc;


### PR DESCRIPTION
This PR fixes two issue that were preventing table sorting to work.

1. Stale closure in `columnOrderBy`

Ant Design caches column header cell instances and doesn't re-call `onHeaderCell()` when columns prop changes, so the `onClick` closure always captured the initial `sortState`. Fixed by storing the latest `sortState` in a ref that's updated on every render — `columnOrderBy` reads `sortStateRef.current` instead of the stale closure value.

2. `atomWithStorage` + `getOnInit: true` deferred mutation

When `DataListSnapshotSyncAtomFamily`'s RESTORE action called `get(storageAtom)`, Jotai detected a "store mutation during atom read" and returned the stale default instead of the sessionStorage value. This caused RESTORE to always reset sort state to the default `{creation_date, desc}`. Fixed by bypassing `DataListStateSnapshotStorageAtomFamily` entirely in RESTORE/SYNC, reading/writing sessionStorage directly via `superjson`.

Fixes [Sorting arrows only work once](https://github.com/openbraininstitute/prod-explore-functionality/issues/456).