### PR TITLE
fix context disappearing when loading point cloud

### DIFF
--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.tsx
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.tsx
@@ -188,6 +188,9 @@ export class Painter {
       this.pointCloudId = annotationValue;
       if (annotationValue !== -1) {
         const dataPoint = await getPointCouldData(annotationValue, accessToken);
+        // Check if context was deleted while fetching data (e.g., user navigated away)
+        if (!this.context) return;
+
         const painter = new TgdPainterPointsCloud(context, {
           dataPoint,
           minSizeInPixels: 5,


### PR DESCRIPTION
When you switch from Data to either (Notebook, Workflow, ...) before the point cloud is loaded, you get a notification error.

This looks like a bug for the end user.

The fix is to check that the context still exists when the points are loaded.