### PR TITLE
update(api-client): api client to use zod schema for validation on se…

### DIFF
--- a/src/api/api-client.ts
+++ b/src/api/api-client.ts
@@ -1,10 +1,13 @@
 import isNil from 'es-toolkit/compat/isNil';
 import omitBy from 'es-toolkit/compat/omitBy';
 
+import { ValidationError } from '@/api/error';
 import { parseApiError } from '@/api/utils';
 import { getSession } from '@/auth-fetch';
 import { compactRecord } from '@/utils/dictionary';
 import { log } from '@/utils/logger';
+
+import type { ZodType } from 'zod';
 
 type BackoffStrategy = {
   type: 'exponential' | 'custom';
@@ -20,6 +23,12 @@ type RequestConfiguration = {
   retryOnException?: boolean;
 };
 
+type ValidationSchemas = {
+  queryParams?: ZodType;
+  body?: ZodType;
+  response?: ZodType;
+};
+
 type RequestOptions = {
   headers?: Record<string, string | undefined>;
   queryParams?: Record<
@@ -30,6 +39,7 @@ type RequestOptions = {
   signal?: AbortSignal;
   cache?: RequestCache;
   next?: NextFetchRequestConfig;
+  validation?: ValidationSchemas;
 };
 
 // New cache configuration type
@@ -47,6 +57,8 @@ type ApiClientOptions = {
   config?: RequestConfiguration;
   cache?: CacheConfiguration; // Add cache configuration to options
 };
+
+export type { ValidationSchemas };
 
 export type ErrorCause<T extends Record<string, any>> = {
   status: number;
@@ -211,11 +223,35 @@ class ApiClient {
     method: string,
     endpoint: string,
     options: RequestOptions = {},
-    config: RequestConfiguration & { cache?: CacheConfiguration; asRawResponse?: boolean } = {},
+    config: RequestConfiguration & {
+      cache?: CacheConfiguration;
+      asRawResponse?: boolean;
+    } = {},
     onAbort?: () => void
   ): Promise<T> {
     let attempt = 0;
     const maxAttempts = config.attempts ?? this._attempts ?? 1;
+
+    // validate input schemas before making the request
+    if (options.validation?.queryParams && options.queryParams) {
+      const result = options.validation.queryParams.safeParse(options.queryParams);
+      if (!result.success) {
+        const error = new ValidationError('queryParams', result.error);
+        log('error', `fetch [${endpoint}] error:`, error.toJSON());
+        throw error;
+      }
+      log('info', `fetch [${endpoint}] [queryParams] succeeded`);
+    }
+
+    if (options.validation?.body && options.body) {
+      const result = options.validation.body.safeParse(options.body);
+      if (!result.success) {
+        const error = new ValidationError('body', result.error);
+        log('error', `fetch [${endpoint}] error:`, error.toJSON());
+        throw error;
+      }
+      log('info', `fetch [${endpoint}] [body] succeeded`);
+    }
 
     const url = new URL(`${this._rootUrl}${endpoint}`);
 
@@ -346,6 +382,18 @@ class ApiClient {
         throw await parseApiError(request.url, response.status, responseData);
       }
 
+      // validate response schema if provided
+      if (options.validation?.response && !config.asRawResponse) {
+        const result = options.validation.response.safeParse(responseData);
+        if (!result.success) {
+          const error = new ValidationError('response', result.error);
+          log('error', `fetch [${endpoint}] error:`, error.toJSON());
+          throw error;
+        }
+        log('info', `fetch [${endpoint}] [response] succeeded`);
+        return result.data as T;
+      }
+
       return responseData;
     };
 
@@ -361,7 +409,10 @@ class ApiClient {
         await new Promise((resolve) => {
           setTimeout(resolve, delay);
         });
-        return this._request<T>(method, endpoint, options, { ...config, attempts: attempt + 1 });
+        return this._request<T>(method, endpoint, options, {
+          ...config,
+          attempts: attempt + 1,
+        });
       }
       throw error;
     }
@@ -415,7 +466,10 @@ class ApiClient {
   get<T>(
     endpoint: string,
     options?: RequestOptions,
-    config?: RequestConfiguration & { cache?: CacheConfiguration; asRawResponse?: boolean }
+    config?: RequestConfiguration & {
+      cache?: CacheConfiguration;
+      asRawResponse?: boolean;
+    }
   ) {
     return this._request<T>('get', endpoint, options, config);
   }

--- a/src/api/auth-manager/index.ts
+++ b/src/api/auth-manager/index.ts
@@ -1,4 +1,4 @@
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 
 export async function authManagerApi(url?: string) {
   const api = await authApiClient(url ?? 'https://staging.openbraininstitute.org/api/auth-manager');

--- a/src/api/entitycore/queries/annotations/etype-classification.ts
+++ b/src/api/entitycore/queries/annotations/etype-classification.ts
@@ -1,7 +1,7 @@
 import z from 'zod';
 
+import { authApiClient } from '@/api/api-client';
 import { getEntityCoreContext } from '@/api/entitycore/utils';
-import { authApiClient } from '@/api/apiClient';
 import { config } from '@/config';
 
 import type { IETypeClassification } from '@/api/entitycore/types/shared/global';

--- a/src/api/entitycore/queries/annotations/etype.ts
+++ b/src/api/entitycore/queries/annotations/etype.ts
@@ -1,9 +1,9 @@
+import { authApiClient } from '@/api/api-client';
 import { getEntityCoreContext } from '@/api/entitycore/utils';
-import { authApiClient } from '@/api/apiClient';
 import { config } from '@/config';
 
-import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { IEType, IETypeFilter } from '@/api/entitycore/types/shared/global';
+import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/etype';

--- a/src/api/entitycore/queries/annotations/mtype-classification.ts
+++ b/src/api/entitycore/queries/annotations/mtype-classification.ts
@@ -1,6 +1,6 @@
 import z from 'zod';
 
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { getEntityCoreContext } from '@/api/entitycore/utils';
 import { config } from '@/config';
 

--- a/src/api/entitycore/queries/annotations/mtype.ts
+++ b/src/api/entitycore/queries/annotations/mtype.ts
@@ -1,5 +1,5 @@
+import { authApiClient } from '@/api/api-client';
 import { getEntityCoreContext } from '@/api/entitycore/utils';
-import { authApiClient } from '@/api/apiClient';
 import { config } from '@/config';
 
 import type { IMType, IMTypeFilter } from '@/api/entitycore/types/shared/global';

--- a/src/api/entitycore/queries/assets/index.ts
+++ b/src/api/entitycore/queries/assets/index.ts
@@ -1,6 +1,6 @@
 import { kebabCase } from 'es-toolkit/compat';
 
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { getEntityCoreContext } from '@/api/entitycore/utils';
 import { config } from '@/config';
 import { compactRecord } from '@/utils/dictionary';

--- a/src/api/entitycore/queries/experimental/cell-morphology.ts
+++ b/src/api/entitycore/queries/experimental/cell-morphology.ts
@@ -1,23 +1,28 @@
 import z from 'zod';
 
+import { makeListResponse } from '@/api/entitycore/schemas/base';
+import {
+  CellMorphologySchema,
+  type TCellMorphology,
+  type TCellMorphologyAnnotationExpanded,
+} from '@/api/entitycore/schemas/cell-morphology';
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 
 import type {
   CellMorphologyFilter,
   ExpandCellMorphologyParm,
-  ICellMorphology,
-  ICellMorphologyExpanded,
 } from '@/api/entitycore/types/entities/cell-morphology';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/cell-morphology';
+
 /**
  * Retrieves a list of cell morphologies from the EntityCoreAPI.
  *
  * @param {Object} options - The options object
  * @param {CellMorphologyFilter} [options.filters] - Optional filters to apply to the query
- * @returns {Promise<EntityCoreResponse<ICellMorphology>>} A promise that resolves to the list of cell morphologies
+ * @returns {Promise<EntityCoreResponse<TCellMorphology>>} A promise that resolves to the list of cell morphologies
  */
 export async function getCellMorphologies({
   withFacets,
@@ -29,17 +34,23 @@ export async function getCellMorphologies({
   context?: WorkspaceContext | null;
 }) {
   const api = await entityCoreApi();
-  return await api.get<EntityCoreResponse<ICellMorphology | ICellMorphologyExpanded>>(baseUri, {
-    queryParams: {
-      ...filters,
-      with_facets: withFacets,
-    },
-    headers: {
-      accept: 'application/json',
-      'content-type': 'application/json',
-      ...getEntityCoreContext(context).headers,
-    },
-  });
+  return await api.get<EntityCoreResponse<TCellMorphology | TCellMorphologyAnnotationExpanded>>(
+    baseUri,
+    {
+      queryParams: {
+        ...filters,
+        with_facets: withFacets,
+      },
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+        ...getEntityCoreContext(context).headers,
+      },
+      validation: {
+        response: makeListResponse(CellMorphologySchema),
+      },
+    }
+  );
 }
 
 /**
@@ -48,7 +59,7 @@ export async function getCellMorphologies({
  * @param {Object} params - The parameters object
  * @param {string} params.id - The unique identifier of the cell morphology to retrieve
  * @param {ExpandCellMorphologyParm} params.expand - Parameter to specify if the morphology should be expanded
- * @returns {Promise<ICellMorphology | ICellMorphologyExpanded>} A promise that resolves to the requested cell morphology
+ * @returns {Promise<TCellMorphology | TCellMorphologyAnnotationExpanded>} A promise that resolves to the requested cell morphology
  */
 export async function getCellMorphology({
   id,
@@ -60,7 +71,7 @@ export async function getCellMorphology({
   context?: WorkspaceContext | null;
 }) {
   const api = await entityCoreApi();
-  return await api.get<ICellMorphology | ICellMorphologyExpanded>(`${baseUri}/${id}`, {
+  return await api.get<TCellMorphology | TCellMorphologyAnnotationExpanded>(`${baseUri}/${id}`, {
     queryParams: {
       expand,
     },
@@ -68,6 +79,9 @@ export async function getCellMorphology({
       accept: 'application/json',
       'content-type': 'application/json',
       ...getEntityCoreContext(context).headers,
+    },
+    validation: {
+      response: CellMorphologySchema,
     },
   });
 }
@@ -143,7 +157,7 @@ export async function createCellMorphology({
   payload: TCellMorphologyCreate;
 }) {
   const api = await entityCoreApi();
-  return await api.post<ICellMorphology>(baseUri, {
+  return await api.post<TCellMorphology>(baseUri, {
     headers: {
       accept: 'application/json',
       'content-type': 'application/json',

--- a/src/api/entitycore/queries/general/consortium-agent.ts
+++ b/src/api/entitycore/queries/general/consortium-agent.ts
@@ -1,4 +1,4 @@
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { config } from '@/config';
 
 import type { IConsortiumFilter } from '@/api/entitycore/types/entities/agent';

--- a/src/api/entitycore/queries/general/contribution.ts
+++ b/src/api/entitycore/queries/general/contribution.ts
@@ -1,6 +1,6 @@
 import z from 'zod';
 
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { getEntityCoreContext } from '@/api/entitycore/utils';
 import { config } from '@/config';
 

--- a/src/api/entitycore/queries/general/organization-agent.ts
+++ b/src/api/entitycore/queries/general/organization-agent.ts
@@ -1,4 +1,4 @@
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { config } from '@/config';
 
 import type { IOrganizationFilter } from '@/api/entitycore/types/entities/agent';

--- a/src/api/entitycore/queries/general/person-agent.ts
+++ b/src/api/entitycore/queries/general/person-agent.ts
@@ -1,9 +1,9 @@
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { config } from '@/config';
 
-import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { IPersonFilter } from '@/api/entitycore/types/entities/agent';
 import type { IPerson } from '@/api/entitycore/types/shared/global';
+import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 
 const baseUri = '/person';
 /**

--- a/src/api/entitycore/schemas/base.ts
+++ b/src/api/entitycore/schemas/base.ts
@@ -1,0 +1,363 @@
+import { z } from 'zod';
+
+export const EntityTypeEnum = z.enum([
+  'analysis_software_source_code',
+  'brain_atlas',
+  'brain_atlas_region',
+  'cell_composition',
+  'cell_morphology',
+  'cell_morphology_protocol',
+  'electrical_cell_recording',
+  'electrical_recording',
+  'electrical_recording_stimulus',
+  'emodel',
+  'experimental_bouton_density',
+  'experimental_neuron_density',
+  'experimental_synapses_per_connection',
+  'external_url',
+  'ion_channel_model',
+  'ion_channel_modeling_campaign',
+  'ion_channel_modeling_config',
+  'ion_channel_recording',
+  'memodel',
+  'memodel_calibration_result',
+  'me_type_density',
+  'simulation',
+  'simulation_campaign',
+  'simulation_result',
+  'scientific_artifact',
+  'single_neuron_simulation',
+  'single_neuron_synaptome',
+  'single_neuron_synaptome_simulation',
+  'subject',
+  'validation_result',
+  'circuit',
+  'circuit_extraction_campaign',
+  'circuit_extraction_config',
+  'em_dense_reconstruction_dataset',
+  'em_cell_mesh',
+  'analysis_notebook_template',
+  'analysis_notebook_environment',
+  'analysis_notebook_result',
+  'skeletonization_config',
+  'skeletonization_campaign',
+]);
+
+export const RepairPipelineTypeEnum = z.enum(['raw', 'curated', 'unraveled', 'repaired']);
+
+export const SexEnum = z.enum(['male', 'female', 'unknown']);
+
+export const AgePeriodEnum = z.enum(['prenatal', 'postnatal', 'unknown']);
+
+export const ContentTypeEnum = z.enum([
+  'application/json',
+  'application/swc',
+  'application/nrrd',
+  'application/obj',
+  'application/hoc',
+  'application/asc',
+  'application/abf',
+  'application/nwb',
+  'application/x-hdf5',
+  'text/plain',
+  'application/vnd.directory',
+  'application/mod',
+  'application/pdf',
+  'image/png',
+  'image/jpeg',
+  'model/gltf-binary',
+  'application/gzip',
+  'image/webp',
+  'application/x-ipynb+json',
+  'application/zip',
+]);
+
+export const StorageTypeEnum = z.enum(['aws_s3_internal', 'aws_s3_open']);
+
+export const AssetStatusEnum = z.enum(['created', 'uploading', 'deleted']);
+
+export const AssetLabelEnum = z.enum([
+  'morphology',
+  'morphology_with_spines',
+  'cell_composition_summary',
+  'cell_composition_volumes',
+  'single_neuron_synaptome_config',
+  'single_neuron_synaptome_simulation_data',
+  'single_neuron_simulation_data',
+  'sonata_circuit',
+  'compressed_sonata_circuit',
+  'circuit_figures',
+  'circuit_analysis_data',
+  'circuit_connectivity_matrices',
+  'nwb',
+  'neuron_hoc',
+  'emodel_optimization_output',
+  'sonata_simulation_config',
+  'simulation_generation_config',
+  'ion_channel_modeling_generation_config',
+  'custom_node_sets',
+  'campaign_generation_config',
+  'campaign_summary',
+  'replay_spikes',
+  'voltage_report',
+  'spike_report',
+  'neuron_mechanisms',
+  'brain_atlas_annotation',
+  'brain_atlas_region_mesh',
+  'voxel_densities',
+  'validation_result_figure',
+  'validation_result_details',
+  'simulation_designer_image',
+  'circuit_visualization',
+  'node_stats',
+  'network_stats_a',
+  'network_stats_b',
+  'cell_surface_mesh',
+  'jupyter_notebook',
+  'requirements',
+  'notebook_required_files',
+  'ion_channel_model_figure',
+  'ion_channel_model_figure_summary_json',
+  'ion_channel_model_thumbnail',
+  'circuit_extraction_config',
+  'skeletonization_config',
+]);
+
+export const CellMorphologyProtocolDesignEnum = z.enum([
+  'electron_microscopy',
+  'cell_patch',
+  'fluorophore',
+  'topological_synthesis',
+]);
+
+export const CellMorphologyGenerationTypeEnum = z.enum([
+  'digital_reconstruction',
+  'modified_reconstruction',
+  'computationally_synthesized',
+  'placeholder',
+]);
+
+export const StainingTypeEnum = z.enum([
+  'golgi',
+  'nissl',
+  'luxol_fast_blue',
+  'fluorescent_nissl',
+  'fluorescent_dyes',
+  'fluorescent_protein_expression',
+  'immunohistochemistry',
+  'other',
+]);
+
+export const SlicingDirectionTypeEnum = z.enum(['coronal', 'sagittal', 'horizontal', 'custom']);
+
+export const ModifiedMorphologyMethodTypeEnum = z.enum([
+  'cloned',
+  'mix_and_match',
+  'mousified',
+  'ratified',
+]);
+
+export const PointLocationSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  z: z.number(),
+});
+
+export const PersonSchema = z.object({
+  id: z.string().uuid(),
+  type: z.string(),
+  sub_id: z.string().uuid().nullable(),
+  given_name: z.string().nullable().optional(),
+  family_name: z.string().nullable().optional(),
+  pref_label: z.string(),
+});
+
+export const TimestampsSchema = z.object({
+  creation_date: z.string().datetime(),
+  update_date: z.string().datetime(),
+});
+
+export const OwnershipSchema = z.object({
+  created_by: PersonSchema,
+  updated_by: PersonSchema,
+});
+
+export const SpeciesSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  taxonomy_id: z.string(),
+});
+
+export const StrainSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  taxonomy_id: z.string(),
+  species_id: z.string().uuid(),
+});
+
+export const BrainRegionSchema = z.object({
+  id: z.string().uuid(),
+  annotation_value: z.number().int(),
+  name: z.string(),
+  acronym: z.string(),
+  color_hex_triplet: z.string(),
+  parent_structure_id: z.string().uuid().nullable(),
+  hierarchy_id: z.string().uuid(),
+});
+
+export const SubjectSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  description: z.string(),
+  sex: SexEnum,
+  weight: z.number().positive().nullable().optional(),
+  age_value: z.number().nullable().optional(),
+  age_min: z.number().nullable().optional(),
+  age_max: z.number().nullable().optional(),
+  age_period: AgePeriodEnum.nullable().optional(),
+  species: SpeciesSchema,
+  strain: StrainSchema.nullable(),
+});
+
+export const LicenseSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  description: z.string(),
+  label: z.string(),
+  creation_date: z.string().datetime(),
+  update_date: z.string().datetime(),
+});
+
+export const AssetSchema = z.object({
+  id: z.string().uuid(),
+  path: z.string(),
+  full_path: z.string(),
+  is_directory: z.boolean(),
+  content_type: ContentTypeEnum,
+  meta: z.record(z.unknown()).default({}),
+  label: AssetLabelEnum,
+  storage_type: StorageTypeEnum,
+  size: z.number().int(),
+  sha256_digest: z.string().nullable(),
+  status: AssetStatusEnum,
+});
+
+export const RoleSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  role_id: z.string(),
+  creation_date: z.string().datetime(),
+  update_date: z.string().datetime(),
+});
+
+export const AgentSchema = z.union([
+  PersonSchema,
+  z.object({
+    id: z.string().uuid(),
+    type: z.string(),
+    pref_label: z.string(),
+    alternative_name: z.string().nullable().optional(),
+  }),
+]);
+
+export const ContributionSchema = z.object({
+  id: z.string().uuid(),
+  agent: AgentSchema,
+  role: RoleSchema,
+});
+
+export const AnnotationSchema = z.object({
+  id: z.string().uuid(),
+  pref_label: z.string(),
+  alt_label: z.string().nullable().optional(),
+  definition: z.string(),
+  creation_date: z.string().datetime(),
+  update_date: z.string().datetime(),
+});
+
+export const MTypeClassSchema = AnnotationSchema;
+
+export const PaginationResponseSchema = z.object({
+  page: z.number().int(),
+  page_size: z.number().int(),
+  total_items: z.number().int(),
+});
+
+export const FacetSchema = z.object({
+  id: z.union([z.string().uuid(), z.number().int()]),
+  label: z.string(),
+  count: z.number().int(),
+  type: z.string().nullable(),
+});
+
+export const FacetsSchema = z.record(z.array(FacetSchema));
+
+export const IdentitySchema = z.object({
+  id: z.string().uuid(),
+});
+
+export const EntityTypeSchema = z.object({
+  type: EntityTypeEnum.nullable().optional(),
+});
+
+export const AuthorizationSchema = z.object({
+  authorized_project_id: z.string().uuid(),
+  authorized_public: z.boolean().default(false),
+});
+
+export const DisplayMetadataSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+});
+
+export const BasicSchema = IdentitySchema.merge(OwnershipSchema)
+  .merge(DisplayMetadataSchema)
+  .merge(AuthorizationSchema)
+  .merge(TimestampsSchema)
+  .merge(EntityTypeSchema);
+
+export function makeListResponse<T extends z.ZodTypeAny>(itemSchema: T) {
+  return z.object({
+    data: z.array(itemSchema),
+    pagination: PaginationResponseSchema,
+    facets: FacetsSchema.nullable().optional(),
+  });
+}
+
+export type TEntityType = z.infer<typeof EntityTypeEnum>;
+export type TRepairPipelineType = z.infer<typeof RepairPipelineTypeEnum>;
+export type TSex = z.infer<typeof SexEnum>;
+export type TAgePeriod = z.infer<typeof AgePeriodEnum>;
+export type TContentType = z.infer<typeof ContentTypeEnum>;
+export type TStorageType = z.infer<typeof StorageTypeEnum>;
+export type TAssetStatus = z.infer<typeof AssetStatusEnum>;
+export type TAssetLabel = z.infer<typeof AssetLabelEnum>;
+export type TCellMorphologyProtocolDesign = z.infer<typeof CellMorphologyProtocolDesignEnum>;
+export type TCellMorphologyGenerationType = z.infer<typeof CellMorphologyGenerationTypeEnum>;
+export type TStainingType = z.infer<typeof StainingTypeEnum>;
+export type TSlicingDirectionType = z.infer<typeof SlicingDirectionTypeEnum>;
+export type TModifiedMorphologyMethodType = z.infer<typeof ModifiedMorphologyMethodTypeEnum>;
+
+export type TPointLocation = z.infer<typeof PointLocationSchema>;
+export type TPerson = z.infer<typeof PersonSchema>;
+export type TTimestamps = z.infer<typeof TimestampsSchema>;
+export type TOwnership = z.infer<typeof OwnershipSchema>;
+export type TSpecies = z.infer<typeof SpeciesSchema>;
+export type TStrain = z.infer<typeof StrainSchema>;
+export type TBrainRegion = z.infer<typeof BrainRegionSchema>;
+export type TSubject = z.infer<typeof SubjectSchema>;
+export type TLicense = z.infer<typeof LicenseSchema>;
+export type TAsset = z.infer<typeof AssetSchema>;
+export type TRole = z.infer<typeof RoleSchema>;
+export type TAgent = z.infer<typeof AgentSchema>;
+export type TContribution = z.infer<typeof ContributionSchema>;
+export type TAnnotation = z.infer<typeof AnnotationSchema>;
+export type TMTypeClass = z.infer<typeof MTypeClassSchema>;
+export type TPaginationResponse = z.infer<typeof PaginationResponseSchema>;
+export type TFacet = z.infer<typeof FacetSchema>;
+export type TFacets = z.infer<typeof FacetsSchema>;
+export type TIdentity = z.infer<typeof IdentitySchema>;
+export type TEntityTypeObj = z.infer<typeof EntityTypeSchema>;
+export type TAuthorization = z.infer<typeof AuthorizationSchema>;
+export type TDisplayMetadata = z.infer<typeof DisplayMetadataSchema>;
+export type TBasic = z.infer<typeof BasicSchema>;

--- a/src/api/entitycore/schemas/cell-morphology.ts
+++ b/src/api/entitycore/schemas/cell-morphology.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod';
+
+import {
+  AssetSchema,
+  BasicSchema,
+  BrainRegionSchema,
+  CellMorphologyProtocolDesignEnum,
+  ContributionSchema,
+  LicenseSchema,
+  ModifiedMorphologyMethodTypeEnum,
+  MTypeClassSchema,
+  PointLocationSchema,
+  RepairPipelineTypeEnum,
+  SlicingDirectionTypeEnum,
+  StainingTypeEnum,
+  SubjectSchema,
+} from '@/api/entitycore/schemas/base';
+
+import { MeasurementAnnotationSchema } from './measurement';
+
+const ProtocolBaseSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  description: z.string(),
+  type: z.literal('cell_morphology_protocol'),
+});
+
+export const NestedDigitalReconstructionProtocolSchema = ProtocolBaseSchema.extend({
+  generation_type: z.literal('digital_reconstruction'),
+  protocol_document: z.string().url().nullable().optional(),
+  protocol_design: CellMorphologyProtocolDesignEnum,
+  staining_type: StainingTypeEnum.nullable().optional(),
+  slicing_thickness: z.number().min(0),
+  slicing_direction: SlicingDirectionTypeEnum.nullable().optional(),
+  magnification: z.number().min(0).nullable().optional(),
+  tissue_shrinkage: z.number().min(0).nullable().optional(),
+  corrected_for_shrinkage: z.boolean().nullable().optional(),
+});
+
+export const NestedModifiedReconstructionProtocolSchema = ProtocolBaseSchema.extend({
+  generation_type: z.literal('modified_reconstruction'),
+  protocol_document: z.string().url().nullable().optional(),
+  protocol_design: CellMorphologyProtocolDesignEnum,
+  method_type: ModifiedMorphologyMethodTypeEnum,
+});
+
+export const NestedComputationallySynthesizedProtocolSchema = ProtocolBaseSchema.extend({
+  generation_type: z.literal('computationally_synthesized'),
+  protocol_document: z.string().url().nullable().optional(),
+  protocol_design: CellMorphologyProtocolDesignEnum,
+  method_type: z.string(),
+});
+
+export const NestedPlaceholderProtocolSchema = ProtocolBaseSchema.extend({
+  generation_type: z.literal('placeholder'),
+});
+
+export const NestedCellMorphologyProtocolSchema = z.discriminatedUnion('generation_type', [
+  NestedDigitalReconstructionProtocolSchema,
+  NestedModifiedReconstructionProtocolSchema,
+  NestedComputationallySynthesizedProtocolSchema,
+  NestedPlaceholderProtocolSchema,
+]);
+
+export const CellMorphologySchema = z
+  .object({
+    experiment_date: z.string().datetime().nullable().optional(),
+    contact_email: z.string().nullable().optional(),
+    published_in: z.string().nullable().optional(),
+    notice_text: z.string().nullable().optional(),
+    location: PointLocationSchema.nullable(),
+    legacy_id: z.array(z.string()).nullable().optional(),
+    has_segmented_spines: z.boolean().default(false),
+    repair_pipeline_state: RepairPipelineTypeEnum.nullable().optional(),
+    subject: SubjectSchema,
+    brain_region: BrainRegionSchema,
+    license: LicenseSchema.nullable().optional(),
+    assets: z.array(AssetSchema),
+    contributions: z.array(ContributionSchema).nullable(),
+    mtypes: z.array(MTypeClassSchema).nullable(),
+    cell_morphology_protocol: NestedCellMorphologyProtocolSchema.nullable(),
+  })
+  .merge(BasicSchema);
+
+export type TCellMorphology = z.infer<typeof CellMorphologySchema>;
+
+export const CellMorphologyAnnotationExpandedSchema = CellMorphologySchema.extend({
+  measurement_annotation: MeasurementAnnotationSchema.nullable(),
+});
+
+export type TCellMorphologyAnnotationExpanded = z.infer<
+  typeof CellMorphologyAnnotationExpandedSchema
+>;

--- a/src/api/entitycore/schemas/measurement.ts
+++ b/src/api/entitycore/schemas/measurement.ts
@@ -1,0 +1,58 @@
+import z from 'zod';
+
+import { IdentitySchema, TimestampsSchema } from './base';
+
+export const MeasurementStatisticEnum = z.enum([
+  'mean',
+  'median',
+  'mode',
+  'variance',
+  'data_point',
+  'sample_size',
+  'standard_error',
+  'standard_deviation',
+  'raw',
+  'minimum',
+  'maximum',
+  'sum',
+]);
+
+export const MeasurementUnitEnum = z.enum([
+  'dimensionless',
+  '1/μm',
+  '1/μm²',
+  '1/mm³',
+  'μm',
+  'μm²',
+  'μm³',
+  'radian',
+]);
+
+export const StructuralDomainEnum = z.enum([
+  'apical_dendrite',
+  'basal_dendrite',
+  'axon',
+  'soma',
+  'neuron_morphology',
+  'not_applicable',
+]);
+
+export const MeasurableEntityTypeSchema = z.string();
+
+export const MeasurementItemSchema = z.object({
+  name: MeasurementStatisticEnum.nullable(),
+  unit: MeasurementUnitEnum.nullable(),
+  value: z.number().nullable(),
+});
+
+export const MeasurementKindSchema = z.object({
+  structural_domain: StructuralDomainEnum,
+  measurement_items: z.array(MeasurementItemSchema),
+  pref_label: z.string(),
+});
+
+export const MeasurementAnnotationSchema = IdentitySchema.merge(TimestampsSchema).extend({
+  entity_id: z.string().uuid(),
+  entity_type: MeasurableEntityTypeSchema,
+  measurement_kinds: z.array(MeasurementKindSchema),
+});

--- a/src/api/entitycore/types/shared/global.ts
+++ b/src/api/entitycore/types/shared/global.ts
@@ -13,7 +13,6 @@ export type EntityCoreDataType =
 
 export type EntityCoreIdentifiable = {
   id: string;
-  legacy_id: Array<string> | null;
 };
 
 export type EntityCoreType = {

--- a/src/api/entitycore/utils.ts
+++ b/src/api/entitycore/utils.ts
@@ -1,6 +1,6 @@
 import { find, snakeCase } from 'es-toolkit/compat';
 
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { config as appConfig } from '@/config';
 
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';

--- a/src/api/error.ts
+++ b/src/api/error.ts
@@ -18,6 +18,42 @@ export class ApiError extends Error {
     this.name = 'ApiError';
     this.cause = cause;
   }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      cause: this.cause,
+    };
+  }
+}
+
+export type ValidationTarget = 'queryParams' | 'body' | 'response';
+
+export class ValidationError extends ApiError {
+  public readonly issues: Array<{
+    path: (string | number)[];
+    message: string;
+    [key: string]: any;
+  }>;
+
+  constructor(target: ValidationTarget, zodError: { issues: ValidationError['issues'] }) {
+    const summary = zodError.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+    super(`Validation failed for ${target}`);
+    this.name = 'ValidationError';
+    this.issues = zodError.issues;
+    this.cause = {
+      message: summary,
+      details: this.issues,
+    };
+  }
+
+  override toJSON() {
+    return {
+      ...super.toJSON(),
+      issues: this.issues,
+    };
+  }
 }
 
 export default ApiError;

--- a/src/api/one/utils.ts
+++ b/src/api/one/utils.ts
@@ -1,4 +1,4 @@
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { config } from '@/config';
 
 export async function obioneApi(url?: string) {

--- a/src/api/small-scale-simulator/utils.ts
+++ b/src/api/small-scale-simulator/utils.ts
@@ -1,4 +1,4 @@
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { config } from '@/config';
 
 export async function smallScaleSimulatorApi(url?: string) {

--- a/src/api/virtual-lab-svc/utils.ts
+++ b/src/api/virtual-lab-svc/utils.ts
@@ -1,4 +1,4 @@
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { config } from '@/config';
 
 export async function virtualLabRootApi(url?: string) {

--- a/src/components/ai-assistant/message-item/message-item.tsx
+++ b/src/components/ai-assistant/message-item/message-item.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 import React from 'react';
-import { ToolInvocation, UIMessage } from '@ai-sdk/ui-utils';
 
-import { MINIMAL_PANEL_SIZE, usePanelWidth } from '../hooks';
-import ToolsProgress from './tools-progress';
-import ToolsComponents from './tools-components';
-
-import { classNames } from '@/util/utils';
 import { GithubFlavorMarkdown } from '@/components/github-flavor-markdown';
 import { isString } from '@/util/type-guards';
+import { classNames } from '@/util/utils';
+import { log } from '@/utils/logger';
+
+import { MINIMAL_PANEL_SIZE, usePanelWidth } from '../hooks';
+import ToolsComponents from './tools-components';
+import ToolsProgress from './tools-progress';
+
+import type { ToolInvocation, UIMessage } from '@ai-sdk/ui-utils';
 
 import styles from './message-item.module.css';
 
@@ -98,21 +100,15 @@ function MessageChild({ value, debug }: { value: UIMessage; debug: boolean }): R
 }
 
 function debugToConsole(value: UIMessage) {
-  // eslint-disable-next-line no-console
-  console.log(value);
   for (const part of value.parts) {
     if (part.type !== 'tool-invocation') continue;
 
     const toolInvocation = part.toolInvocation as ToolInvocation & { result: string };
-    // eslint-disable-next-line no-console
-    console.debug(`%c${toolInvocation.toolName}`, 'font-weight: bolder; font-size: 110%');
     const { result } = toolInvocation;
     try {
-      // eslint-disable-next-line no-console
-      console.debug(JSON.parse(result));
-    } catch (ex) {
-      // eslint-disable-next-line no-console
-      console.error('Not a valid JSON:', result);
+      log('info', JSON.parse(result));
+    } catch {
+      log('error', 'Not a valid JSON:', result);
     }
   }
 }
@@ -131,7 +127,7 @@ function formatDate(d: Date | string): string {
     });
     const date = isString(d) ? new Date(d) : d;
     return formatter.format(date);
-  } catch (ex) {
+  } catch {
     return '';
   }
 }

--- a/src/entity-configuration/domain/experimental/cell-morphology.ts
+++ b/src/entity-configuration/domain/experimental/cell-morphology.ts
@@ -11,11 +11,6 @@ import { ViewsDefinitionRegistry } from '@/entity-configuration/definitions/view
 import { EntityTypeGroup } from '@/entity-configuration/domain/group';
 import { EntitySlug } from '@/entity-configuration/domain/slug';
 
-import type {
-  ICellMorphology,
-  ICellMorphologyExpanded,
-} from '@/api/entitycore/types/entities/cell-morphology';
-
 // TODO: Uncomment until entitycore support filtering by `not_in`
 // export const cellMorphologyGenerationTypeFilter = {
 //   cell_morphology_protocol__generation_type__in: without(
@@ -24,9 +19,15 @@ import type {
 //   ),
 // };
 
+import type {
+  TCellMorphology,
+  TCellMorphologyAnnotationExpanded,
+} from '@/api/entitycore/schemas/cell-morphology';
 import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
 
-export const CellMorphology: EntityCoreTypeConfig<ICellMorphology | ICellMorphologyExpanded> = {
+export const CellMorphology: EntityCoreTypeConfig<
+  TCellMorphology | TCellMorphologyAnnotationExpanded
+> = {
   group: EntityTypeGroup.Experimental,
   title: 'Morphology',
   extendedType: ExtendedEntitiesTypeDict.CellMorphology,

--- a/src/features/offline-auth-management/auth-manager-client.ts
+++ b/src/features/offline-auth-management/auth-manager-client.ts
@@ -1,4 +1,4 @@
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { config } from '@/config';
 
 type RawRequestConsentResponse = {


### PR DESCRIPTION
- add `zod` schema validation for api-client
- the validation is optional for the moment
- the validation is on 
    - query parameters 
    - request body
    - response
- i updated the cell morphology to use the schema validation on response for the time being for test
- i would suggest to keep it optional, and update endpoint gradually to not break more the linting, and functionalities 
- this is require the `zod` schema to be in sync with pydantic schemas of entitycore (or whatever service use this client)

cc: @tolokoban 