### PR TITLE
round credits in activity logs

### DIFF
--- a/src/ui/segments/project/credits/job-report-list.tsx
+++ b/src/ui/segments/project/credits/job-report-list.tsx
@@ -78,7 +78,9 @@ function scaleRenderFn(subtype: ServiceSubtype) {
 }
 
 function costRenderFn(amount: string) {
-  return <span>{amount}</span>;
+  const numericAmount = parseFloat(amount);
+  const formattedAmount = Number.isNaN(numericAmount) ? amount : numericAmount.toFixed(2);
+  return <span>{formattedAmount}</span>;
 }
 
 export function JobReportList() {


### PR DESCRIPTION
credits are round to 2 decimal in the activity log:
for instance:
1564.5998 -> 1564.60