### PR TITLE
fix link color

### DIFF
--- a/src/entity-configuration/definitions/renderer.tsx
+++ b/src/entity-configuration/definitions/renderer.tsx
@@ -44,7 +44,7 @@ export const renderLicense = ({ license }: { license?: ILicense | null }) => {
       href={license.name}
       target="_blank"
       rel="noopener noreferrer"
-      className="line-clamp-1 truncate"
+      className="line-clamp-1 truncate text-inherit"
     >
       {license.label ?? 'View license'} 🔗
     </a>


### PR DESCRIPTION
The text for the license gets the default color of the browser as it is a hyperlink. Therefore it is not readable in preview as it is blue against darkblue. and it looks a different blue in the detail page.
Now it inherits from the parent element and gets the same color.