### PR TITLE
Add compatibility check for M- and E-models

### DIFF
--- a/src/api/small-scale-simulator/index.ts
+++ b/src/api/small-scale-simulator/index.ts
@@ -1,5 +1,9 @@
 // Small circuit scale
 export { runBatch as runCircuitSimulationBatch } from './circuit/simulation';
+export {
+  type CompatibilityCheckResponse,
+  checkCompatibility as checkSingleNeuronCompatibility,
+} from './single-neuron/compatibility';
 export { getMorphology as getSingleNeuronMorphology } from './single-neuron/morphology';
 export { runSimulation as runSingleNeuronSimulation } from './single-neuron/simulation';
 export { createModel as createSingleNeuronModel } from './single-neuron/single-neuron';

--- a/src/api/small-scale-simulator/single-neuron/compatibility.ts
+++ b/src/api/small-scale-simulator/single-neuron/compatibility.ts
@@ -1,0 +1,44 @@
+import { getEntityCoreContext } from '@/api/entitycore/utils';
+import { smallScaleSimulatorApi } from '@/api/small-scale-simulator/utils';
+
+import type { WorkspaceContext } from '@/types/common';
+import type { ApiResponse } from '@/types/small-scale-simulator/common';
+
+export type CompatibilityCheckResponse = {
+  compatible: boolean;
+  morphology_id: string;
+  emodel_id: string;
+  error?: string | null;
+};
+
+type CheckCompatibilityParams = {
+  ctx: WorkspaceContext;
+  morphologyId: string;
+  emodelId: string;
+  signal?: AbortSignal;
+};
+
+export async function checkCompatibility({
+  ctx,
+  morphologyId,
+  emodelId,
+  signal,
+}: CheckCompatibilityParams) {
+  const api = await smallScaleSimulatorApi();
+
+  return await api.post<ApiResponse<CompatibilityCheckResponse>>(
+    '/single-neuron/compatibility/run',
+    {
+      headers: {
+        ...getEntityCoreContext(ctx).headers,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: {
+        morphology_id: morphologyId,
+        emodel_id: emodelId,
+      },
+      signal,
+    }
+  );
+}

--- a/src/components/loader.tsx
+++ b/src/components/loader.tsx
@@ -1,5 +1,5 @@
 import { LoadingOutlined } from '@ant-design/icons';
-import Spin, { SpinIndicator } from 'antd/es/spin';
+import Spin, { type SpinIndicator } from 'antd/es/spin';
 
 export function Loader({
   size = 'large',

--- a/src/i18n/en/me-model.ts
+++ b/src/i18n/en/me-model.ts
@@ -10,6 +10,5 @@ export const messages = {
   ValidationError: 'Validation failed. Please check the data and try again.',
   CreationModelSucceed: 'The me-model has been successfully created.',
   CheckingCompatibility: 'Model compatibility check in progress...',
-  IncompatibleModels:
-    'The selected M-model and E-model are not compatible. Please select a different combination.',
+  IncompatibleModels: 'Incompatible M-model and E-model, please select a different combination.',
 };

--- a/src/i18n/en/me-model.ts
+++ b/src/i18n/en/me-model.ts
@@ -9,7 +9,7 @@ export const messages = {
   RunAnalysisError: 'Something went wrong while launching model calibration and validation',
   ValidationError: 'Validation failed. Please check the data and try again.',
   CreationModelSucceed: 'The me-model has been successfully created.',
-  CheckingCompatibility: 'Checking model compatibility...',
+  CheckingCompatibility: 'Model compatibility check in progress...',
   IncompatibleModels:
     'The selected M-model and E-model are not compatible. Please select a different combination.',
 };

--- a/src/i18n/en/me-model.ts
+++ b/src/i18n/en/me-model.ts
@@ -9,4 +9,7 @@ export const messages = {
   RunAnalysisError: 'Something went wrong while launching model calibration and validation',
   ValidationError: 'Validation failed. Please check the data and try again.',
   CreationModelSucceed: 'The me-model has been successfully created.',
+  CheckingCompatibility: 'Checking model compatibility...',
+  IncompatibleModels:
+    'The selected M-model and E-model are not compatible. Please select a different combination.',
 };

--- a/src/ui/segments/workflows/build/memodel/menu.tsx
+++ b/src/ui/segments/workflows/build/memodel/menu.tsx
@@ -78,8 +78,10 @@ export function Menu({ sessionId }: { sessionId: string }) {
     queryFn: ({ signal }) =>
       checkSingleNeuronCompatibility({
         ctx: { virtualLabId, projectId },
-        morphologyId: morphologyId as string,
-        emodelId: emodelId as string,
+        // biome-ignore lint/style/noNonNullAssertion: Guaranteed by selectionComplete
+        morphologyId: morphologyId!,
+        // biome-ignore lint/style/noNonNullAssertion: Guaranteed by selectionComplete
+        emodelId: emodelId!,
         signal,
       }),
     enabled: selectionComplete,

--- a/src/ui/segments/workflows/build/memodel/menu.tsx
+++ b/src/ui/segments/workflows/build/memodel/menu.tsx
@@ -86,11 +86,15 @@ export function Menu({ sessionId }: { sessionId: string }) {
       }),
     enabled: selectionComplete,
     retry: false,
+    refetchOnWindowFocus: false,
     staleTime: Infinity,
   });
 
   const isCheckingCompatibility = selectionComplete && compatibilityCheck.isFetching;
-  const isIncompatible = selectionComplete && compatibilityCheck.data?.data.compatible === false;
+  const isIncompatible =
+    selectionComplete &&
+    compatibilityCheck.isSuccess &&
+    compatibilityCheck.data?.data.compatible === false;
 
   const onStepChange = (s: BuildStepKeys) => {
     const query = new URLSearchParams(searchParams);

--- a/src/ui/segments/workflows/build/memodel/menu.tsx
+++ b/src/ui/segments/workflows/build/memodel/menu.tsx
@@ -2,6 +2,7 @@
 
 import {
   CheckCircleFilled,
+  ExclamationCircleOutlined,
   LoadingOutlined,
   RightOutlined,
   SettingFilled,
@@ -324,8 +325,16 @@ export function Menu({ sessionId }: { sessionId: string }) {
             />
           </div>
         </Button>
+        {isCheckingCompatibility && (
+          <div className="p-4 pl-6 text-sm font-bold text-primary-9 flex items-center gap-3">
+            <LoadingOutlined />
+            {messages.CheckingCompatibility}
+          </div>
+        )}
         {isIncompatible && (
-          <div className="mx-1 rounded-md px-3 py-2 text-sm text-destructive">
+          <div className="p-4 pl-6 text-sm font-bold text-destructive flex items-center gap-3">
+            <ExclamationCircleOutlined />
+
             {messages.IncompatibleModels}
           </div>
         )}
@@ -342,33 +351,16 @@ export function Menu({ sessionId }: { sessionId: string }) {
                 onClick={() => mutate.mutateAsync()}
                 disabled={disabled}
               >
-                <div className="shrink-0 font-bold">
-                  {isCheckingCompatibility ? messages.CheckingCompatibility : 'Build model'}
-                </div>
-                {(mutate.isPending || isCheckingCompatibility) && (
-                  <LoadingOutlined
-                    className={cn(
-                      'ml-2',
-                      isCheckingCompatibility ? 'text-neutral-4' : 'text-white'
-                    )}
-                  />
-                )}
+                <div className="shrink-0 font-bold">Build model</div>
+                {mutate.isPending && <LoadingOutlined className="ml-2 text-white" />}
               </Button>
             </div>
           </TooltipTrigger>
           {disabled && (
             <TooltipContent sideOffset={10} arrowClassName="bg-primary-9">
               <p className={cn('text-justify text-base')}>
-                {isIncompatible ? (
-                  messages.IncompatibleModels
-                ) : isCheckingCompatibility ? (
-                  messages.CheckingCompatibility
-                ) : (
-                  <>
-                    Please fill all the required information <br /> along with selecting m-model and
-                    e-model
-                  </>
-                )}
+                Please fill all the required information along with <br /> selecting compatible
+                M-model and E-model
               </p>
             </TooltipContent>
           )}

--- a/src/ui/segments/workflows/build/memodel/menu.tsx
+++ b/src/ui/segments/workflows/build/memodel/menu.tsx
@@ -326,15 +326,14 @@ export function Menu({ sessionId }: { sessionId: string }) {
           </div>
         </Button>
         {isCheckingCompatibility && (
-          <div className="p-4 pl-6 text-sm font-bold text-primary-9 flex items-center gap-3">
+          <div className="p-4 pl-6 font-semibold text-primary-9 flex items-center gap-3">
             <LoadingOutlined />
             {messages.CheckingCompatibility}
           </div>
         )}
         {isIncompatible && (
-          <div className="p-4 pl-6 text-sm font-bold text-destructive flex items-center gap-3">
+          <div className="p-4 pl-6 font-semibold text-destructive flex items-center gap-3">
             <ExclamationCircleOutlined />
-
             {messages.IncompatibleModels}
           </div>
         )}

--- a/src/ui/segments/workflows/build/memodel/menu.tsx
+++ b/src/ui/segments/workflows/build/memodel/menu.tsx
@@ -8,7 +8,7 @@ import {
   WarningFilled,
 } from '@ant-design/icons';
 import { useRouter } from '@bprogress/next';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import delay from 'es-toolkit/compat/delay';
 import get from 'es-toolkit/compat/get';
 import kebabCase from 'es-toolkit/compat/kebabCase';
@@ -17,6 +17,7 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import { checkSingleNeuronCompatibility } from '@/api/small-scale-simulator';
 import { createModel } from '@/api/small-scale-simulator/single-neuron/single-neuron';
 import { CreateSingleNeuronSchema } from '@/api/small-scale-simulator/types';
 import { useAppNotification } from '@/components/notification';
@@ -35,6 +36,7 @@ import {
   useBuildMeModelSessionState,
 } from '@/ui/segments/workflows/build/memodel/helpers';
 import { ActivityValues } from '@/ui/segments/workflows/elements/helpers';
+import { keyBuilder } from '@/ui/use-query-keys/data';
 import { browserHistoryReplace } from '@/utils/browser';
 import { cn } from '@/utils/css-class';
 import { log } from '@/utils/logger';
@@ -61,6 +63,32 @@ export function Menu({ sessionId }: { sessionId: string }) {
     virtualLabId,
     projectId,
   });
+
+  const morphologyId = sessionValue.mmodel?.id;
+  const emodelId = sessionValue.emodel?.id;
+  const selectionComplete = !!morphologyId && !!emodelId;
+
+  const compatibilityCheck = useQuery({
+    queryKey: keyBuilder.meModelCompatibility({
+      virtualLabId,
+      projectId,
+      morphologyId: morphologyId ?? '',
+      emodelId: emodelId ?? '',
+    }),
+    queryFn: ({ signal }) =>
+      checkSingleNeuronCompatibility({
+        ctx: { virtualLabId, projectId },
+        morphologyId: morphologyId as string,
+        emodelId: emodelId as string,
+        signal,
+      }),
+    enabled: selectionComplete,
+    retry: false,
+    staleTime: Infinity,
+  });
+
+  const isCheckingCompatibility = selectionComplete && compatibilityCheck.isFetching;
+  const isIncompatible = selectionComplete && compatibilityCheck.data?.data.compatible === false;
 
   const onStepChange = (s: BuildStepKeys) => {
     const query = new URLSearchParams(searchParams);
@@ -147,7 +175,7 @@ export function Menu({ sessionId }: { sessionId: string }) {
   });
 
   const result = CreateSingleNeuronContextSchema.safeParse(payload);
-  const disabled = mutate.isPending || !!result.error;
+  const disabled = mutate.isPending || !!result.error || isCheckingCompatibility || isIncompatible;
 
   return (
     <>
@@ -290,6 +318,11 @@ export function Menu({ sessionId }: { sessionId: string }) {
             />
           </div>
         </Button>
+        {isIncompatible && (
+          <div className="mx-1 rounded-md px-3 py-2 text-sm text-destructive">
+            {messages.IncompatibleModels}
+          </div>
+        )}
         <Tooltip>
           <TooltipTrigger asChild>
             <div className="mt-auto w-full">
@@ -303,16 +336,33 @@ export function Menu({ sessionId }: { sessionId: string }) {
                 onClick={() => mutate.mutateAsync()}
                 disabled={disabled}
               >
-                <div className="shrink-0 font-bold">Build model</div>
-                {mutate.isPending && <LoadingOutlined className="ml-2 text-white" />}
+                <div className="shrink-0 font-bold">
+                  {isCheckingCompatibility ? messages.CheckingCompatibility : 'Build model'}
+                </div>
+                {(mutate.isPending || isCheckingCompatibility) && (
+                  <LoadingOutlined
+                    className={cn(
+                      'ml-2',
+                      isCheckingCompatibility ? 'text-neutral-4' : 'text-white'
+                    )}
+                  />
+                )}
               </Button>
             </div>
           </TooltipTrigger>
           {disabled && (
             <TooltipContent sideOffset={10} arrowClassName="bg-primary-9">
               <p className={cn('text-justify text-base')}>
-                Please fill all the required information <br /> along with selecting m-model and
-                e-model
+                {isIncompatible ? (
+                  messages.IncompatibleModels
+                ) : isCheckingCompatibility ? (
+                  messages.CheckingCompatibility
+                ) : (
+                  <>
+                    Please fill all the required information <br /> along with selecting m-model and
+                    e-model
+                  </>
+                )}
               </p>
             </TooltipContent>
           )}

--- a/src/ui/use-query-keys/data.tsx
+++ b/src/ui/use-query-keys/data.tsx
@@ -108,6 +108,15 @@ export const keyBuilder = {
     `${prefix}-single-neuron-model`,
     { virtualLabId, projectId, entityId },
   ],
+  meModelCompatibility: ({
+    virtualLabId,
+    projectId,
+    morphologyId,
+    emodelId,
+  }: WorkspaceContext & { morphologyId: string; emodelId: string }) => [
+    `${prefix}-me-model-compatibility`,
+    { virtualLabId, projectId, morphologyId, emodelId },
+  ],
   synaptome: ({ virtualLabId, projectId, entityId }: WorkspaceContext & { entityId: string }) => [
     `${prefix}-single-neuron-synaptome-model`,
     { virtualLabId, projectId, entityId },


### PR DESCRIPTION
## Summary
  - Adds a server-side compatibility check (`POST /single-neuron/compatibility/run`) that fires automatically when both M-model and E-model are selected
  - Build button shows "Checking model compatibility..." with spinner while validating, stays disabled with inline error if incompatible
  - Uses `useQuery` with auto-cancellation on selection change and infinite stale time per pair

  ## Changes
  - **New:** `src/api/small-scale-simulator/single-neuron/compatibility.ts` — API client for the compatibility endpoint
  - **Modified:** `menu.tsx` — compatibility query integration, button state machine, inline error message
  - **Modified:** `data.tsx` — `meModelCompatibility` query key builder
  - **Modified:** `me-model.ts` — i18n strings
  - **Modified:** `index.ts` — re-export

  ## Test plan
  - [x] Select both M-model and E-model → button shows "Checking model compatibility..." with spinner
  - [x] Compatible pair → button enables with "Build model"
  - [x] Incompatible pair → button stays disabled, red text appears above it
  - [x] Change either model → previous check cancels, new check starts
  - [x] Deselect a model → warning disappears, button returns to default disabled state
  
  Relates to [Add a pre-check for me-model building just after the user builds a new me-model before Calibration and Validaton Launch](https://github.com/openbraininstitute/prod-build-emodel/issues/126).