### PR TITLE
Address linting issues in src/api folder

### DIFF
--- a/src/api/api-client.ts
+++ b/src/api/api-client.ts
@@ -61,8 +61,6 @@ class ApiClient {
 
   private _token?: string;
 
-  private _timeout?: number;
-
   private _attempts?: number;
 
   private _backoff?: BackoffStrategy;
@@ -84,7 +82,6 @@ class ApiClient {
       'Content-Type': 'application/json',
     };
     this._token = token;
-    this._timeout = config.timeout;
     this._attempts = config.attempts;
     this._backoff = config.backoff;
     this._retryOnError = config.retryOnError;
@@ -221,7 +218,7 @@ class ApiClient {
 
     Object.entries(omitBy(options.queryParams, isNil) || {}).forEach(([key, value]) => {
       if (Array.isArray(value)) {
-        value.forEach((v) => url.searchParams.append(`${key}`, `${v}`));
+        value.forEach((v) => void url.searchParams.append(`${key}`, `${v}`));
       } else {
         url.searchParams.append(key, String(value));
       }

--- a/src/api/auth-manager/index.ts
+++ b/src/api/auth-manager/index.ts
@@ -1,4 +1,4 @@
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 
 export async function authManagerApi(url?: string) {
   const api = await authApiClient(url ?? 'https://staging.openbraininstitute.org/api/auth-manager');

--- a/src/api/entitycore/guards.ts
+++ b/src/api/entitycore/guards.ts
@@ -1,17 +1,17 @@
 import { EntityTypeDict } from '@/api/entitycore/types/entity-type';
 
-import type { EntityCoreBaseAsset } from '@/api/entitycore/types/shared/global';
 import type {
-  IExperimentalSynapsesPerConnection,
-  IExperimentalBoutonDensity,
-  IExperimentalNeuronDensity,
+  EntityCoreObjectTypes,
   ICellMorphology,
   IElectricalCellRecording,
-  ISingleNeuronSynaptome,
-  EntityCoreObjectTypes,
   IEModel,
+  IExperimentalBoutonDensity,
+  IExperimentalNeuronDensity,
+  IExperimentalSynapsesPerConnection,
   IMEModel,
+  ISingleNeuronSynaptome,
 } from '@/api/entitycore/types';
+import type { EntityCoreBaseAsset } from '@/api/entitycore/types/shared/global';
 
 export function hasAssets(
   obj?: EntityCoreObjectTypes | null

--- a/src/api/entitycore/queries/annotations/etype-classification.ts
+++ b/src/api/entitycore/queries/annotations/etype-classification.ts
@@ -1,7 +1,7 @@
 import z from 'zod';
 
+import { authApiClient } from '@/api/api-client';
 import { getEntityCoreContext } from '@/api/entitycore/utils';
-import { authApiClient } from '@/api/apiClient';
 import { config } from '@/config';
 
 import type { IETypeClassification } from '@/api/entitycore/types/shared/global';

--- a/src/api/entitycore/queries/annotations/etype.ts
+++ b/src/api/entitycore/queries/annotations/etype.ts
@@ -1,9 +1,9 @@
+import { authApiClient } from '@/api/api-client';
 import { getEntityCoreContext } from '@/api/entitycore/utils';
-import { authApiClient } from '@/api/apiClient';
 import { config } from '@/config';
 
-import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { IEType, IETypeFilter } from '@/api/entitycore/types/shared/global';
+import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/etype';

--- a/src/api/entitycore/queries/annotations/mtype-classification.ts
+++ b/src/api/entitycore/queries/annotations/mtype-classification.ts
@@ -1,6 +1,6 @@
 import z from 'zod';
 
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { getEntityCoreContext } from '@/api/entitycore/utils';
 import { config } from '@/config';
 

--- a/src/api/entitycore/queries/annotations/mtype.ts
+++ b/src/api/entitycore/queries/annotations/mtype.ts
@@ -1,5 +1,5 @@
+import { authApiClient } from '@/api/api-client';
 import { getEntityCoreContext } from '@/api/entitycore/utils';
-import { authApiClient } from '@/api/apiClient';
 import { config } from '@/config';
 
 import type { IMType, IMTypeFilter } from '@/api/entitycore/types/shared/global';

--- a/src/api/entitycore/queries/assets/index.ts
+++ b/src/api/entitycore/queries/assets/index.ts
@@ -1,6 +1,6 @@
 import { kebabCase } from 'es-toolkit/compat';
 
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { getEntityCoreContext } from '@/api/entitycore/utils';
 import { config } from '@/config';
 import { compactRecord } from '@/utils/dictionary';

--- a/src/api/entitycore/queries/experimental/bouton-density.ts
+++ b/src/api/entitycore/queries/experimental/bouton-density.ts
@@ -1,11 +1,13 @@
 import z from 'zod';
+
 import { measurementSchema } from '@/api/entitycore/queries/experimental/neuron-density';
+import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
+
 import type {
   ExperimentalBoutonDensityFilter,
   IExperimentalBoutonDensity,
 } from '@/api/entitycore/types/entities/bouton-density';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
-import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/experimental-bouton-density';
@@ -65,27 +67,16 @@ export async function getExperimentalBoutonDensity({
 
 const ExperimentalBoutonDensitySchema = z.object({
   name: z
-    .string({ message: 'Experimental bouton density name is required' })
-    .nonempty({ message: 'Experimental bouton density name is required' }),
-  description: z
-    .string({ message: 'Experimental bouton density description is required' })
-    .nonempty({
-      message: 'Experimental bouton density description is required',
-    }),
-  brain_region_id: z
-    .string({ message: 'Brain region is required' })
-    .uuid()
-    .nonempty({ message: 'Brain region is required' }),
-  subject_id: z
-    .string({ message: 'Subject is required' })
-    .uuid()
-    .nonempty({ message: 'Subject is required' }),
-  license_id: z
-    .string({ message: 'License is required' })
-    .uuid()
-    .nonempty({ message: 'License is required' }),
+    .string({ error: 'Experimental bouton density name is required' })
+    .nonempty({ error: 'Experimental bouton density name is required' }),
+  description: z.string({ error: 'Experimental bouton density description is required' }).nonempty({
+    error: 'Experimental bouton density description is required',
+  }),
+  brain_region_id: z.uuid({ error: 'Brain region is required' }),
+  subject_id: z.uuid({ error: 'Subject is required' }),
+  license_id: z.uuid({ error: 'License is required' }),
   measurements: z.array(measurementSchema),
-  legacy_id: z.string().uuid().nullable().optional(),
+  legacy_id: z.uuid().nullable().optional(),
 });
 
 export type TExperimentalBoutonDensityCreate = z.infer<typeof ExperimentalBoutonDensitySchema>;

--- a/src/api/entitycore/queries/experimental/electrical-cell-recording.ts
+++ b/src/api/entitycore/queries/experimental/electrical-cell-recording.ts
@@ -3,11 +3,11 @@ import z from 'zod';
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import { compactRecord } from '@/utils/dictionary';
 
-import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type {
   ElectricalCellRecordingFilter,
   IElectricalCellRecording,
 } from '@/api/entitycore/types/entities/electrical-cell-recording';
+import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/electrical-cell-recording';
@@ -71,49 +71,34 @@ export async function getElectricalCellRecording({
 
 const electricalCellRecordingSchema = z.object({
   name: z
-    .string({ message: 'Cell recording name is required' })
-    .nonempty({ message: 'Cell recording name is required' }),
+    .string({ error: 'Cell recording name is required' })
+    .nonempty({ error: 'Cell recording name is required' }),
   description: z
-    .string({ message: 'Cell recording description is required' })
-    .nonempty({ message: 'Cell recording description is required' }),
-  brain_region_id: z
-    .string({ message: 'Brain region is required' })
-    .uuid()
-    .nonempty({ message: 'Brain region is required' }),
-  subject_id: z
-    .string({ message: 'Subject is required' })
-    .uuid()
-    .nonempty({ message: 'Subject is required' }),
-  license_id: z
-    .string({ message: 'License is required' })
-    .uuid()
-    .nonempty({ message: 'License is required' }),
-  experiment_date: z.string({ message: 'Experiment date is required' }).nullish(),
-  contact_email: z
-    .string({ message: 'Contact email is required' })
-    .email({ message: 'Contact email is required' })
-    .nullish(),
-  published_in: z.string({ message: 'Published in is required' }).nullish(),
+    .string({ error: 'Cell recording description is required' })
+    .nonempty({ error: 'Cell recording description is required' }),
+  brain_region_id: z.uuid({ error: 'Brain region is required' }),
+  subject_id: z.uuid({ error: 'Subject is required' }),
+  license_id: z.uuid({ error: 'License is required' }),
+  experiment_date: z.string({ error: 'Experiment date is required' }).nullish(),
+  contact_email: z.email({ error: 'Contact email is required' }).nullish(),
+  published_in: z.string({ error: 'Published in is required' }).nullish(),
   location: z.object({ x: z.number(), y: z.number(), z: z.number() }).nullable(),
   recording_location: z
     .array(
       z
-        .string({ message: 'Cell recording location is required' })
-        .nonempty({ message: 'Cell recording location is required' })
+        .string({ error: 'Cell recording location is required' })
+        .nonempty({ error: 'Cell recording location is required' })
     )
     .nullable(),
   recording_type: z.string({ message: 'Cell recording type is required' }).nonempty({
-    message: 'Cell recording type is required',
+    error: 'Cell recording type is required',
   }),
   recording_origin: z.string({ message: 'Cell recording origin is required' }).nonempty({
-    message: 'Cell recording origin is required',
+    error: 'Cell recording origin is required',
   }),
-  temperature: z
-    .number({ invalid_type_error: 'Temperature must be a number' })
-    .optional()
-    .nullable(),
+  temperature: z.number({ error: 'Temperature must be a number' }).optional().nullable(),
   ljp: z
-    .number({ invalid_type_error: 'Liquid junction potential (ljp) must be a number' })
+    .number({ error: 'Liquid junction potential (ljp) must be a number' })
     .optional()
     .default(0.0),
   comment: z.string().optional().nullable(),

--- a/src/api/entitycore/queries/experimental/em-cell-mesh.ts
+++ b/src/api/entitycore/queries/experimental/em-cell-mesh.ts
@@ -1,13 +1,12 @@
 import z from 'zod';
+
+import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
+
 import type {
-  EMCellMeshFilter,
-  ExpandEMCellMeshParm,
   IEMCellMesh,
-  IEMCellMeshExpanded,
   IEmCellMeshQueryFilters,
 } from '@/api/entitycore/types/entities/em-cell-mesh';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
-import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/em-cell-mesh';
@@ -69,29 +68,17 @@ export async function getEmCellMesh({
 
 const EMCellMeshSchema = z.object({
   name: z
-    .string({ message: 'Cell mesh name is required' })
-    .nonempty({ message: 'Cell mesh name is required' }),
+    .string({ error: 'Cell mesh name is required' })
+    .nonempty({ error: 'Cell mesh name is required' }),
   description: z
-    .string({ message: 'Cell mesh description is required' })
-    .nonempty({ message: 'Cell mesh description is required' }),
-  brain_region_id: z
-    .string({ message: 'Brain region is required' })
-    .uuid()
-    .nonempty({ message: 'Brain region is required' }),
-  subject_id: z
-    .string({ message: 'Subject is required' })
-    .uuid()
-    .nonempty({ message: 'Subject is required' }),
-  license_id: z
-    .string({ message: 'License is required' })
-    .uuid()
-    .nonempty({ message: 'License is required' }),
-  experiment_date: z.string({ message: 'Experiment date is required' }).nullish(),
-  contact_email: z
-    .string({ message: 'Contact email is required' })
-    .email({ message: 'Contact email is required' })
-    .nullish(),
-  published_in: z.string({ message: 'Published in is required' }).nullish(),
+    .string({ error: 'Cell mesh description is required' })
+    .nonempty({ error: 'Cell mesh description is required' }),
+  brain_region_id: z.uuid({ error: 'Brain region is required' }),
+  subject_id: z.uuid({ error: 'Subject is required' }),
+  license_id: z.uuid({ error: 'License is required' }),
+  experiment_date: z.string({ error: 'Experiment date is required' }).nullish(),
+  contact_email: z.string({ error: 'Contact email is required' }).nullish(),
+  published_in: z.string({ error: 'Published in is required' }).nullish(),
   location: z.object({ x: z.number(), y: z.number(), z: z.number() }).nullable(),
 });
 

--- a/src/api/entitycore/queries/experimental/ion-channel-recording.ts
+++ b/src/api/entitycore/queries/experimental/ion-channel-recording.ts
@@ -1,11 +1,11 @@
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import { compactRecord } from '@/utils/dictionary';
 
-import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type {
-  IonChannelRecordingFilter,
   IIonChannelRecording,
+  IonChannelRecordingFilter,
 } from '@/api/entitycore/types/entities/ion-channel-recording';
+import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/ion-channel-recording';

--- a/src/api/entitycore/queries/experimental/neuron-density.ts
+++ b/src/api/entitycore/queries/experimental/neuron-density.ts
@@ -1,11 +1,12 @@
 import z from 'zod';
 
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
-import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
+
 import type {
   ExperimentalNeuronDensityFilter,
   IExperimentalNeuronDensity,
 } from '@/api/entitycore/types/entities/neuron-density';
+import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/experimental-neuron-density';

--- a/src/api/entitycore/queries/experimental/synapses-per-connection.ts
+++ b/src/api/entitycore/queries/experimental/synapses-per-connection.ts
@@ -1,11 +1,13 @@
 import z from 'zod';
+
 import { measurementSchema } from '@/api/entitycore/queries/experimental/neuron-density';
+import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
+
 import type {
   ExperimentalSynapsesPerConnectionFilter,
   IExperimentalSynapsesPerConnection,
 } from '@/api/entitycore/types/entities/synapses-per-connection';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
-import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/experimental-synapses-per-connection';

--- a/src/api/entitycore/queries/extraction/circuit/circuit-extraction-campaign.ts
+++ b/src/api/entitycore/queries/extraction/circuit/circuit-extraction-campaign.ts
@@ -1,3 +1,6 @@
+import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
+import { compactRecord } from '@/utils/dictionary';
+
 import type {
   ICircuitExtractionCampaign,
   ICircuitExtractionCampaignFilter,
@@ -5,9 +8,7 @@ import type {
   TUpdateCircuitExtractionCampaign,
 } from '@/api/entitycore/types/entities/circuit-extraction-campaign';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
-import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import type { WorkspaceContext } from '@/types/common';
-import { compactRecord } from '@/utils/dictionary';
 
 const baseUri = '/circuit-extraction-campaign';
 

--- a/src/api/entitycore/queries/extraction/circuit/circuit-extraction-config-generation.ts
+++ b/src/api/entitycore/queries/extraction/circuit/circuit-extraction-config-generation.ts
@@ -1,3 +1,6 @@
+import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
+import { compactRecord } from '@/utils/dictionary';
+
 import type {
   ICircuitExtractionConfigGeneration,
   ICircuitExtractionConfigGenerationFilter,
@@ -5,9 +8,7 @@ import type {
   TUpdateCircuitExtractionConfigGeneration,
 } from '@/api/entitycore/types/entities/circuit-extraction-config-generation';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
-import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import type { WorkspaceContext } from '@/types/common';
-import { compactRecord } from '@/utils/dictionary';
 
 const baseUri = '/circuit-extraction-config-generation';
 

--- a/src/api/entitycore/queries/extraction/circuit/circuit-extraction-config.ts
+++ b/src/api/entitycore/queries/extraction/circuit/circuit-extraction-config.ts
@@ -1,3 +1,6 @@
+import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
+import { compactRecord } from '@/utils/dictionary';
+
 import type {
   ICircuitExtractionConfig,
   ICircuitExtractionConfigFilter,
@@ -5,9 +8,7 @@ import type {
   TUpdateCircuitExtractionConfig,
 } from '@/api/entitycore/types/entities/circuit-extraction-config';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
-import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import type { WorkspaceContext } from '@/types/common';
-import { compactRecord } from '@/utils/dictionary';
 
 const baseUri = '/circuit-extraction-config';
 

--- a/src/api/entitycore/queries/general/brain-atlas.ts
+++ b/src/api/entitycore/queries/general/brain-atlas.ts
@@ -1,12 +1,13 @@
-import { EntityCoreResponse } from '../../types/shared/response';
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
+
 import type {
   IBrainAtlas,
-  IBrainAtlasRegion,
   IBrainAtlasFilter,
+  IBrainAtlasRegion,
   IBrainAtlasRegionFilter,
 } from '@/api/entitycore/types/entities/brain-atlas';
-import { WorkspaceContext } from '@/types/common';
+import type { WorkspaceContext } from '@/types/common';
+import type { EntityCoreResponse } from '../../types/shared/response';
 
 const baseUri = '/brain-atlas';
 

--- a/src/api/entitycore/queries/general/brain-region.ts
+++ b/src/api/entitycore/queries/general/brain-region.ts
@@ -1,10 +1,11 @@
 import { entityCoreApi } from '@/api/entitycore/utils';
-import {
+import { config } from '@/config';
+
+import type {
   IBrainRegionHierarchy,
   ITemporaryBrainRegionHierarchy,
   TemporaryFlatBrainRegionHierarchy,
 } from '@/api/entitycore/types/entities/brain-region';
-import { config } from '@/config';
 
 /**
  * Retrieves the brain region hierarchy from the Entity Core API.

--- a/src/api/entitycore/queries/general/cell-composition.ts
+++ b/src/api/entitycore/queries/general/cell-composition.ts
@@ -4,8 +4,8 @@ import type {
   ICellComposition,
   ICellCompositionFilter,
 } from '@/api/entitycore/types/entities/cell-composition';
-import type { WorkspaceContext } from '@/types/common';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
+import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/cell-composition';
 

--- a/src/api/entitycore/queries/general/consortium-agent.ts
+++ b/src/api/entitycore/queries/general/consortium-agent.ts
@@ -1,4 +1,4 @@
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { config } from '@/config';
 
 import type { IConsortiumFilter } from '@/api/entitycore/types/entities/agent';

--- a/src/api/entitycore/queries/general/contribution.ts
+++ b/src/api/entitycore/queries/general/contribution.ts
@@ -1,6 +1,6 @@
 import z from 'zod';
 
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { getEntityCoreContext } from '@/api/entitycore/utils';
 import { config } from '@/config';
 

--- a/src/api/entitycore/queries/general/derivation.ts
+++ b/src/api/entitycore/queries/general/derivation.ts
@@ -1,13 +1,13 @@
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 
 import type {
-  IDerivationFilter,
   IDerivationBase,
+  IDerivationFilter,
 } from '@/api/entitycore/types/entities/derivation';
-import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { TEntityTypeDict } from '@/api/entitycore/types/entity-type';
-import type { KebabCase, NormalizeChars } from '@/utils/type';
+import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { WorkspaceContext } from '@/types/common';
+import type { KebabCase, NormalizeChars } from '@/utils/type';
 
 /**
  * Retrieves derivations for a specific entity using the provided route, entity ID, and filter parameters.

--- a/src/api/entitycore/queries/general/electrical-recording-stimulus.ts
+++ b/src/api/entitycore/queries/general/electrical-recording-stimulus.ts
@@ -1,11 +1,11 @@
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import { compactRecord } from '@/utils/dictionary';
 
-import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type {
-  IElectricalRecordingStimulusFilter,
   IElectricalRecordingStimulus,
+  IElectricalRecordingStimulusFilter,
 } from '@/api/entitycore/types/shared/electrical-recording-stimulus';
+import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/electrical-recording-stimulus';

--- a/src/api/entitycore/queries/general/em-dense-reconstruction-dataset.ts
+++ b/src/api/entitycore/queries/general/em-dense-reconstruction-dataset.ts
@@ -1,10 +1,10 @@
+import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
+
 import type {
   IEMDenseReconstructionDatasetFilter,
   IEmDenseReconstructionDataset,
 } from '@/api/entitycore/types/entities/em-dense-reconstruction-dataset';
-
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
-import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/em-dense-reconstruction-dataset';

--- a/src/api/entitycore/queries/general/license.ts
+++ b/src/api/entitycore/queries/general/license.ts
@@ -1,9 +1,9 @@
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import { compactRecord } from '@/utils/dictionary';
 
+import type { ILicense } from '@/api/entitycore/types/shared/global';
 import type { ILicenseFilter } from '@/api/entitycore/types/shared/license';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
-import type { ILicense } from '@/api/entitycore/types/shared/global';
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/license';

--- a/src/api/entitycore/queries/general/measurement-annotation.ts
+++ b/src/api/entitycore/queries/general/measurement-annotation.ts
@@ -1,10 +1,11 @@
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
-import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
-import type { WorkspaceContext } from '@/types/common';
+
 import type {
   MeasurementAnnotation,
   MeasurementAnnotationFilter,
 } from '@/api/entitycore/types/entities/measurement-annotation';
+import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
+import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/measurement-annotation';
 

--- a/src/api/entitycore/queries/general/organization-agent.ts
+++ b/src/api/entitycore/queries/general/organization-agent.ts
@@ -1,4 +1,4 @@
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { config } from '@/config';
 
 import type { IOrganizationFilter } from '@/api/entitycore/types/entities/agent';

--- a/src/api/entitycore/queries/general/person-agent.ts
+++ b/src/api/entitycore/queries/general/person-agent.ts
@@ -1,9 +1,9 @@
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { config } from '@/config';
 
-import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { IPersonFilter } from '@/api/entitycore/types/entities/agent';
 import type { IPerson } from '@/api/entitycore/types/shared/global';
+import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 
 const baseUri = '/person';
 /**

--- a/src/api/entitycore/queries/general/role.ts
+++ b/src/api/entitycore/queries/general/role.ts
@@ -1,8 +1,8 @@
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import { compactRecord } from '@/utils/dictionary';
 
-import type { IRoleFilter, IRole } from '@/api/entitycore/types/shared/role';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
+import type { IRole, IRoleFilter } from '@/api/entitycore/types/shared/role';
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/role';

--- a/src/api/entitycore/queries/general/scientific-artifact-publication-link.ts
+++ b/src/api/entitycore/queries/general/scientific-artifact-publication-link.ts
@@ -1,4 +1,5 @@
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
+import { compactRecord } from '@/utils/dictionary';
 
 import type {
   IScientificArtifactPublicationLink,
@@ -6,7 +7,6 @@ import type {
 } from '@/api/entitycore/types/entities/scientific-artifact-publication-link';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { WorkspaceContext } from '@/types/common';
-import { compactRecord } from '@/utils/dictionary';
 
 const baseUri = '/scientific-artifact-publication-link';
 

--- a/src/api/entitycore/queries/general/species.ts
+++ b/src/api/entitycore/queries/general/species.ts
@@ -1,9 +1,9 @@
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import { compactRecord } from '@/utils/dictionary';
 
-import type { ISpeciesFilter, TSpeciesCreate } from '@/api/entitycore/types/shared/species';
-import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { ISpecies } from '@/api/entitycore/types/shared/global';
+import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
+import type { ISpeciesFilter, TSpeciesCreate } from '@/api/entitycore/types/shared/species';
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/species';

--- a/src/api/entitycore/queries/general/strain.ts
+++ b/src/api/entitycore/queries/general/strain.ts
@@ -1,9 +1,9 @@
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import { compactRecord } from '@/utils/dictionary';
 
+import type { IStrain } from '@/api/entitycore/types/shared/global';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { IStrainFilter, TStrainCreate } from '@/api/entitycore/types/shared/strain';
-import type { IStrain } from '@/api/entitycore/types/shared/global';
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/strain';

--- a/src/api/entitycore/queries/general/subject.tsx
+++ b/src/api/entitycore/queries/general/subject.tsx
@@ -1,9 +1,9 @@
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import { compactRecord } from '@/utils/dictionary';
 
-import type { ISubjectFilter, TSubjectCreate } from '@/api/entitycore/types/shared/subject';
-import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { ISubject } from '@/api/entitycore/types/shared/global';
+import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
+import type { ISubjectFilter, TSubjectCreate } from '@/api/entitycore/types/shared/subject';
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/subject';

--- a/src/api/entitycore/queries/general/validation-result.ts
+++ b/src/api/entitycore/queries/general/validation-result.ts
@@ -1,11 +1,11 @@
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 
-import type { WorkspaceContext } from '@/types/common';
 import type {
   IValidationResult,
   IValidationResultFilter,
 } from '@/api/entitycore/types/entities/validation-result';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
+import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/validation-result';
 

--- a/src/api/entitycore/queries/model/e-model.ts
+++ b/src/api/entitycore/queries/model/e-model.ts
@@ -1,6 +1,6 @@
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 
-import type { IEModelFilter, IEModel } from '@/api/entitycore/types/entities/e-model';
+import type { IEModel, IEModelFilter } from '@/api/entitycore/types/entities/e-model';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { WorkspaceContext } from '@/types/common';
 

--- a/src/api/entitycore/queries/model/ion-channel-model.ts
+++ b/src/api/entitycore/queries/model/ion-channel-model.ts
@@ -1,8 +1,8 @@
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 
 import type {
-  IonChannelModelFilter,
   IonChannelModel,
+  IonChannelModelFilter,
 } from '@/api/entitycore/types/entities/ion-channel';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { WorkspaceContext } from '@/types/common';

--- a/src/api/entitycore/queries/model/single-neuron-synaptome.ts
+++ b/src/api/entitycore/queries/model/single-neuron-synaptome.ts
@@ -1,12 +1,14 @@
 /* eslint-disable no-param-reassign */
-import startsWith from 'es-toolkit/compat/startsWith';
-import some from 'es-toolkit/compat/some';
 
-import { entityCoreApi, getEntityCoreContext, getAssetElement } from '@/api/entitycore/utils';
+import some from 'es-toolkit/compat/some';
+import startsWith from 'es-toolkit/compat/startsWith';
+
+import { downloadAsset } from '@/api/entitycore/queries/assets';
 import { EntityTypeDict } from '@/api/entitycore/types/entity-type';
 import { AssetLabel } from '@/api/entitycore/types/shared/global';
-import { downloadAsset } from '@/api/entitycore/queries/assets';
+import { entityCoreApi, getAssetElement, getEntityCoreContext } from '@/api/entitycore/utils';
 import { tryCatch } from '@/api/utils';
+import { getColorFromGeneratedPalette } from '@/ui/segments/workflows/simulate/single-neuron/shared/steps/webgl-neuron-selector/colors';
 
 import type {
   ISingleNeuronSynaptome,
@@ -16,7 +18,6 @@ import type {
 } from '@/api/entitycore/types/entities/single-neuron-synaptome';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { WorkspaceContext } from '@/types/common';
-import { getColorFromGeneratedPalette } from '@/ui/segments/workflows/simulate/single-neuron/shared/steps/webgl-neuron-selector/colors';
 
 const baseUri = '/single-neuron-synaptome';
 

--- a/src/api/entitycore/transformers.ts
+++ b/src/api/entitycore/transformers.ts
@@ -1,6 +1,7 @@
-import { isEmpty, sortBy, omit, map } from 'es-toolkit/compat';
+import { isEmpty, map, omit, sortBy } from 'es-toolkit/compat';
 
-import { AgentType, type Agent, type IContributor } from '@/api/entitycore/types/shared/global';
+import { type Agent, AgentType, type IContributor } from '@/api/entitycore/types/shared/global';
+
 import type { TCoreFilter } from '@/entity-configuration/definitions/types';
 
 type TransformFiltersToQueryReturnValue = Record<

--- a/src/api/entitycore/types/entities/brain-atlas.ts
+++ b/src/api/entitycore/types/entities/brain-atlas.ts
@@ -1,11 +1,11 @@
 import type {
-  EntityCoreIdentifiable,
-  Timestamps,
-  ISpecies,
-  IAsset,
   EntityAuthorization,
+  EntityCoreIdentifiable,
+  IAsset,
+  ISpecies,
+  Timestamps,
 } from '@/api/entitycore/types/shared/global';
-import {
+import type {
   PaginationFilter,
   SharedFilter,
   SpeciesFilter,

--- a/src/api/entitycore/types/entities/cell-composition.ts
+++ b/src/api/entitycore/types/entities/cell-composition.ts
@@ -1,4 +1,11 @@
-import {
+import type {
+  ContributionFilter,
+  IDFilter,
+  NameFilter,
+  OwnershipFilter,
+  TimestampsFilter,
+} from '@/api/entitycore/types/shared/request';
+import type {
   EntityCoreBaseAsset,
   EntityCoreIdentifiable,
   EntityCoreOwnership,
@@ -6,13 +13,6 @@ import {
   IContributor,
   Timestamps,
 } from '../shared/global';
-import {
-  ContributionFilter,
-  TimestampsFilter,
-  OwnershipFilter,
-  IDFilter,
-  NameFilter,
-} from '@/api/entitycore/types/shared/request';
 
 type Density = {
   density: number;

--- a/src/api/entitycore/types/entities/ion-channel.ts
+++ b/src/api/entitycore/types/entities/ion-channel.ts
@@ -10,7 +10,6 @@ import type {
   IStrain,
   Timestamps,
 } from '@/api/entitycore/types/shared/global';
-
 import type {
   BrainRegionHierarchyFilter,
   ContributionFilter,

--- a/src/api/entitycore/types/entities/me-model.ts
+++ b/src/api/entitycore/types/entities/me-model.ts
@@ -1,6 +1,6 @@
 import z from 'zod';
-import type { BrainRegionHierarchyBase } from '@/api/entitycore/types/entities/brain-region';
 
+import type { BrainRegionHierarchyBase } from '@/api/entitycore/types/entities/brain-region';
 import type { ICellMorphology } from '@/api/entitycore/types/entities/cell-morphology';
 import type { IEModel } from '@/api/entitycore/types/entities/e-model';
 import type {

--- a/src/api/entitycore/types/entities/measurement-annotation.ts
+++ b/src/api/entitycore/types/entities/measurement-annotation.ts
@@ -1,6 +1,6 @@
-import { Timestamps, EntityCoreIdentifiable } from '@/api/entitycore/types/shared/global';
-import { TimestampsFilter, PaginationFilter } from '@/api/entitycore/types/shared/request';
-import { TEntityTypeDict } from '@/api/entitycore/types/entity-type';
+import type { TEntityTypeDict } from '@/api/entitycore/types/entity-type';
+import type { EntityCoreIdentifiable, Timestamps } from '@/api/entitycore/types/shared/global';
+import type { PaginationFilter, TimestampsFilter } from '@/api/entitycore/types/shared/request';
 
 type MeasurementItem = {
   name: string;

--- a/src/api/entitycore/types/entities/publication.ts
+++ b/src/api/entitycore/types/entities/publication.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   EntityAuthorization,
   EntityCoreIdentifiable,
   EntityCoreOwnership,
@@ -6,7 +6,7 @@ import {
   IContributor,
   Timestamps,
 } from '../shared/global';
-import {
+import type {
   ContributionFilter,
   IdFilter,
   NameFilter,

--- a/src/api/entitycore/types/entities/scientific-artifact-publication-link.ts
+++ b/src/api/entitycore/types/entities/scientific-artifact-publication-link.ts
@@ -1,5 +1,5 @@
-import type { ScientificArtifactBase } from '@/api/entitycore/types/entities/scientific-artifact';
 import type { IPublication } from '@/api/entitycore/types/entities/publication';
+import type { ScientificArtifactBase } from '@/api/entitycore/types/entities/scientific-artifact';
 import type {
   EntityCoreIdentifiable,
   EntityCoreOwnership,

--- a/src/api/entitycore/types/entities/scientific-artifact.ts
+++ b/src/api/entitycore/types/entities/scientific-artifact.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   EntityCoreIdentifiable,
   EntityCoreType,
   Timestamps,

--- a/src/api/entitycore/types/index.ts
+++ b/src/api/entitycore/types/index.ts
@@ -21,20 +21,20 @@ import type { IExperimentalSynapsesPerConnection } from '@/api/entitycore/types/
 export * from '@/api/entitycore/types/entity-type';
 
 export type {
-  ICellMorphologyExpanded,
-  IExperimentalSynapsesPerConnection,
-  IExperimentalNeuronDensity,
-  IExperimentalBoutonDensity,
   ICellMorphology,
-  IElectricalCellRecording,
-  ISingleNeuronSynaptome,
-  IMEModel,
-  IEModel,
-  IonChannelModel,
+  ICellMorphologyExpanded,
   ICircuit,
-  ISingleNeuronSimulation,
-  ISingleNeuronSynaptomeSimulation,
+  IElectricalCellRecording,
+  IEModel,
+  IExperimentalBoutonDensity,
+  IExperimentalNeuronDensity,
+  IExperimentalSynapsesPerConnection,
   IIonChannelRecording,
+  IMEModel,
+  IonChannelModel,
+  ISingleNeuronSimulation,
+  ISingleNeuronSynaptome,
+  ISingleNeuronSynaptomeSimulation,
 };
 
 export type EntityCoreDensityObjectTypes =

--- a/src/api/entitycore/types/shared/density.ts
+++ b/src/api/entitycore/types/shared/density.ts
@@ -1,4 +1,4 @@
-import { BrainRegionHierarchyBase } from '@/api/entitycore/types/entities/brain-region';
+import type { BrainRegionHierarchyBase } from '@/api/entitycore/types/entities/brain-region';
 import type {
   EntityAuthorization,
   EntityCoreIdentifiable,

--- a/src/api/entitycore/types/shared/hierarchy.ts
+++ b/src/api/entitycore/types/shared/hierarchy.ts
@@ -1,4 +1,4 @@
-import { TDerivationType } from '@/api/entitycore/types/entities/derivation';
+import type { TDerivationType } from '@/api/entitycore/types/entities/derivation';
 
 export interface HierarchyNode {
   id: string;

--- a/src/api/entitycore/types/shared/species.ts
+++ b/src/api/entitycore/types/shared/species.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import type {
   ContributionFilter,
   IDFilter,

--- a/src/api/entitycore/utils.ts
+++ b/src/api/entitycore/utils.ts
@@ -1,6 +1,6 @@
 import { find, snakeCase } from 'es-toolkit/compat';
 
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { config as appConfig } from '@/config';
 
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';

--- a/src/api/one/extraction.ts
+++ b/src/api/one/extraction.ts
@@ -1,5 +1,6 @@
 import { getEntityCoreContext } from '@/api/entitycore/utils';
 import { obioneApi } from '@/api/one/utils';
+
 import type { WorkspaceContext } from '@/types/common';
 
 export const ObiOneTaskTypeDict = {

--- a/src/api/one/generated/grid-scan-coordinate-count.ts
+++ b/src/api/one/generated/grid-scan-coordinate-count.ts
@@ -1,4 +1,5 @@
 import { obioneApi } from '@/api/one/utils';
+
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/declared/scan_config/grid-scan-coordinate-count';

--- a/src/api/one/generated/ion-channel-fitting-scan-config-generate-grid.ts
+++ b/src/api/one/generated/ion-channel-fitting-scan-config-generate-grid.ts
@@ -1,4 +1,5 @@
 import { obioneApi } from '@/api/one/utils';
+
 import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/generated/ion-channel-fitting-scan-config-generate-grid';

--- a/src/api/one/utils.ts
+++ b/src/api/one/utils.ts
@@ -1,4 +1,4 @@
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { config } from '@/config';
 
 export async function obioneApi(url?: string) {

--- a/src/api/small-scale-simulator/index.ts
+++ b/src/api/small-scale-simulator/index.ts
@@ -1,11 +1,12 @@
 // Small circuit scale
 export { runBatch as runCircuitSimulationBatch } from './circuit/simulation';
-
-// Single neuron scale
-export { createModel as createSingleNeuronSynaptome } from './single-neuron/synaptome';
-export { createModel as createSingleNeuronModel } from './single-neuron/single-neuron';
 export { getMorphology as getSingleNeuronMorphology } from './single-neuron/morphology';
-export { getStimuliPlot as getSingleNeuronStimuliPlot } from './single-neuron/stimuli-plot';
-export { getSynaptomePlacement as getSingleNeuronSynaptomePlacement } from './single-neuron/synaptome';
 export { runSimulation as runSingleNeuronSimulation } from './single-neuron/simulation';
-export { validateFormula as validateSingleNeuronSynapseGenerationFormula } from './single-neuron/synaptome';
+export { createModel as createSingleNeuronModel } from './single-neuron/single-neuron';
+export { getStimuliPlot as getSingleNeuronStimuliPlot } from './single-neuron/stimuli-plot';
+// Single neuron scale
+export {
+  createModel as createSingleNeuronSynaptome,
+  getSynaptomePlacement as getSingleNeuronSynaptomePlacement,
+  validateFormula as validateSingleNeuronSynapseGenerationFormula,
+} from './single-neuron/synaptome';

--- a/src/api/small-scale-simulator/single-neuron/single-neuron.ts
+++ b/src/api/small-scale-simulator/single-neuron/single-neuron.ts
@@ -1,10 +1,10 @@
 import { getEntityCoreContext } from '@/api/entitycore/utils';
 import { smallScaleSimulatorApi } from '@/api/small-scale-simulator/utils';
 
+import type { IMEModel } from '@/api/entitycore/types';
 import type { TCreateSingleNeuron } from '@/api/small-scale-simulator/types';
-import type { ApiResponse } from '@/types/small-scale-simulator/common';
 import type { WorkspaceContext } from '@/types/common';
-import { IMEModel } from '@/api/entitycore/types';
+import type { ApiResponse } from '@/types/small-scale-simulator/common';
 
 type CreateSingleNeuronParams = {
   ctx: WorkspaceContext;

--- a/src/api/small-scale-simulator/single-neuron/stimuli-plot.ts
+++ b/src/api/small-scale-simulator/single-neuron/stimuli-plot.ts
@@ -1,11 +1,12 @@
 import { getEntityCoreContext } from '@/api/entitycore/utils';
 import { smallScaleSimulatorApi } from '@/api/small-scale-simulator/utils';
+import { convertObjectKeysToSnakeCase } from '@/util/object-keys-format';
+
 import type { WorkspaceContext } from '@/types/common';
 import type {
   CurrentInjectionGraphRequest,
   CurrentInjectionGraphResponse,
 } from '@/types/small-scale-simulator/graph';
-import { convertObjectKeysToSnakeCase } from '@/util/object-keys-format';
 
 type Params = {
   ctx: WorkspaceContext;

--- a/src/api/small-scale-simulator/types.ts
+++ b/src/api/small-scale-simulator/types.ts
@@ -1,4 +1,5 @@
 import z from 'zod';
+
 import { SingleNeuronSynaptomeConfigurationSchema } from '@/api/entitycore/types/entities/single-neuron-synaptome';
 
 type Coordinates3D = [number, number, number];

--- a/src/api/small-scale-simulator/utils.ts
+++ b/src/api/small-scale-simulator/utils.ts
@@ -1,4 +1,4 @@
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { config } from '@/config';
 
 export async function smallScaleSimulatorApi(url?: string) {

--- a/src/api/virtual-lab-svc/queries/bookmark.ts
+++ b/src/api/virtual-lab-svc/queries/bookmark.ts
@@ -1,16 +1,16 @@
 import { virtualLabRootApi } from '@/api/virtual-lab-svc/utils';
 
 import type { TEntityTypeDict } from '@/api/entitycore/types/entity-type';
-import type { WorkspaceContext } from '@/types/common';
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type {
-  BookmarkRequest,
   AddBookmarkResponse,
+  BookmarkRequest,
   DeleteBookmarksResponse,
   VlmGetProjectBookmarksResponse,
   VlmGetProjectLibraryCategories,
   VlmGetProjectLibraryPerCategory,
 } from '@/api/virtual-lab-svc/queries/types';
-import { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import type { WorkspaceContext } from '@/types/common';
 
 const baseUri = '/virtual-labs';
 

--- a/src/api/virtual-lab-svc/queries/email-verification.ts
+++ b/src/api/virtual-lab-svc/queries/email-verification.ts
@@ -1,7 +1,7 @@
 import { getSession } from '@/auth-fetch';
-
-import { VerificationCodeEmailResponse } from '@/api/virtual-lab-svc/queries/types';
 import { config } from '@/config';
+
+import type { VerificationCodeEmailResponse } from '@/api/virtual-lab-svc/queries/types';
 
 type VerificationCodeResponse<T extends 'init' | 'verify'> = T extends 'init'
   ? {
@@ -51,7 +51,7 @@ export async function getEmailVerificationCode({
     );
     const result = (await response.json()) as VerificationCodeEmailResponse;
     return result.data as VerificationCodeResponse<'init'>;
-  } catch (error) {
+  } catch {
     return {
       status: 'error',
       message: 'Error during generating a new verification code',
@@ -82,7 +82,7 @@ export async function verifyOtpCode({
     });
     const result = (await response.json()) as VerificationCodeEmailResponse;
     return result.data as VerificationCodeResponse<'verify'>;
-  } catch (error) {
+  } catch {
     return {
       status: 'error',
       message: 'Error during verification the code',

--- a/src/api/virtual-lab-svc/queries/invite.ts
+++ b/src/api/virtual-lab-svc/queries/invite.ts
@@ -1,8 +1,8 @@
-import { InviteResponse } from '@/api/virtual-lab-svc/queries/types';
 import { virtualLabRootApi } from '@/api/virtual-lab-svc/utils';
 
-import type { AcceptInviteResponse, InvitationContentResponse } from '@/types/virtual-lab/invites';
+import type { InviteResponse } from '@/api/virtual-lab-svc/queries/types';
 import type { Role } from '@/api/virtual-lab-svc/types';
+import type { AcceptInviteResponse, InvitationContentResponse } from '@/types/virtual-lab/invites';
 
 export async function inviteToProject({
   virtualLabId,

--- a/src/api/virtual-lab-svc/queries/member.ts
+++ b/src/api/virtual-lab-svc/queries/member.ts
@@ -1,12 +1,12 @@
-import {
+import { getSession } from '@/auth-fetch';
+import { config } from '@/config';
+
+import type {
   MemberResponse,
   MembersResponse,
   Role,
   VlmDeleteProjectMemberResponse,
 } from '@/api/virtual-lab-svc/queries/types';
-import { getSession } from '@/auth-fetch';
-import { config } from '@/config';
-
 import type { VlmResponse } from '@/types/virtual-lab/common';
 
 const baseUri = `${config.VIRTUAL_LAB_API_URL}/virtual-labs`;

--- a/src/api/virtual-lab-svc/queries/onboarding.ts
+++ b/src/api/virtual-lab-svc/queries/onboarding.ts
@@ -1,8 +1,8 @@
 import { virtualLabRootApi } from '@/api/virtual-lab-svc/utils';
 
 import type {
-  TOnboardingFeature,
   OnboardingUpdateRequest,
+  TOnboardingFeature,
   VlmOnboardingResponse,
 } from '@/api/virtual-lab-svc/queries/types';
 

--- a/src/api/virtual-lab-svc/queries/payment.ts
+++ b/src/api/virtual-lab-svc/queries/payment.ts
@@ -1,12 +1,12 @@
 import { getSession } from '@/auth-fetch';
+import { config } from '@/config';
 
-import {
+import type {
   SetupIntentResponse,
   StandalonePaymentRequest,
   StandalonePaymentResponse,
   SubscriptionPaymentsResponse,
 } from '@/api/virtual-lab-svc/queries/types';
-import { config } from '@/config';
 
 function getPaymentsPrl() {
   return `${config.VIRTUAL_LAB_API_URL}/payments`;

--- a/src/api/virtual-lab-svc/queries/project.ts
+++ b/src/api/virtual-lab-svc/queries/project.ts
@@ -1,6 +1,5 @@
-import { getSession } from '@/auth-fetch';
-
 import { virtualLabRootApi } from '@/api/virtual-lab-svc/utils';
+import { getSession } from '@/auth-fetch';
 import { config } from '@/config';
 
 import type {

--- a/src/api/virtual-lab-svc/queries/promotion.ts
+++ b/src/api/virtual-lab-svc/queries/promotion.ts
@@ -1,5 +1,6 @@
 import { virtualLabRootApi } from '../utils';
-import { RedeemPromotionCodeRequest, VlmPromotionResponse } from './types';
+
+import type { RedeemPromotionCodeRequest, VlmPromotionResponse } from './types';
 
 const baseUri = '/promotions';
 

--- a/src/api/virtual-lab-svc/queries/stats.ts
+++ b/src/api/virtual-lab-svc/queries/stats.ts
@@ -1,10 +1,11 @@
-import {
+import { getSession } from '@/auth-fetch';
+import { config } from '@/config';
+
+import type {
   VlmProjectStatsResponse,
   VlmUserStatsResponse,
   VlmVirtualLabStatsResponse,
 } from '@/api/virtual-lab-svc/queries/types';
-import { getSession } from '@/auth-fetch';
-import { config } from '@/config';
 
 /**
  * Get statistics for the current user.

--- a/src/api/virtual-lab-svc/queries/subscription.ts
+++ b/src/api/virtual-lab-svc/queries/subscription.ts
@@ -1,19 +1,19 @@
 import { getSession } from '@/auth-fetch';
-
 import { config } from '@/config';
-import {
+
+import type {
   CancelSubscriptionRequest,
-  CreateSubscriptionRequest,
-  VlmUserSubscriptionsResponse,
-  VlmCancelSubscriptionResponse,
-  VlmCreateSubscriptionResponse,
-  VlmActiveSubscriptionResponse,
-  VlmListSubscriptionTiersResponse,
-  UserSubscriptionsResponse,
-  CreateSubscriptionResponse,
   CancelSubscriptionResponse,
+  CreateSubscriptionRequest,
+  CreateSubscriptionResponse,
   SubscriptionTiersResponse,
   UserActiveSubscriptionResponse,
+  UserSubscriptionsResponse,
+  VlmActiveSubscriptionResponse,
+  VlmCancelSubscriptionResponse,
+  VlmCreateSubscriptionResponse,
+  VlmListSubscriptionTiersResponse,
+  VlmUserSubscriptionsResponse,
 } from '@/api/virtual-lab-svc/queries/types';
 
 function getBaseUrl() {

--- a/src/api/virtual-lab-svc/queries/virtual-lab.ts
+++ b/src/api/virtual-lab-svc/queries/virtual-lab.ts
@@ -1,16 +1,16 @@
 import isEmpty from 'es-toolkit/compat/isEmpty';
 
-import { LabTypeEnum, VirtualLabPayload } from '@/api/virtual-lab-svc/types';
+import { LabTypeEnum, type VirtualLabPayload } from '@/api/virtual-lab-svc/types';
 import { virtualLabRootApi } from '@/api/virtual-lab-svc/utils';
 import { getSession } from '@/auth-fetch';
-import {
+import { config } from '@/config';
+
+import type {
   VirtualLab,
   VirtualLabExistsVerificationResponse,
   VirtualLabListResponse,
   VirtualLabResponse,
 } from '@/api/virtual-lab-svc/queries/types';
-import { config } from '@/config';
-
 import type { VlmResponse } from '@/types/virtual-lab/common';
 
 function getBaseUrl() {

--- a/src/api/virtual-lab-svc/types.ts
+++ b/src/api/virtual-lab-svc/types.ts
@@ -1,5 +1,5 @@
-import { z } from 'zod';
-import {
+import type { z } from 'zod';
+import type {
   ProjectPayloadSchema,
   RoleSchema,
   VirtualLabPayloadSchema,

--- a/src/api/virtual-lab-svc/utils.ts
+++ b/src/api/virtual-lab-svc/utils.ts
@@ -1,4 +1,4 @@
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { config } from '@/config';
 
 export async function virtualLabRootApi(url?: string) {

--- a/src/features/offline-auth-management/auth-manager-client.ts
+++ b/src/features/offline-auth-management/auth-manager-client.ts
@@ -1,4 +1,4 @@
-import { authApiClient } from '@/api/apiClient';
+import { authApiClient } from '@/api/api-client';
 import { config } from '@/config';
 
 type RawRequestConsentResponse = {


### PR DESCRIPTION
With linter not failing CI builds there is always a possibility to miss important typing issues.

This is one change of a series to address those issues so that we can re-configure CI to make linting errors more prominent.

Current PR targets `src/api` modules.