### PR TITLE
CI: Create GH release with auto-generated notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - github-actions[bot]
+  categories:
+    - title: 'New Features'
+      labels:
+        - feature
+        - enhancement
+    - title: 'Bug Fixes'
+      labels:
+        - bug
+    - title: 'Other Changes'
+      labels:
+        - '*'

--- a/.github/workflows/release-aws.yml
+++ b/.github/workflows/release-aws.yml
@@ -71,3 +71,23 @@ jobs:
 
       - name: Build and publish Docker image for AWS
         run: make publish
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREV_TAG=$(git tag --sort=-v:refname | grep -E '^[0-9]{4}\.[0-9]{2}\.[0-9]{2}\.[0-9]+$' | sed -n '2p')
+          DOCKER_URI="${IMAGE_NAME}:${APP_VERSION}"
+
+          ARGS=(
+            "$NEW_TAG"
+            --title "$NEW_TAG"
+            --generate-notes
+            --notes "**Docker image:** \`${DOCKER_URI}\`"
+          )
+
+          if [[ -n "$PREV_TAG" ]]; then
+            ARGS+=(--notes-start-tag "$PREV_TAG")
+          fi
+
+          gh release create "${ARGS[@]}"


### PR DESCRIPTION
## Summary

  - Add automatic GitHub Release creation to the release workflow, including auto-generated changelogs with Docker image URI
  - Add `.github/release.yml` to categorize release notes by label (features, bug fixes, other)

  ## Changes

  ### `.github/workflows/release-aws.yml`
  - New **Create GitHub Release** step after Docker publish
  - Resolves previous tag automatically to scope release notes (`--notes-start-tag`)
  - Includes Docker image URI in release body

  ### `.github/release.yml` (new)
  - Changelog config: excludes dependabot/bot authors
  - Groups PRs into **New Features**, **Bug Fixes**, and **Other Changes** by label