### PR TITLE
Support multiple NWB files within a single entity

### DIFF
--- a/src/features/ephys-viewer/atoms/index.ts
+++ b/src/features/ephys-viewer/atoms/index.ts
@@ -11,13 +11,17 @@ import type { WorkspaceContext } from '@/types/common';
 export const nwbArrayBufferAtomFamily = readAtomFamilyWithExpiration(
   ({
     entity,
+    assetId,
     ctx,
   }: {
     entity: IElectricalCellRecording | ICircuitSimulationResult;
+    assetId?: string;
     ctx?: WorkspaceContext;
   }) =>
     atom<Promise<ArrayBuffer>>(() => {
-      const asset = entity.assets?.find((a) => a.content_type === 'application/nwb');
+      const asset = assetId
+        ? entity.assets?.find((a) => a.id === assetId)
+        : entity.assets?.find((a) => a.content_type === 'application/nwb');
 
       if (!asset) {
         throw new Error('No NWB file found');

--- a/src/features/ephys-viewer/ephys-viewer.tsx
+++ b/src/features/ephys-viewer/ephys-viewer.tsx
@@ -1,5 +1,5 @@
 import { FileImageOutlined, LineChartOutlined } from '@ant-design/icons';
-import { Empty, Radio, RadioChangeEvent, Spin } from 'antd';
+import { Empty, Radio, type RadioChangeEvent, Spin } from 'antd';
 import { useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
@@ -21,12 +21,14 @@ enum VIEW {
 
 export default function EphysViewer({
   resource,
+  assetId,
   ctx,
 }: {
   resource: IElectricalCellRecording | ICircuitSimulationResult;
+  assetId?: string;
   ctx?: WorkspaceContext;
 }) {
-  const [trace, error] = useTrace({ resource, ctx });
+  const [trace, error] = useTrace({ resource, assetId, ctx });
 
   const [view, setView] = useState<VIEW>(VIEW.OVERVIEW);
   const [repetition, setRepetition] = useState<string>();

--- a/src/features/ephys-viewer/hooks/use-nwb-trace.ts
+++ b/src/features/ephys-viewer/hooks/use-nwb-trace.ts
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAtomValue } from 'jotai';
 import { loadable } from 'jotai/utils';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { nwbArrayBufferAtomFamily } from '@/features/ephys-viewer/atoms';
 import NWBTrace from '@/features/ephys-viewer/nwb-trace';
@@ -11,13 +11,18 @@ import type { WorkspaceContext } from '@/types/common';
 
 type UseTraceArgs = {
   resource: IElectricalCellRecording | ICircuitSimulationResult;
+  assetId?: string;
   ctx?: WorkspaceContext;
 };
 
-export default function useTrace({ resource, ctx }: UseTraceArgs): [NWBTrace | null, Error | null] {
+export default function useTrace({
+  resource,
+  assetId,
+  ctx,
+}: UseTraceArgs): [NWBTrace | null, Error | null] {
   const nwbAtom = useMemo(
-    () => loadable(nwbArrayBufferAtomFamily({ entity: resource, ctx })),
-    [ctx, resource]
+    () => loadable(nwbArrayBufferAtomFamily({ entity: resource, assetId, ctx })),
+    [ctx, resource, assetId]
   );
   const nwb = useAtomValue(nwbAtom);
 
@@ -41,7 +46,9 @@ export default function useTrace({ resource, ctx }: UseTraceArgs): [NWBTrace | n
 
     initialized.current = true;
 
-    NWBTrace.create(resource.id, nwbArrayBuffer)
+    const traceId = assetId ?? resource.id;
+
+    NWBTrace.create(traceId, nwbArrayBuffer)
       .then((t) => {
         traceRef.current = t;
         setTrace(t);
@@ -52,7 +59,7 @@ export default function useTrace({ resource, ctx }: UseTraceArgs): [NWBTrace | n
       traceRef.current?.destroy();
       initialized.current = false;
     };
-  }, [nwbArrayBuffer, resource]);
+  }, [nwbArrayBuffer, resource, assetId]);
 
   return [trace, error];
 }

--- a/src/features/scan-config/components/file-viewer/index.tsx
+++ b/src/features/scan-config/components/file-viewer/index.tsx
@@ -132,9 +132,14 @@ type NwbFileViewerProps = {
 };
 
 function NwbFileViewer({ file, context }: NwbFileViewerProps) {
-  const { entity } = file;
+  const { entity, asset } = file;
   return (
-    <EphysViewer key={entity.id} resource={entity as ICircuitSimulationResult} ctx={context} />
+    <EphysViewer
+      key={asset.id}
+      resource={entity as ICircuitSimulationResult}
+      assetId={asset.id}
+      ctx={context}
+    />
   );
 }
 


### PR DESCRIPTION
Simulation results might have multiple NWB files but the current version of the ephors viewer assumes there is only one such file. This PR addresses that issue.