### PR TITLE
High performance spike viewer

### DIFF
--- a/src/features/spike-viewer/components/raster-plot.tsx
+++ b/src/features/spike-viewer/components/raster-plot.tsx
@@ -1,36 +1,29 @@
 'use client';
 
 import { Checkbox, Empty } from 'antd';
-import dynamic from 'next/dynamic';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
-import type { Layout, PlotData } from 'plotly.js-dist-min';
-import type { SpikeData, SpikePopulation } from '@/features/spike-viewer/spike-trace';
+import { useRasterRenderer } from '@/features/spike-viewer/hooks/use-raster-renderer';
+import { POPULATION_COLORS } from '@/features/spike-viewer/renderer/raster-renderer';
 
-const Plot = dynamic(() => import('react-plotly.js'), { ssr: false });
-
-// Color palette for different populations
-const POPULATION_COLORS = [
-  '#1f77b4', // blue
-  '#d62728', // red
-  '#2ca02c', // green
-  '#ff7f0e', // orange
-  '#9467bd', // purple
-  '#8c564b', // brown
-  '#e377c2', // pink
-  '#7f7f7f', // gray
-  '#bcbd22', // olive
-  '#17becf', // cyan
-];
+import type { SpikeData } from '@/features/spike-viewer/spike-trace';
 
 type RasterPlotProps = {
   data: SpikeData;
 };
 
 export default function RasterPlot({ data }: RasterPlotProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { setVisiblePopulations } = useRasterRenderer(containerRef, data);
+
   const [selectedPopulations, setSelectedPopulations] = useState<Set<string>>(
     new Set(data.populations.map((p) => p.name))
   );
+
+  // Sync visibility when selection changes
+  useEffect(() => {
+    setVisiblePopulations(selectedPopulations);
+  }, [selectedPopulations, setVisiblePopulations]);
 
   const togglePopulation = (name: string, checked: boolean) => {
     setSelectedPopulations((prev) => {
@@ -44,169 +37,44 @@ export default function RasterPlot({ data }: RasterPlotProps) {
     });
   };
 
-  // Get unique node IDs for y-axis ticks when there are few neurons
-  const uniqueNodeIds = useMemo(() => {
-    const allNodeIds = new Set<number>();
-    data.populations
-      .filter((pop) => selectedPopulations.has(pop.name))
-      .forEach((pop) => pop.nodeIds.forEach((id) => allNodeIds.add(id)));
-    return Array.from(allNodeIds).sort((a, b) => a - b);
-  }, [data.populations, selectedPopulations]);
-
-  const showIndividualTicks = uniqueNodeIds.length <= 50;
-  const usePointsMode = uniqueNodeIds.length > 20;
-
-  // Check if there are any spikes to display
   const totalSpikes = useMemo(() => {
-    return data.populations
-      .filter((pop) => selectedPopulations.has(pop.name))
-      .reduce((sum, pop) => sum + pop.timestamps.length, 0);
-  }, [data.populations, selectedPopulations]);
+    return data.populations.reduce((sum, pop) => sum + pop.timestamps.length, 0);
+  }, [data.populations]);
 
-  const plotData: PlotData[] = useMemo(() => {
-    return data.populations
-      .filter((pop) => selectedPopulations.has(pop.name))
-      .map((pop, idx) => createRasterTrace(pop, idx, usePointsMode));
-  }, [data.populations, selectedPopulations, usePointsMode]);
-
-  // Calculate appropriate y-axis padding based on node ID range
-  const nodeRange = data.nodeIdRange.max - data.nodeIdRange.min;
-  // For single neuron or small range, use fixed padding; otherwise scale with range
-  const yPadding = nodeRange === 0 ? 1 : Math.max(1, nodeRange * 0.05);
-
-  // Round end time to a nice multiple if close
-  const roundedEndTime = useMemo(() => {
-    const maxTime = data.timeRange.max;
-    const niceMultiples = [1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000];
-    for (const mult of niceMultiples) {
-      const rounded = Math.ceil(maxTime / mult) * mult;
-      // Use rounded value if within 10% of actual max
-      if (rounded >= maxTime && rounded <= maxTime * 1.1) {
-        return rounded;
-      }
-    }
-    return maxTime;
-  }, [data.timeRange.max]);
-
-  // Generate nice tick values including 0 and the end time
-  const xTickVals = useMemo(() => {
-    const ticks: number[] = [0];
-    // Determine a nice tick interval
-    const intervals = [10, 20, 25, 50, 100, 200, 250, 500, 1000];
-    const targetTicks = 5;
-    const idealInterval = roundedEndTime / targetTicks;
-    const interval = intervals.find((i) => i >= idealInterval) ?? intervals[intervals.length - 1];
-
-    for (let t = interval; t < roundedEndTime; t += interval) {
-      ticks.push(t);
-    }
-    ticks.push(roundedEndTime);
-    return ticks;
-  }, [roundedEndTime]);
-
-  const layout: Partial<Layout> = useMemo(
-    () => ({
-      xaxis: {
-        title: { text: 'time (ms)', standoff: 10 },
-        range: [0, roundedEndTime],
-        showgrid: true,
-        gridcolor: '#e8e8e8',
-        gridwidth: 1,
-        showline: true,
-        linecolor: '#888',
-        linewidth: 1,
-        zeroline: false,
-        tickmode: 'array',
-        tickvals: xTickVals,
-      },
-      yaxis: {
-        title: { text: 'Neuron ID', standoff: 10 },
-        range: [data.nodeIdRange.min - 2, data.nodeIdRange.max + yPadding],
-        showgrid: true,
-        gridcolor: '#e8e8e8',
-        gridwidth: 1,
-        tickmode: showIndividualTicks ? 'array' : 'auto',
-        tickvals: showIndividualTicks ? uniqueNodeIds : undefined,
-        ticktext: showIndividualTicks ? uniqueNodeIds.map(String) : undefined,
-        showline: false,
-        zeroline: false,
-      },
-      showlegend: true,
-      legend: {
-        orientation: 'h',
-        y: -0.15,
-      },
-      hovermode: 'closest',
-      autosize: true,
-      margin: { t: 50, b: 80, l: 70, r: 20 },
-      plot_bgcolor: 'white',
-      paper_bgcolor: 'white',
-    }),
-    [data, yPadding, showIndividualTicks, uniqueNodeIds, roundedEndTime, xTickVals]
-  );
+  if (totalSpikes === 0) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center">
+        <Empty description="No spikes recorded during this simulation" />
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-full flex-col">
-      <div className="mb-4 flex flex-wrap gap-4">
-        {data.populations.map((pop, idx) => (
-          <Checkbox
-            key={pop.name}
-            checked={selectedPopulations.has(pop.name)}
-            onChange={(e) => togglePopulation(pop.name, e.target.checked)}
-          >
-            <span style={{ color: POPULATION_COLORS[idx % POPULATION_COLORS.length] }}>
-              Population: {pop.name} ({pop.timestamps.length} spikes)
-            </span>
-          </Checkbox>
-        ))}
+      <div className="mb-2 flex flex-wrap items-center gap-4">
+        {data.populations.length === 1 ? (
+          <span style={{ color: POPULATION_COLORS[0] }}>
+            Population: {data.populations[0].name} (
+            {data.populations[0].timestamps.length.toLocaleString()} spikes)
+          </span>
+        ) : (
+          data.populations.map((pop, idx) => (
+            <Checkbox
+              key={pop.name}
+              checked={selectedPopulations.has(pop.name)}
+              onChange={(e) => togglePopulation(pop.name, e.target.checked)}
+            >
+              <span style={{ color: POPULATION_COLORS[idx % POPULATION_COLORS.length] }}>
+                Population: {pop.name} ({pop.timestamps.length.toLocaleString()} spikes)
+              </span>
+            </Checkbox>
+          ))
+        )}
+        <span className="ml-auto text-xs text-gray-400">
+          Scroll to zoom · Drag to pan · Double-click to reset
+        </span>
       </div>
-      {totalSpikes === 0 ? (
-        <div className="flex min-h-0 flex-1 items-center justify-center">
-          <Empty description="No spikes recorded during this simulation" />
-        </div>
-      ) : (
-        <div className="min-h-0 flex-1">
-          <Plot
-            data={plotData}
-            layout={layout}
-            config={{ responsive: true, displayModeBar: true }}
-            style={{ width: '100%', height: '100%' }}
-            useResizeHandler
-          />
-        </div>
-      )}
+      <div ref={containerRef} className="min-h-0 flex-1" />
     </div>
   );
-}
-
-/**
- * Creates a raster plot trace where each spike is a vertical tick mark.
- * Uses 'markers' mode with 'line-ns' symbol to create vertical lines,
- * or simple circle points when there are many neurons.
- */
-function createRasterTrace(pop: SpikePopulation, colorIndex: number, usePoints: boolean): PlotData {
-  const color = POPULATION_COLORS[colorIndex % POPULATION_COLORS.length];
-
-  return {
-    x: pop.timestamps,
-    y: pop.nodeIds,
-    mode: 'markers',
-    type: 'scattergl',
-    name: pop.name,
-    marker: usePoints
-      ? {
-          size: 3,
-          color,
-        }
-      : {
-          size: 8,
-          color,
-          symbol: 'line-ns',
-          line: {
-            width: 1.5,
-            color,
-          },
-        },
-    hovertemplate: `Neuron: %{y}<br>Time: %{x:.2f} ms<extra>${pop.name}</extra>`,
-  } as PlotData;
 }

--- a/src/features/spike-viewer/hooks/use-raster-renderer.ts
+++ b/src/features/spike-viewer/hooks/use-raster-renderer.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import { RasterRenderer } from '@/features/spike-viewer/renderer/raster-renderer';
+
+import type { SpikeData } from '@/features/spike-viewer/spike-trace';
+
+export function useRasterRenderer(
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  data: SpikeData | null
+) {
+  const rendererRef = useRef<RasterRenderer | null>(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const renderer = new RasterRenderer(el);
+    rendererRef.current = renderer;
+
+    return () => {
+      renderer.destroy();
+      rendererRef.current = null;
+    };
+  }, [containerRef]);
+
+  useEffect(() => {
+    if (!rendererRef.current || !data) return;
+
+    rendererRef.current.setData(data.populations, {
+      xMin: data.timeRange.min,
+      xMax: data.timeRange.max,
+      yMin: data.nodeIdRange.min,
+      yMax: data.nodeIdRange.max,
+    });
+  }, [data]);
+
+  const setVisiblePopulations = useCallback((names: Set<string>) => {
+    rendererRef.current?.setVisiblePopulations(names);
+  }, []);
+
+  return { setVisiblePopulations };
+}

--- a/src/features/spike-viewer/hooks/use-spike-trace.ts
+++ b/src/features/spike-viewer/hooks/use-spike-trace.ts
@@ -1,12 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
-import { useEffect, useRef, useState } from 'react';
+import * as Comlink from 'comlink';
+import { useEffect, useState } from 'react';
 
 import { downloadAsset } from '@/api/entitycore/queries/assets';
-import SpikeTrace from '@/features/spike-viewer/spike-trace';
 import { keyBuilder } from '@/ui/use-query-keys/data';
 
 import type { TEntityTypeDict } from '@/api/entitycore/types';
 import type { IAsset } from '@/api/entitycore/types/shared/global';
+import type { SpikeData } from '@/features/spike-viewer/spike-trace';
+import type { SpikeTraceWorkerApi } from '@/features/spike-viewer/spike-trace.worker';
 import type { WorkspaceContext } from '@/types/common';
 
 type UseSpikeTraceArgs = {
@@ -21,11 +23,9 @@ export default function useSpikeTrace({
   entityType,
   asset,
   ctx,
-}: UseSpikeTraceArgs): [SpikeTrace | null, Error | null] {
-  const [trace, setTrace] = useState<SpikeTrace | null>(null);
+}: UseSpikeTraceArgs): [SpikeData | null, Error | null] {
+  const [data, setData] = useState<SpikeData | null>(null);
   const [error, setError] = useState<Error | null>(null);
-  const initialized = useRef<boolean>(false);
-  const traceRef = useRef<SpikeTrace | null>(null);
 
   const {
     data: spikeArrayBuffer,
@@ -56,24 +56,30 @@ export default function useSpikeTrace({
   }, [fetchError, isError]);
 
   useEffect(() => {
-    if (initialized.current || !spikeArrayBuffer) {
-      return;
-    }
+    if (!spikeArrayBuffer) return;
 
-    initialized.current = true;
+    let cancelled = false;
+    const worker = new Worker(new URL('../spike-trace.worker.ts', import.meta.url));
+    const proxy = Comlink.wrap<SpikeTraceWorkerApi>(worker);
 
-    SpikeTrace.create(asset.id, spikeArrayBuffer)
-      .then((t) => {
-        traceRef.current = t;
-        setTrace(t);
+    proxy
+      .parseSpikeFile(asset.id, spikeArrayBuffer)
+      .then((result) => {
+        if (!cancelled) setData(result);
       })
-      .catch((e) => setError(e));
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e : new Error(String(e)));
+      })
+      .finally(() => {
+        proxy[Comlink.releaseProxy]();
+        worker.terminate();
+      });
 
     return () => {
-      traceRef.current?.destroy();
-      initialized.current = false;
+      cancelled = true;
+      worker.terminate();
     };
   }, [spikeArrayBuffer, asset.id]);
 
-  return [trace, error];
+  return [data, error];
 }

--- a/src/features/spike-viewer/hooks/use-spike-trace.ts
+++ b/src/features/spike-viewer/hooks/use-spike-trace.ts
@@ -58,6 +58,9 @@ export default function useSpikeTrace({
   useEffect(() => {
     if (!spikeArrayBuffer) return;
 
+    setData(null);
+    setError(null);
+
     let cancelled = false;
     const worker = new Worker(new URL('../spike-trace.worker.ts', import.meta.url));
     const proxy = Comlink.wrap<SpikeTraceWorkerApi>(worker);
@@ -72,7 +75,6 @@ export default function useSpikeTrace({
       })
       .finally(() => {
         proxy[Comlink.releaseProxy]();
-        worker.terminate();
       });
 
     return () => {

--- a/src/features/spike-viewer/renderer/axis-overlay.ts
+++ b/src/features/spike-viewer/renderer/axis-overlay.ts
@@ -57,13 +57,16 @@ export class AxisOverlay {
     const ctx = this.ctx;
     const dpr = window.devicePixelRatio || 1;
 
+    const xTicks = computeTicks(bounds.xMin, bounds.xMax, 6);
+    const yTicks = computeTicks(bounds.yMin, bounds.yMax, 6);
+
     ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
     ctx.save();
     ctx.scale(dpr, dpr);
 
     this.drawBackground(ctx, plotRect);
-    this.drawGrid(ctx, bounds, plotRect);
-    this.drawAxes(ctx, bounds, plotRect);
+    this.drawGrid(ctx, bounds, plotRect, xTicks, yTicks);
+    this.drawAxes(ctx, bounds, plotRect, xTicks, yTicks);
     this.drawAxisTitles(ctx, plotRect, ctx.canvas.height / dpr);
 
     ctx.restore();
@@ -74,10 +77,13 @@ export class AxisOverlay {
     ctx.fillRect(rect.x, rect.y, rect.width, rect.height);
   }
 
-  private drawGrid(ctx: CanvasRenderingContext2D, bounds: ViewBounds, rect: PlotRect) {
-    const xTicks = computeTicks(bounds.xMin, bounds.xMax, 6);
-    const yTicks = computeTicks(bounds.yMin, bounds.yMax, 6);
-
+  private drawGrid(
+    ctx: CanvasRenderingContext2D,
+    bounds: ViewBounds,
+    rect: PlotRect,
+    xTicks: number[],
+    yTicks: number[]
+  ) {
     ctx.strokeStyle = '#e8e8e8';
     ctx.lineWidth = 1;
     ctx.beginPath();
@@ -98,11 +104,15 @@ export class AxisOverlay {
     ctx.stroke();
   }
 
-  private drawAxes(ctx: CanvasRenderingContext2D, bounds: ViewBounds, rect: PlotRect) {
+  private drawAxes(
+    ctx: CanvasRenderingContext2D,
+    bounds: ViewBounds,
+    rect: PlotRect,
+    xTicks: number[],
+    yTicks: number[]
+  ) {
     const xRange = bounds.xMax - bounds.xMin;
     const yRange = bounds.yMax - bounds.yMin;
-    const xTicks = computeTicks(bounds.xMin, bounds.xMax, 6);
-    const yTicks = computeTicks(bounds.yMin, bounds.yMax, 6);
     const xStep = xTicks.length > 1 ? xTicks[1] - xTicks[0] : 1;
     const yStep = yTicks.length > 1 ? yTicks[1] - yTicks[0] : 1;
 

--- a/src/features/spike-viewer/renderer/axis-overlay.ts
+++ b/src/features/spike-viewer/renderer/axis-overlay.ts
@@ -1,0 +1,167 @@
+export type ViewBounds = {
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
+};
+
+export type PlotRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export const MARGIN = { top: 20, right: 20, bottom: 60, left: 70 };
+
+/** Compute nice tick values for an axis range. */
+function computeTicks(min: number, max: number, targetCount: number): number[] {
+  const range = max - min;
+  if (range <= 0) return [min];
+
+  const rawStep = range / targetCount;
+  const magnitude = 10 ** Math.floor(Math.log10(rawStep));
+  const residual = rawStep / magnitude;
+
+  let niceStep: number;
+  if (residual <= 1.5) niceStep = magnitude;
+  else if (residual <= 3.5) niceStep = 2 * magnitude;
+  else if (residual <= 7.5) niceStep = 5 * magnitude;
+  else niceStep = 10 * magnitude;
+
+  const ticks: number[] = [];
+  const start = Math.ceil(min / niceStep) * niceStep;
+  for (let v = start; v <= max + niceStep * 0.001; v += niceStep) {
+    ticks.push(v);
+  }
+  return ticks;
+}
+
+/** Format a tick value to a reasonable number of decimal places. */
+function formatTick(value: number, step: number): string {
+  if (step >= 1) return Math.round(value).toString();
+  const decimals = Math.max(0, -Math.floor(Math.log10(step)) + 1);
+  return value.toFixed(decimals);
+}
+
+export class AxisOverlay {
+  private ctx: CanvasRenderingContext2D;
+
+  constructor(canvas: HTMLCanvasElement) {
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Could not get 2D context');
+    this.ctx = ctx;
+  }
+
+  draw(bounds: ViewBounds, plotRect: PlotRect) {
+    const ctx = this.ctx;
+    const dpr = window.devicePixelRatio || 1;
+
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+    ctx.save();
+    ctx.scale(dpr, dpr);
+
+    this.drawBackground(ctx, plotRect);
+    this.drawGrid(ctx, bounds, plotRect);
+    this.drawAxes(ctx, bounds, plotRect);
+    this.drawAxisTitles(ctx, plotRect, ctx.canvas.height / dpr);
+
+    ctx.restore();
+  }
+
+  private drawBackground(ctx: CanvasRenderingContext2D, rect: PlotRect) {
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(rect.x, rect.y, rect.width, rect.height);
+  }
+
+  private drawGrid(ctx: CanvasRenderingContext2D, bounds: ViewBounds, rect: PlotRect) {
+    const xTicks = computeTicks(bounds.xMin, bounds.xMax, 6);
+    const yTicks = computeTicks(bounds.yMin, bounds.yMax, 6);
+
+    ctx.strokeStyle = '#e8e8e8';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+
+    for (const v of xTicks) {
+      const px = rect.x + ((v - bounds.xMin) / (bounds.xMax - bounds.xMin)) * rect.width;
+      ctx.moveTo(px, rect.y);
+      ctx.lineTo(px, rect.y + rect.height);
+    }
+
+    for (const v of yTicks) {
+      const py =
+        rect.y + rect.height - ((v - bounds.yMin) / (bounds.yMax - bounds.yMin)) * rect.height;
+      ctx.moveTo(rect.x, py);
+      ctx.lineTo(rect.x + rect.width, py);
+    }
+
+    ctx.stroke();
+  }
+
+  private drawAxes(ctx: CanvasRenderingContext2D, bounds: ViewBounds, rect: PlotRect) {
+    const xRange = bounds.xMax - bounds.xMin;
+    const yRange = bounds.yMax - bounds.yMin;
+    const xTicks = computeTicks(bounds.xMin, bounds.xMax, 6);
+    const yTicks = computeTicks(bounds.yMin, bounds.yMax, 6);
+    const xStep = xTicks.length > 1 ? xTicks[1] - xTicks[0] : 1;
+    const yStep = yTicks.length > 1 ? yTicks[1] - yTicks[0] : 1;
+
+    // Axis lines
+    ctx.strokeStyle = '#888888';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(rect.x, rect.y + rect.height);
+    ctx.lineTo(rect.x + rect.width, rect.y + rect.height);
+    ctx.moveTo(rect.x, rect.y);
+    ctx.lineTo(rect.x, rect.y + rect.height);
+    ctx.stroke();
+
+    // X-axis ticks and labels
+    ctx.fillStyle = '#333333';
+    ctx.font = '11px -apple-system, BlinkMacSystemFont, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+
+    for (const v of xTicks) {
+      const px = rect.x + ((v - bounds.xMin) / xRange) * rect.width;
+      ctx.beginPath();
+      ctx.moveTo(px, rect.y + rect.height);
+      ctx.lineTo(px, rect.y + rect.height + 5);
+      ctx.stroke();
+      ctx.fillText(formatTick(v, xStep), px, rect.y + rect.height + 8);
+    }
+
+    // Y-axis ticks and labels
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+
+    for (const v of yTicks) {
+      const py = rect.y + rect.height - ((v - bounds.yMin) / yRange) * rect.height;
+      ctx.beginPath();
+      ctx.moveTo(rect.x - 5, py);
+      ctx.lineTo(rect.x, py);
+      ctx.stroke();
+      ctx.fillText(formatTick(v, yStep), rect.x - 8, py);
+    }
+  }
+
+  private drawAxisTitles(ctx: CanvasRenderingContext2D, rect: PlotRect, canvasH: number) {
+    ctx.fillStyle = '#333333';
+    ctx.font = '12px -apple-system, BlinkMacSystemFont, sans-serif';
+
+    // X-axis title
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'bottom';
+    ctx.fillText('Time (ms)', rect.x + rect.width / 2, canvasH - 4);
+
+    // Y-axis title (rotated)
+    ctx.save();
+    const yCenter = rect.y + rect.height / 2;
+    ctx.translate(14, yCenter);
+    ctx.rotate(-Math.PI / 2);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('Neuron ID', 0, 0);
+    ctx.restore();
+  }
+}

--- a/src/features/spike-viewer/renderer/interaction.ts
+++ b/src/features/spike-viewer/renderer/interaction.ts
@@ -103,6 +103,7 @@ export class InteractionManager {
     if (!this.isInPlotArea(e.clientX, e.clientY)) return;
 
     this.isDragging = true;
+    this.onHover?.(null);
     this.lastMouse = { x: e.clientX, y: e.clientY };
     this.element.setPointerCapture(e.pointerId);
     this.element.style.cursor = 'grabbing';

--- a/src/features/spike-viewer/renderer/interaction.ts
+++ b/src/features/spike-viewer/renderer/interaction.ts
@@ -1,0 +1,215 @@
+import type { PlotRect, ViewBounds } from '@/features/spike-viewer/renderer/axis-overlay';
+
+const ZOOM_FACTOR = 0.1;
+const MIN_RANGE = 1e-6;
+
+export type HoverInfo = {
+  dataX: number;
+  dataY: number;
+  pixelX: number;
+  pixelY: number;
+};
+
+export class InteractionManager {
+  private view: ViewBounds = { xMin: 0, xMax: 1, yMin: 0, yMax: 1 };
+  private initialView: ViewBounds = { xMin: 0, xMax: 1, yMin: 0, yMax: 1 };
+  private plotRect: PlotRect = { x: 0, y: 0, width: 1, height: 1 };
+  private element: HTMLElement;
+
+  private isDragging = false;
+  private lastMouse: { x: number; y: number } | null = null;
+
+  onViewChange: ((bounds: ViewBounds) => void) | null = null;
+  onHover: ((info: HoverInfo | null) => void) | null = null;
+
+  constructor(element: HTMLElement) {
+    this.element = element;
+    element.addEventListener('wheel', this.handleWheel, { passive: false });
+    element.addEventListener('pointerdown', this.handlePointerDown);
+    element.addEventListener('pointermove', this.handlePointerMove);
+    element.addEventListener('pointerup', this.handlePointerUp);
+    element.addEventListener('pointerleave', this.handlePointerLeave);
+    element.addEventListener('dblclick', this.handleDblClick);
+    element.style.cursor = 'crosshair';
+    element.style.touchAction = 'none';
+  }
+
+  setView(bounds: ViewBounds) {
+    this.view = { ...bounds };
+  }
+
+  setInitialView(bounds: ViewBounds) {
+    this.initialView = { ...bounds };
+    this.view = { ...bounds };
+  }
+
+  setPlotRect(rect: PlotRect) {
+    this.plotRect = rect;
+  }
+
+  resetView() {
+    this.view = { ...this.initialView };
+    this.onViewChange?.(this.view);
+  }
+
+  private isInPlotArea(clientX: number, clientY: number): boolean {
+    const rect = this.element.getBoundingClientRect();
+    const px = clientX - rect.left;
+    const py = clientY - rect.top;
+    const { x, y, width, height } = this.plotRect;
+    return px >= x && px <= x + width && py >= y && py <= y + height;
+  }
+
+  private pixelToData(clientX: number, clientY: number): { x: number; y: number } {
+    const rect = this.element.getBoundingClientRect();
+    const px = clientX - rect.left;
+    const py = clientY - rect.top;
+    const { x, y, width, height } = this.plotRect;
+    const normX = (px - x) / width;
+    const normY = 1 - (py - y) / height; // Flip Y: pixel Y goes down, data Y goes up
+    return {
+      x: this.view.xMin + normX * (this.view.xMax - this.view.xMin),
+      y: this.view.yMin + normY * (this.view.yMax - this.view.yMin),
+    };
+  }
+
+  private readonly handleWheel = (e: WheelEvent) => {
+    e.preventDefault();
+    if (!this.isInPlotArea(e.clientX, e.clientY)) return;
+
+    const direction = e.deltaY > 0 ? 1 : -1;
+    const factor = 1 + ZOOM_FACTOR * direction;
+    const cursor = this.pixelToData(e.clientX, e.clientY);
+
+    const xRange = this.view.xMax - this.view.xMin;
+    const yRange = this.view.yMax - this.view.yMin;
+
+    // Zoom centered on cursor position
+    const xRatio = (cursor.x - this.view.xMin) / xRange;
+    const yRatio = (cursor.y - this.view.yMin) / yRange;
+
+    const newXRange = Math.max(MIN_RANGE, xRange * factor);
+    const newYRange = Math.max(MIN_RANGE, yRange * factor);
+
+    this.view = {
+      xMin: cursor.x - xRatio * newXRange,
+      xMax: cursor.x + (1 - xRatio) * newXRange,
+      yMin: cursor.y - yRatio * newYRange,
+      yMax: cursor.y + (1 - yRatio) * newYRange,
+    };
+
+    this.clampView();
+    this.onViewChange?.(this.view);
+  };
+
+  private readonly handlePointerDown = (e: PointerEvent) => {
+    if (e.button !== 0) return;
+    if (!this.isInPlotArea(e.clientX, e.clientY)) return;
+
+    this.isDragging = true;
+    this.lastMouse = { x: e.clientX, y: e.clientY };
+    this.element.setPointerCapture(e.pointerId);
+    this.element.style.cursor = 'grabbing';
+  };
+
+  private readonly handlePointerMove = (e: PointerEvent) => {
+    if (this.isDragging && this.lastMouse) {
+      const dx = e.clientX - this.lastMouse.x;
+      const dy = e.clientY - this.lastMouse.y;
+      this.lastMouse = { x: e.clientX, y: e.clientY };
+
+      const xRange = this.view.xMax - this.view.xMin;
+      const yRange = this.view.yMax - this.view.yMin;
+      const dataX = -(dx / this.plotRect.width) * xRange;
+      const dataY = (dy / this.plotRect.height) * yRange; // Flip Y
+
+      this.view = {
+        xMin: this.view.xMin + dataX,
+        xMax: this.view.xMax + dataX,
+        yMin: this.view.yMin + dataY,
+        yMax: this.view.yMax + dataY,
+      };
+
+      this.clampView();
+      this.onViewChange?.(this.view);
+    } else if (this.isInPlotArea(e.clientX, e.clientY)) {
+      const rect = this.element.getBoundingClientRect();
+      const data = this.pixelToData(e.clientX, e.clientY);
+      this.onHover?.({
+        dataX: data.x,
+        dataY: data.y,
+        pixelX: e.clientX - rect.left,
+        pixelY: e.clientY - rect.top,
+      });
+    } else {
+      this.onHover?.(null);
+    }
+  };
+
+  private readonly handlePointerUp = (e: PointerEvent) => {
+    if (this.isDragging) {
+      this.isDragging = false;
+      this.lastMouse = null;
+      this.element.releasePointerCapture(e.pointerId);
+      this.element.style.cursor = 'crosshair';
+    }
+  };
+
+  private readonly handlePointerLeave = () => {
+    this.onHover?.(null);
+  };
+
+  private readonly handleDblClick = (e: MouseEvent) => {
+    if (this.isInPlotArea(e.clientX, e.clientY)) {
+      this.resetView();
+    }
+  };
+
+  private clampView() {
+    const iv = this.initialView;
+
+    // X axis
+    const xRange = this.view.xMax - this.view.xMin;
+    const xDataRange = iv.xMax - iv.xMin;
+    if (xRange >= xDataRange) {
+      this.view.xMin = iv.xMin;
+      this.view.xMax = iv.xMax;
+    } else {
+      if (this.view.xMin < iv.xMin) {
+        this.view.xMax += iv.xMin - this.view.xMin;
+        this.view.xMin = iv.xMin;
+      }
+      if (this.view.xMax > iv.xMax) {
+        this.view.xMin -= this.view.xMax - iv.xMax;
+        this.view.xMax = iv.xMax;
+      }
+    }
+
+    // Y axis
+    const yRange = this.view.yMax - this.view.yMin;
+    const yDataRange = iv.yMax - iv.yMin;
+    if (yRange >= yDataRange) {
+      this.view.yMin = iv.yMin;
+      this.view.yMax = iv.yMax;
+    } else {
+      if (this.view.yMin < iv.yMin) {
+        this.view.yMax += iv.yMin - this.view.yMin;
+        this.view.yMin = iv.yMin;
+      }
+      if (this.view.yMax > iv.yMax) {
+        this.view.yMin -= this.view.yMax - iv.yMax;
+        this.view.yMax = iv.yMax;
+      }
+    }
+  }
+
+  destroy() {
+    const el = this.element;
+    el.removeEventListener('wheel', this.handleWheel);
+    el.removeEventListener('pointerdown', this.handlePointerDown);
+    el.removeEventListener('pointermove', this.handlePointerMove);
+    el.removeEventListener('pointerup', this.handlePointerUp);
+    el.removeEventListener('pointerleave', this.handlePointerLeave);
+    el.removeEventListener('dblclick', this.handleDblClick);
+  }
+}

--- a/src/features/spike-viewer/renderer/interaction.ts
+++ b/src/features/spike-viewer/renderer/interaction.ts
@@ -34,10 +34,6 @@ export class InteractionManager {
     element.style.touchAction = 'none';
   }
 
-  setView(bounds: ViewBounds) {
-    this.view = { ...bounds };
-  }
-
   setInitialView(bounds: ViewBounds) {
     this.initialView = { ...bounds };
     this.view = { ...bounds };

--- a/src/features/spike-viewer/renderer/raster-renderer.ts
+++ b/src/features/spike-viewer/renderer/raster-renderer.ts
@@ -1,0 +1,338 @@
+import { AxisOverlay, MARGIN } from '@/features/spike-viewer/renderer/axis-overlay';
+import { InteractionManager } from '@/features/spike-viewer/renderer/interaction';
+import { WebGLPoints } from '@/features/spike-viewer/renderer/webgl-points';
+
+import type { PlotRect, ViewBounds } from '@/features/spike-viewer/renderer/axis-overlay';
+import type { HoverInfo } from '@/features/spike-viewer/renderer/interaction';
+import type { SpikePopulation } from '@/features/spike-viewer/spike-trace';
+
+export const POPULATION_COLORS = [
+  '#1f77b4',
+  '#d62728',
+  '#2ca02c',
+  '#ff7f0e',
+  '#9467bd',
+  '#8c564b',
+  '#e377c2',
+  '#7f7f7f',
+  '#bcbd22',
+  '#17becf',
+];
+
+/** Sorted population data for efficient binary-search hover. */
+type SortedPopulation = {
+  name: string;
+  timestamps: Float32Array;
+  nodeIds: Float32Array;
+  visible: boolean;
+};
+
+export class RasterRenderer {
+  private glCanvas: HTMLCanvasElement;
+  private axisCanvas: HTMLCanvasElement;
+  private interactionLayer: HTMLDivElement;
+  private tooltipEl: HTMLDivElement;
+
+  private webgl: WebGLPoints;
+  private axis: AxisOverlay;
+  private interaction: InteractionManager;
+  private observer: ResizeObserver;
+
+  private view: ViewBounds = { xMin: 0, xMax: 1, yMin: 0, yMax: 1 };
+  private initialView: ViewBounds = { xMin: 0, xMax: 1, yMin: 0, yMax: 1 };
+  private plotRect: PlotRect = { x: 0, y: 0, width: 1, height: 1 };
+  private sortedPops: SortedPopulation[] = [];
+  private totalSpikes = 0;
+  private dirty = true;
+  private rafId: number | null = null;
+  private hasData = false;
+
+  constructor(container: HTMLElement) {
+    container.style.position = 'relative';
+    container.style.overflow = 'hidden';
+
+    // Axis overlay (full size, behind WebGL)
+    this.axisCanvas = document.createElement('canvas');
+    this.axisCanvas.style.cssText = 'position:absolute;inset:0;width:100%;height:100%';
+    container.appendChild(this.axisCanvas);
+
+    // WebGL canvas (positioned within margins for the plot area)
+    this.glCanvas = document.createElement('canvas');
+    this.glCanvas.style.cssText = 'position:absolute';
+    container.appendChild(this.glCanvas);
+
+    // Interaction layer (full size, topmost)
+    this.interactionLayer = document.createElement('div');
+    this.interactionLayer.style.cssText = 'position:absolute;inset:0;width:100%;height:100%';
+    container.appendChild(this.interactionLayer);
+
+    // Tooltip
+    this.tooltipEl = document.createElement('div');
+    this.tooltipEl.style.cssText =
+      'position:absolute;pointer-events:none;display:none;' +
+      'background:rgba(0,0,0,0.8);color:#fff;padding:4px 8px;border-radius:4px;' +
+      'font:11px -apple-system,BlinkMacSystemFont,sans-serif;white-space:nowrap;z-index:10';
+    container.appendChild(this.tooltipEl);
+
+    this.webgl = new WebGLPoints(this.glCanvas);
+    this.axis = new AxisOverlay(this.axisCanvas);
+    this.interaction = new InteractionManager(this.interactionLayer);
+
+    this.interaction.onViewChange = (bounds) => {
+      this.view = bounds;
+      this.scheduleRender();
+    };
+
+    this.interaction.onHover = (info) => this.handleHover(info);
+
+    this.observer = new ResizeObserver(() => this.handleResize());
+    this.observer.observe(container);
+    this.handleResize();
+  }
+
+  setData(populations: SpikePopulation[], dataBounds: ViewBounds) {
+    // Add padding to data bounds
+    const xPad = (dataBounds.xMax - dataBounds.xMin) * 0.02 || 1;
+    const yPad = (dataBounds.yMax - dataBounds.yMin) * 0.05 || 1;
+    this.initialView = {
+      xMin: dataBounds.xMin - xPad,
+      xMax: dataBounds.xMax + xPad,
+      yMin: dataBounds.yMin - yPad,
+      yMax: dataBounds.yMax + yPad,
+    };
+    this.view = { ...this.initialView };
+
+    this.webgl.setData(populations, POPULATION_COLORS);
+    this.interaction.setInitialView(this.initialView);
+
+    // Build sorted copies for binary-search hover
+    this.sortedPops = populations.map((pop) => {
+      const { timestamps, nodeIds } = sortByTimestamp(pop.timestamps, pop.nodeIds);
+      return { name: pop.name, timestamps, nodeIds, visible: true };
+    });
+
+    this.totalSpikes = populations.reduce((sum, p) => sum + p.timestamps.length, 0);
+    this.hasData = true;
+    this.scheduleRender();
+  }
+
+  setVisiblePopulations(names: Set<string>) {
+    for (const pop of this.sortedPops) {
+      const visible = names.has(pop.name);
+      pop.visible = visible;
+      this.webgl.setVisibility(pop.name, visible);
+    }
+    this.scheduleRender();
+  }
+
+  private scheduleRender() {
+    this.dirty = true;
+    if (this.rafId === null) {
+      this.rafId = requestAnimationFrame(() => {
+        this.rafId = null;
+        if (this.dirty) this.render();
+      });
+    }
+  }
+
+  private render() {
+    this.dirty = false;
+    if (!this.hasData) return;
+
+    const pointSize = this.computePointSize();
+    this.webgl.draw(this.view, pointSize);
+    this.axis.draw(this.view, this.plotRect);
+  }
+
+  private computePointSize(): number {
+    // Density-aware base: large for sparse data, small for dense
+    const visibleArea = this.plotRect.width * this.plotRect.height;
+    const density = this.totalSpikes / Math.max(1, visibleArea);
+    const baseSize = Math.min(6, Math.max(2, 4 - Math.log10(Math.max(1e-4, density))));
+
+    // Zoom scaling: grows as user zooms in
+    const xZoom =
+      (this.initialView.xMax - this.initialView.xMin) / (this.view.xMax - this.view.xMin);
+    const yZoom =
+      (this.initialView.yMax - this.initialView.yMin) / (this.view.yMax - this.view.yMin);
+    const zoom = Math.min(xZoom, yZoom);
+    const zoomBonus = Math.log2(Math.max(1, zoom));
+
+    return Math.min(12, baseSize + zoomBonus);
+  }
+
+  private handleHover(info: HoverInfo | null) {
+    if (!info) {
+      this.tooltipEl.style.display = 'none';
+      return;
+    }
+
+    const nearest = this.findNearestPoint(info.dataX, info.dataY);
+    if (!nearest) {
+      this.tooltipEl.style.display = 'none';
+      return;
+    }
+
+    // Check pixel distance threshold
+    const pxX =
+      this.plotRect.x +
+      ((nearest.time - this.view.xMin) / (this.view.xMax - this.view.xMin)) * this.plotRect.width;
+    const pxY =
+      this.plotRect.y +
+      (1 - (nearest.nodeId - this.view.yMin) / (this.view.yMax - this.view.yMin)) *
+        this.plotRect.height;
+    const dist = Math.hypot(info.pixelX - pxX, info.pixelY - pxY);
+
+    if (dist > 20) {
+      this.tooltipEl.style.display = 'none';
+      return;
+    }
+
+    this.tooltipEl.style.display = 'block';
+    this.tooltipEl.textContent =
+      `${nearest.population}_${Math.round(nearest.nodeId)}: ${nearest.time.toFixed(2)} ms`;
+
+    // Edge-aware placement: flip when tooltip would overflow container
+    const container = this.glCanvas.parentElement;
+    const cw = container?.clientWidth ?? 0;
+    const ch = container?.clientHeight ?? 0;
+    const tw = this.tooltipEl.offsetWidth;
+    const th = this.tooltipEl.offsetHeight;
+    const gap = 12;
+
+    const flipsLeft = info.pixelX + gap + tw > cw;
+    const left = flipsLeft ? info.pixelX - gap - tw : info.pixelX + gap;
+    const flipsUp = info.pixelY - gap + th > ch;
+    const top = flipsUp ? info.pixelY - gap - th : info.pixelY - gap;
+
+    this.tooltipEl.style.left = `${left}px`;
+    this.tooltipEl.style.top = `${top}px`;
+  }
+
+  private findNearestPoint(
+    dataX: number,
+    dataY: number
+  ): { population: string; nodeId: number; time: number } | null {
+    const xRange = this.view.xMax - this.view.xMin;
+    const yRange = this.view.yMax - this.view.yMin;
+    // Search threshold: 20px in data coordinates
+    const xThresh = (xRange * 20) / Math.max(1, this.plotRect.width);
+    const yThresh = (yRange * 20) / Math.max(1, this.plotRect.height);
+
+    let bestDist = Infinity;
+    let bestResult: { population: string; nodeId: number; time: number } | null = null;
+
+    for (const pop of this.sortedPops) {
+      if (!pop.visible || pop.timestamps.length === 0) continue;
+
+      // Binary search for start of x window
+      const lo = lowerBound(pop.timestamps, dataX - xThresh);
+      const hi = upperBound(pop.timestamps, dataX + xThresh);
+
+      for (let i = lo; i < hi; i++) {
+        const dy = Math.abs(pop.nodeIds[i] - dataY);
+        if (dy > yThresh) continue;
+
+        // Normalized distance for fair comparison across axes
+        const dx = (pop.timestamps[i] - dataX) / xRange;
+        const dyNorm = (pop.nodeIds[i] - dataY) / yRange;
+        const dist = dx * dx + dyNorm * dyNorm;
+
+        if (dist < bestDist) {
+          bestDist = dist;
+          bestResult = { population: pop.name, nodeId: pop.nodeIds[i], time: pop.timestamps[i] };
+        }
+      }
+    }
+
+    return bestResult;
+  }
+
+  private handleResize() {
+    const container = this.glCanvas.parentElement;
+    if (!container) return;
+    const { clientWidth: w, clientHeight: h } = container;
+    if (w === 0 || h === 0) return;
+
+    const dpr = window.devicePixelRatio || 1;
+
+    // Update plot rect
+    this.plotRect = {
+      x: MARGIN.left,
+      y: MARGIN.top,
+      width: Math.max(1, w - MARGIN.left - MARGIN.right),
+      height: Math.max(1, h - MARGIN.top - MARGIN.bottom),
+    };
+
+    // Size and position GL canvas to plot area
+    this.glCanvas.style.left = `${this.plotRect.x}px`;
+    this.glCanvas.style.top = `${this.plotRect.y}px`;
+    this.glCanvas.style.width = `${this.plotRect.width}px`;
+    this.glCanvas.style.height = `${this.plotRect.height}px`;
+    this.glCanvas.width = this.plotRect.width * dpr;
+    this.glCanvas.height = this.plotRect.height * dpr;
+    this.webgl.resize(this.glCanvas.width, this.glCanvas.height);
+
+    // Size axis canvas to full container
+    this.axisCanvas.width = w * dpr;
+    this.axisCanvas.height = h * dpr;
+
+    this.interaction.setPlotRect(this.plotRect);
+    this.scheduleRender();
+  }
+
+  destroy() {
+    if (this.rafId !== null) cancelAnimationFrame(this.rafId);
+    this.observer.disconnect();
+    this.interaction.destroy();
+    this.webgl.destroy();
+
+    this.glCanvas.remove();
+    this.axisCanvas.remove();
+    this.interactionLayer.remove();
+    this.tooltipEl.remove();
+  }
+}
+
+/** Sort timestamps and nodeIds arrays together by timestamp (ascending). */
+function sortByTimestamp(
+  timestamps: Float32Array,
+  nodeIds: Float32Array
+): { timestamps: Float32Array; nodeIds: Float32Array } {
+  const n = timestamps.length;
+  const indices = new Uint32Array(n);
+  for (let i = 0; i < n; i++) indices[i] = i;
+  indices.sort((a, b) => timestamps[a] - timestamps[b]);
+
+  const sortedTs = new Float32Array(n);
+  const sortedIds = new Float32Array(n);
+  for (let i = 0; i < n; i++) {
+    sortedTs[i] = timestamps[indices[i]];
+    sortedIds[i] = nodeIds[indices[i]];
+  }
+  return { timestamps: sortedTs, nodeIds: sortedIds };
+}
+
+/** Find first index where arr[i] >= value (lower bound). */
+function lowerBound(arr: Float32Array, value: number): number {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (arr[mid] < value) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/** Find first index where arr[i] > value (upper bound). */
+function upperBound(arr: Float32Array, value: number): number {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (arr[mid] <= value) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}

--- a/src/features/spike-viewer/renderer/raster-renderer.ts
+++ b/src/features/spike-viewer/renderer/raster-renderer.ts
@@ -42,9 +42,10 @@ export class RasterRenderer {
   private initialView: ViewBounds = { xMin: 0, xMax: 1, yMin: 0, yMax: 1 };
   private plotRect: PlotRect = { x: 0, y: 0, width: 1, height: 1 };
   private sortedPops: SortedPopulation[] = [];
-  private totalSpikes = 0;
+  private visibleSpikes = 0;
   private dirty = true;
   private rafId: number | null = null;
+  private resizeRafId: number | null = null;
   private hasData = false;
 
   constructor(container: HTMLElement) {
@@ -75,6 +76,13 @@ export class RasterRenderer {
     container.appendChild(this.tooltipEl);
 
     this.webgl = new WebGLPoints(this.glCanvas);
+    this.webgl.onRestored = () => {
+      for (const pop of this.sortedPops) {
+        this.webgl.setVisibility(pop.name, pop.visible);
+      }
+      this.webgl.resize(this.glCanvas.width, this.glCanvas.height);
+      this.scheduleRender();
+    };
     this.axis = new AxisOverlay(this.axisCanvas);
     this.interaction = new InteractionManager(this.interactionLayer);
 
@@ -85,7 +93,14 @@ export class RasterRenderer {
 
     this.interaction.onHover = (info) => this.handleHover(info);
 
-    this.observer = new ResizeObserver(() => this.handleResize());
+    this.observer = new ResizeObserver(() => {
+      if (this.resizeRafId === null) {
+        this.resizeRafId = requestAnimationFrame(() => {
+          this.resizeRafId = null;
+          this.handleResize();
+        });
+      }
+    });
     this.observer.observe(container);
     this.handleResize();
   }
@@ -111,7 +126,7 @@ export class RasterRenderer {
       return { name: pop.name, timestamps, nodeIds, visible: true };
     });
 
-    this.totalSpikes = populations.reduce((sum, p) => sum + p.timestamps.length, 0);
+    this.visibleSpikes = populations.reduce((sum, p) => sum + p.timestamps.length, 0);
     this.hasData = true;
     this.scheduleRender();
   }
@@ -122,6 +137,9 @@ export class RasterRenderer {
       pop.visible = visible;
       this.webgl.setVisibility(pop.name, visible);
     }
+    this.visibleSpikes = this.sortedPops
+      .filter((p) => p.visible)
+      .reduce((sum, p) => sum + p.timestamps.length, 0);
     this.scheduleRender();
   }
 
@@ -147,7 +165,7 @@ export class RasterRenderer {
   private computePointSize(): number {
     // Density-aware base: large for sparse data, small for dense
     const visibleArea = this.plotRect.width * this.plotRect.height;
-    const density = this.totalSpikes / Math.max(1, visibleArea);
+    const density = this.visibleSpikes / Math.max(1, visibleArea);
     const baseSize = Math.min(6, Math.max(2, 4 - Math.log10(Math.max(1e-4, density))));
 
     // Zoom scaling: grows as user zooms in
@@ -189,8 +207,7 @@ export class RasterRenderer {
     }
 
     this.tooltipEl.style.display = 'block';
-    this.tooltipEl.textContent =
-      `${nearest.population}_${Math.round(nearest.nodeId)}: ${nearest.time.toFixed(2)} ms`;
+    this.tooltipEl.textContent = `${nearest.population}_${Math.round(nearest.nodeId)}: ${nearest.time.toFixed(2)} ms`;
 
     // Edge-aware placement: flip when tooltip would overflow container
     const container = this.glCanvas.parentElement;
@@ -283,6 +300,7 @@ export class RasterRenderer {
 
   destroy() {
     if (this.rafId !== null) cancelAnimationFrame(this.rafId);
+    if (this.resizeRafId !== null) cancelAnimationFrame(this.resizeRafId);
     this.observer.disconnect();
     this.interaction.destroy();
     this.webgl.destroy();

--- a/src/features/spike-viewer/renderer/webgl-points.ts
+++ b/src/features/spike-viewer/renderer/webgl-points.ts
@@ -48,14 +48,20 @@ function glRequire<T>(value: T | null, name: string): T {
 }
 
 export class WebGLPoints {
+  private canvas: HTMLCanvasElement;
   private gl: WebGL2RenderingContext;
-  private program: WebGLProgram;
-  private uBounds: WebGLUniformLocation;
-  private uColor: WebGLUniformLocation;
-  private uPointSize: WebGLUniformLocation;
+  private program!: WebGLProgram;
+  private uBounds!: WebGLUniformLocation;
+  private uColor!: WebGLUniformLocation;
+  private uPointSize!: WebGLUniformLocation;
   private populations: PopulationBuffer[] = [];
+  private lastData: { populations: SpikePopulation[]; colors: string[] } | null = null;
+  private contextLost = false;
+
+  onRestored: (() => void) | null = null;
 
   constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas;
     const gl = canvas.getContext('webgl2', {
       antialias: true,
       alpha: true,
@@ -64,16 +70,67 @@ export class WebGLPoints {
     if (!gl) throw new Error('WebGL2 not supported');
     this.gl = gl;
 
+    this.initGL();
+
+    canvas.addEventListener('webglcontextlost', this.handleContextLost);
+    canvas.addEventListener('webglcontextrestored', this.handleContextRestored);
+  }
+
+  setData(populations: SpikePopulation[], colors: string[]) {
+    this.lastData = { populations, colors };
+    this.initBuffers(populations, colors);
+  }
+
+  draw(bounds: { xMin: number; yMin: number; xMax: number; yMax: number }, pointSize: number) {
+    if (this.contextLost) return;
+    const { gl } = this;
+
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    // biome-ignore lint/correctness/useHookAtTopLevel: WebGL API, not a React hook
+    gl.useProgram(this.program);
+    gl.uniform4f(this.uBounds, bounds.xMin, bounds.yMin, bounds.xMax, bounds.yMax);
+    gl.uniform1f(this.uPointSize, pointSize * (window.devicePixelRatio || 1));
+
+    for (const pop of this.populations) {
+      if (!pop.visible || pop.count === 0) continue;
+      gl.uniform4fv(this.uColor, pop.color);
+      gl.bindVertexArray(pop.vao);
+      gl.drawArrays(gl.POINTS, 0, pop.count);
+    }
+
+    gl.bindVertexArray(null);
+  }
+
+  setVisibility(name: string, visible: boolean) {
+    const pop = this.populations.find((p) => p.name === name);
+    if (pop) pop.visible = visible;
+  }
+
+  resize(width: number, height: number) {
+    if (!this.contextLost) this.gl.viewport(0, 0, width, height);
+  }
+
+  destroy() {
+    this.cleanup();
+    if (!this.contextLost) this.gl.deleteProgram(this.program);
+    this.canvas.removeEventListener('webglcontextlost', this.handleContextLost);
+    this.canvas.removeEventListener('webglcontextrestored', this.handleContextRestored);
+    this.lastData = null;
+  }
+
+  private initGL() {
+    const { gl } = this;
     this.program = this.createProgram(VERTEX_SHADER, FRAGMENT_SHADER);
     this.uBounds = glRequire(gl.getUniformLocation(this.program, 'u_bounds'), 'u_bounds');
     this.uColor = glRequire(gl.getUniformLocation(this.program, 'u_color'), 'u_color');
     this.uPointSize = glRequire(gl.getUniformLocation(this.program, 'u_pointSize'), 'u_pointSize');
-
     gl.enable(gl.BLEND);
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
   }
 
-  setData(populations: SpikePopulation[], colors: string[]) {
+  private initBuffers(populations: SpikePopulation[], colors: string[]) {
     this.cleanup();
     const { gl } = this;
 
@@ -112,35 +169,17 @@ export class WebGLPoints {
     }
   }
 
-  draw(bounds: { xMin: number; yMin: number; xMax: number; yMax: number }, pointSize: number) {
-    const { gl } = this;
+  private readonly handleContextLost = (e: Event) => {
+    e.preventDefault();
+    this.contextLost = true;
+  };
 
-    gl.clearColor(0, 0, 0, 0);
-    gl.clear(gl.COLOR_BUFFER_BIT);
-
-    // biome-ignore lint/correctness/useHookAtTopLevel: WebGL API, not a React hook
-    gl.useProgram(this.program);
-    gl.uniform4f(this.uBounds, bounds.xMin, bounds.yMin, bounds.xMax, bounds.yMax);
-    gl.uniform1f(this.uPointSize, pointSize * (window.devicePixelRatio || 1));
-
-    for (const pop of this.populations) {
-      if (!pop.visible || pop.count === 0) continue;
-      gl.uniform4fv(this.uColor, pop.color);
-      gl.bindVertexArray(pop.vao);
-      gl.drawArrays(gl.POINTS, 0, pop.count);
-    }
-
-    gl.bindVertexArray(null);
-  }
-
-  setVisibility(name: string, visible: boolean) {
-    const pop = this.populations.find((p) => p.name === name);
-    if (pop) pop.visible = visible;
-  }
-
-  resize(width: number, height: number) {
-    this.gl.viewport(0, 0, width, height);
-  }
+  private readonly handleContextRestored = () => {
+    this.contextLost = false;
+    this.initGL();
+    if (this.lastData) this.initBuffers(this.lastData.populations, this.lastData.colors);
+    this.onRestored?.();
+  };
 
   private createProgram(vsSrc: string, fsSrc: string): WebGLProgram {
     const { gl } = this;
@@ -174,6 +213,10 @@ export class WebGLPoints {
   }
 
   private cleanup() {
+    if (this.contextLost) {
+      this.populations = [];
+      return;
+    }
     const { gl } = this;
     for (const pop of this.populations) {
       gl.deleteVertexArray(pop.vao);
@@ -181,10 +224,5 @@ export class WebGLPoints {
       gl.deleteBuffer(pop.yBuffer);
     }
     this.populations = [];
-  }
-
-  destroy() {
-    this.cleanup();
-    this.gl.deleteProgram(this.program);
   }
 }

--- a/src/features/spike-viewer/renderer/webgl-points.ts
+++ b/src/features/spike-viewer/renderer/webgl-points.ts
@@ -1,0 +1,190 @@
+import type { SpikePopulation } from '@/features/spike-viewer/spike-trace';
+
+const VERTEX_SHADER = `#version 300 es
+layout(location = 0) in float a_x;
+layout(location = 1) in float a_y;
+uniform vec4 u_bounds; // xMin, yMin, xMax, yMax
+uniform float u_pointSize;
+
+void main() {
+  float x = 2.0 * (a_x - u_bounds.x) / (u_bounds.z - u_bounds.x) - 1.0;
+  float y = 2.0 * (a_y - u_bounds.y) / (u_bounds.w - u_bounds.y) - 1.0;
+  gl_Position = vec4(x, y, 0.0, 1.0);
+  gl_PointSize = u_pointSize;
+}`;
+
+const FRAGMENT_SHADER = `#version 300 es
+precision mediump float;
+uniform vec4 u_color;
+out vec4 fragColor;
+
+void main() {
+  // Vertical tick mark: only draw the center strip
+  float dx = abs(gl_PointCoord.x - 0.5);
+  if (dx > 0.2) discard;
+  fragColor = u_color;
+}`;
+
+type PopulationBuffer = {
+  name: string;
+  color: [number, number, number, number];
+  count: number;
+  vao: WebGLVertexArrayObject;
+  xBuffer: WebGLBuffer;
+  yBuffer: WebGLBuffer;
+  visible: boolean;
+};
+
+function hexToGLColor(hex: string): [number, number, number, number] {
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  return [r, g, b, 1.0];
+}
+
+function glRequire<T>(value: T | null, name: string): T {
+  if (value === null) throw new Error(`WebGL resource creation failed: ${name}`);
+  return value;
+}
+
+export class WebGLPoints {
+  private gl: WebGL2RenderingContext;
+  private program: WebGLProgram;
+  private uBounds: WebGLUniformLocation;
+  private uColor: WebGLUniformLocation;
+  private uPointSize: WebGLUniformLocation;
+  private populations: PopulationBuffer[] = [];
+
+  constructor(canvas: HTMLCanvasElement) {
+    const gl = canvas.getContext('webgl2', {
+      antialias: true,
+      alpha: true,
+      premultipliedAlpha: false,
+    });
+    if (!gl) throw new Error('WebGL2 not supported');
+    this.gl = gl;
+
+    this.program = this.createProgram(VERTEX_SHADER, FRAGMENT_SHADER);
+    this.uBounds = glRequire(gl.getUniformLocation(this.program, 'u_bounds'), 'u_bounds');
+    this.uColor = glRequire(gl.getUniformLocation(this.program, 'u_color'), 'u_color');
+    this.uPointSize = glRequire(gl.getUniformLocation(this.program, 'u_pointSize'), 'u_pointSize');
+
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+  }
+
+  setData(populations: SpikePopulation[], colors: string[]) {
+    this.cleanup();
+    const { gl } = this;
+
+    for (let i = 0; i < populations.length; i++) {
+      const pop = populations[i];
+      const color = hexToGLColor(colors[i % colors.length]);
+
+      const vao = glRequire(gl.createVertexArray(), 'VAO');
+      gl.bindVertexArray(vao);
+
+      // Timestamps → attribute 0 (x)
+      const xBuffer = glRequire(gl.createBuffer(), 'xBuffer');
+      gl.bindBuffer(gl.ARRAY_BUFFER, xBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, pop.timestamps, gl.STATIC_DRAW);
+      gl.enableVertexAttribArray(0);
+      gl.vertexAttribPointer(0, 1, gl.FLOAT, false, 0, 0);
+
+      // Node IDs → attribute 1 (y)
+      const yBuffer = glRequire(gl.createBuffer(), 'yBuffer');
+      gl.bindBuffer(gl.ARRAY_BUFFER, yBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, pop.nodeIds, gl.STATIC_DRAW);
+      gl.enableVertexAttribArray(1);
+      gl.vertexAttribPointer(1, 1, gl.FLOAT, false, 0, 0);
+
+      gl.bindVertexArray(null);
+
+      this.populations.push({
+        name: pop.name,
+        color,
+        count: pop.timestamps.length,
+        vao,
+        xBuffer,
+        yBuffer,
+        visible: true,
+      });
+    }
+  }
+
+  draw(bounds: { xMin: number; yMin: number; xMax: number; yMax: number }, pointSize: number) {
+    const { gl } = this;
+
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    // biome-ignore lint/correctness/useHookAtTopLevel: WebGL API, not a React hook
+    gl.useProgram(this.program);
+    gl.uniform4f(this.uBounds, bounds.xMin, bounds.yMin, bounds.xMax, bounds.yMax);
+    gl.uniform1f(this.uPointSize, pointSize * (window.devicePixelRatio || 1));
+
+    for (const pop of this.populations) {
+      if (!pop.visible || pop.count === 0) continue;
+      gl.uniform4fv(this.uColor, pop.color);
+      gl.bindVertexArray(pop.vao);
+      gl.drawArrays(gl.POINTS, 0, pop.count);
+    }
+
+    gl.bindVertexArray(null);
+  }
+
+  setVisibility(name: string, visible: boolean) {
+    const pop = this.populations.find((p) => p.name === name);
+    if (pop) pop.visible = visible;
+  }
+
+  resize(width: number, height: number) {
+    this.gl.viewport(0, 0, width, height);
+  }
+
+  private createProgram(vsSrc: string, fsSrc: string): WebGLProgram {
+    const { gl } = this;
+    const vs = this.compileShader(gl.VERTEX_SHADER, vsSrc);
+    const fs = this.compileShader(gl.FRAGMENT_SHADER, fsSrc);
+    const program = glRequire(gl.createProgram(), 'program');
+    gl.attachShader(program, vs);
+    gl.attachShader(program, fs);
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      const log = gl.getProgramInfoLog(program);
+      gl.deleteProgram(program);
+      throw new Error(`Shader link failed: ${log}`);
+    }
+    gl.deleteShader(vs);
+    gl.deleteShader(fs);
+    return program;
+  }
+
+  private compileShader(type: number, src: string): WebGLShader {
+    const { gl } = this;
+    const shader = glRequire(gl.createShader(type), 'shader');
+    gl.shaderSource(shader, src);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+      const log = gl.getShaderInfoLog(shader);
+      gl.deleteShader(shader);
+      throw new Error(`Shader compile failed: ${log}`);
+    }
+    return shader;
+  }
+
+  private cleanup() {
+    const { gl } = this;
+    for (const pop of this.populations) {
+      gl.deleteVertexArray(pop.vao);
+      gl.deleteBuffer(pop.xBuffer);
+      gl.deleteBuffer(pop.yBuffer);
+    }
+    this.populations = [];
+  }
+
+  destroy() {
+    this.cleanup();
+    this.gl.deleteProgram(this.program);
+  }
+}

--- a/src/features/spike-viewer/spike-trace.ts
+++ b/src/features/spike-viewer/spike-trace.ts
@@ -1,9 +1,34 @@
 import { Dataset, File, Group, ready } from 'h5wasm';
 
+/** Convert any TypedArray from h5wasm to Float32Array without unnecessary copies. */
+function toFloat32(arr: ArrayLike<number | bigint>): Float32Array {
+  if (arr instanceof Float32Array) return arr;
+  if (arr instanceof Float64Array || arr instanceof Int32Array || arr instanceof Uint32Array) {
+    return new Float32Array(arr);
+  }
+  // Handle BigInt64Array / BigUint64Array from int64/uint64 HDF5 datasets
+  const result = new Float32Array(arr.length);
+  for (let i = 0; i < arr.length; i++) {
+    result[i] = Number(arr[i]);
+  }
+  return result;
+}
+
+/** Loop-based min/max that avoids stack overflow from Math.min/max spread on large arrays. */
+function float32MinMax(arr: Float32Array): [number, number] {
+  let min = arr[0];
+  let max = arr[0];
+  for (let i = 1; i < arr.length; i++) {
+    if (arr[i] < min) min = arr[i];
+    if (arr[i] > max) max = arr[i];
+  }
+  return [min, max];
+}
+
 export type SpikePopulation = {
   name: string;
-  nodeIds: number[];
-  timestamps: number[];
+  nodeIds: Float32Array;
+  timestamps: Float32Array;
   units?: string;
 };
 
@@ -101,8 +126,12 @@ export default class SpikeTrace {
         continue;
       }
 
-      const nodeIds = Array.from(nodeIdsDataset.to_array() as number[]);
-      const timestamps = Array.from(timestampsDataset.to_array() as number[]);
+      const rawNodeIds = nodeIdsDataset.to_array();
+      const rawTimestamps = timestampsDataset.to_array();
+      if (!rawNodeIds || !rawTimestamps) continue;
+
+      const nodeIds = toFloat32(rawNodeIds as ArrayLike<number | bigint>);
+      const timestamps = toFloat32(rawTimestamps as ArrayLike<number | bigint>);
 
       // Get units attribute if available
       let units: string | undefined;
@@ -119,17 +148,15 @@ export default class SpikeTrace {
         units,
       });
 
-      // Update global ranges
+      // Update global ranges using loop-based min/max (spread operator crashes on large arrays)
       if (timestamps.length > 0) {
-        const minTime = Math.min(...timestamps);
-        const maxTime = Math.max(...timestamps);
+        const [minTime, maxTime] = float32MinMax(timestamps);
         globalMinTime = Math.min(globalMinTime, minTime);
         globalMaxTime = Math.max(globalMaxTime, maxTime);
       }
 
       if (nodeIds.length > 0) {
-        const minNodeId = Math.min(...nodeIds);
-        const maxNodeId = Math.max(...nodeIds);
+        const [minNodeId, maxNodeId] = float32MinMax(nodeIds);
         globalMinNodeId = Math.min(globalMinNodeId, minNodeId);
         globalMaxNodeId = Math.max(globalMaxNodeId, maxNodeId);
       }

--- a/src/features/spike-viewer/spike-trace.ts
+++ b/src/features/spike-viewer/spike-trace.ts
@@ -1,7 +1,7 @@
-import { Dataset, File, Group, ready } from 'h5wasm';
+import { Dataset, type File, Group, ready } from 'h5wasm';
 
 /** Convert any TypedArray from h5wasm to Float32Array without unnecessary copies. */
-function toFloat32(arr: ArrayLike<number | bigint>): Float32Array {
+export function toFloat32(arr: ArrayLike<number | bigint>): Float32Array {
   if (arr instanceof Float32Array) return arr;
   if (arr instanceof Float64Array || arr instanceof Int32Array || arr instanceof Uint32Array) {
     return new Float32Array(arr);
@@ -15,7 +15,7 @@ function toFloat32(arr: ArrayLike<number | bigint>): Float32Array {
 }
 
 /** Loop-based min/max that avoids stack overflow from Math.min/max spread on large arrays. */
-function float32MinMax(arr: Float32Array): [number, number] {
+export function float32MinMax(arr: Float32Array): [number, number] {
   let min = arr[0];
   let max = arr[0];
   for (let i = 1; i < arr.length; i++) {
@@ -39,155 +39,93 @@ export type SpikeData = {
 };
 
 /**
- * SpikeTrace handles SONATA-format spike files.
+ * Parse SONATA-format spike data from an h5wasm File.
  *
  * Expected HDF5 structure:
  * /spikes/{population}/node_ids - array of node IDs
  * /spikes/{population}/timestamps - array of spike times
  */
-export default class SpikeTrace {
-  file: File;
-  data: SpikeData | null = null;
-
-  constructor(h5File: File) {
-    this.file = h5File;
+export function parseSpikeData(file: File): SpikeData {
+  const spikesGroup = file.get('spikes');
+  if (!(spikesGroup instanceof Group)) {
+    throw new Error('Invalid spike file: /spikes group not found');
   }
 
-  public static async create(id: string, arrayBuffer: ArrayBuffer): Promise<SpikeTrace> {
-    const { FS } = await ready;
-    const filename = `${id}.h5`;
+  const populations: SpikePopulation[] = [];
+  let globalMinTime = Infinity;
+  let globalMaxTime = -Infinity;
+  let globalMinNodeId = Infinity;
+  let globalMaxNodeId = -Infinity;
 
-    try {
-      FS.stat(filename);
-    } catch (error: any) {
-      if (error?.message === 'FS error') {
-        FS.writeFile(filename, new Uint8Array(arrayBuffer));
-      }
+  for (const popName of spikesGroup.keys()) {
+    const popGroup = spikesGroup.get(popName);
+    if (!(popGroup instanceof Group)) continue;
+
+    const nodeIdsDataset = popGroup.get('node_ids');
+    const timestampsDataset = popGroup.get('timestamps');
+
+    if (!(nodeIdsDataset instanceof Dataset) || !(timestampsDataset instanceof Dataset)) {
+      continue;
     }
 
-    const file = new File(filename, 'r');
-    const trace = new SpikeTrace(file);
-    trace.init();
-    return trace;
-  }
+    const rawNodeIds = nodeIdsDataset.to_array();
+    const rawTimestamps = timestampsDataset.to_array();
+    if (!rawNodeIds || !rawTimestamps) continue;
 
-  /**
-   * Check if an HDF5 file contains spike data in SONATA format.
-   */
-  public static async isSpikeFile(id: string, arrayBuffer: ArrayBuffer): Promise<boolean> {
-    const { FS } = await ready;
-    const filename = `${id}_check.h5`;
+    const nodeIds = toFloat32(rawNodeIds as ArrayLike<number | bigint>);
+    const timestamps = toFloat32(rawTimestamps as ArrayLike<number | bigint>);
 
+    // Get units attribute if available
+    let units: string | undefined;
     try {
-      FS.stat(filename);
-    } catch (error: any) {
-      if (error?.message === 'FS error') {
-        FS.writeFile(filename, new Uint8Array(arrayBuffer));
-      }
-    }
-
-    try {
-      const file = new File(filename, 'r');
-      const spikesGroup = file.get('spikes');
-      const isSpike = spikesGroup instanceof Group;
-      file.close();
-      FS.unlink(filename);
-      return isSpike;
+      units = timestampsDataset.get_attribute('units', true) as string;
     } catch {
-      try {
-        FS.unlink(filename);
-      } catch {
-        // ignore cleanup errors
-      }
-      return false;
+      // units attribute is optional
+    }
+
+    populations.push({ name: popName, nodeIds, timestamps, units });
+
+    // Update global ranges using loop-based min/max (spread operator crashes on large arrays)
+    if (timestamps.length > 0) {
+      const [minTime, maxTime] = float32MinMax(timestamps);
+      globalMinTime = Math.min(globalMinTime, minTime);
+      globalMaxTime = Math.max(globalMaxTime, maxTime);
+    }
+
+    if (nodeIds.length > 0) {
+      const [minNodeId, maxNodeId] = float32MinMax(nodeIds);
+      globalMinNodeId = Math.min(globalMinNodeId, minNodeId);
+      globalMaxNodeId = Math.max(globalMaxNodeId, maxNodeId);
     }
   }
 
-  private init(): void {
-    const spikesGroup = this.file.get('spikes');
-    if (!(spikesGroup instanceof Group)) {
-      throw new Error('Invalid spike file: /spikes group not found');
-    }
+  return {
+    populations,
+    timeRange: {
+      min: globalMinTime === Infinity ? 0 : globalMinTime,
+      max: globalMaxTime === -Infinity ? 0 : globalMaxTime,
+    },
+    nodeIdRange: {
+      min: globalMinNodeId === Infinity ? 0 : globalMinNodeId,
+      max: globalMaxNodeId === -Infinity ? 0 : globalMaxNodeId,
+    },
+  };
+}
 
-    const populations: SpikePopulation[] = [];
-    let globalMinTime = Infinity;
-    let globalMaxTime = -Infinity;
-    let globalMinNodeId = Infinity;
-    let globalMaxNodeId = -Infinity;
+/**
+ * Write an ArrayBuffer to the Emscripten virtual FS, skipping if already present.
+ * Returns a non-null FS handle and the filename used.
+ */
+export async function writeToEmscriptenFS(id: string, buffer: ArrayBuffer, suffix = '.h5') {
+  const { FS } = await ready;
+  if (!FS) throw new Error('h5wasm FS not initialized');
+  const filename = `${id}${suffix}`;
 
-    for (const popName of spikesGroup.keys()) {
-      const popGroup = spikesGroup.get(popName);
-      if (!(popGroup instanceof Group)) continue;
-
-      const nodeIdsDataset = popGroup.get('node_ids');
-      const timestampsDataset = popGroup.get('timestamps');
-
-      if (!(nodeIdsDataset instanceof Dataset) || !(timestampsDataset instanceof Dataset)) {
-        continue;
-      }
-
-      const rawNodeIds = nodeIdsDataset.to_array();
-      const rawTimestamps = timestampsDataset.to_array();
-      if (!rawNodeIds || !rawTimestamps) continue;
-
-      const nodeIds = toFloat32(rawNodeIds as ArrayLike<number | bigint>);
-      const timestamps = toFloat32(rawTimestamps as ArrayLike<number | bigint>);
-
-      // Get units attribute if available
-      let units: string | undefined;
-      try {
-        units = timestampsDataset.get_attribute('units', true) as string;
-      } catch {
-        // units attribute is optional
-      }
-
-      populations.push({
-        name: popName,
-        nodeIds,
-        timestamps,
-        units,
-      });
-
-      // Update global ranges using loop-based min/max (spread operator crashes on large arrays)
-      if (timestamps.length > 0) {
-        const [minTime, maxTime] = float32MinMax(timestamps);
-        globalMinTime = Math.min(globalMinTime, minTime);
-        globalMaxTime = Math.max(globalMaxTime, maxTime);
-      }
-
-      if (nodeIds.length > 0) {
-        const [minNodeId, maxNodeId] = float32MinMax(nodeIds);
-        globalMinNodeId = Math.min(globalMinNodeId, minNodeId);
-        globalMaxNodeId = Math.max(globalMaxNodeId, maxNodeId);
-      }
-    }
-
-    this.data = {
-      populations,
-      timeRange: {
-        min: globalMinTime === Infinity ? 0 : globalMinTime,
-        max: globalMaxTime === -Infinity ? 0 : globalMaxTime,
-      },
-      nodeIdRange: {
-        min: globalMinNodeId === Infinity ? 0 : globalMinNodeId,
-        max: globalMaxNodeId === -Infinity ? 0 : globalMaxNodeId,
-      },
-    };
+  try {
+    FS.stat(filename);
+  } catch {
+    FS.writeFile(filename, new Uint8Array(buffer));
   }
 
-  public getPopulations(): string[] {
-    return this.data?.populations.map((p) => p.name) ?? [];
-  }
-
-  public getPopulationData(name: string): SpikePopulation | undefined {
-    return this.data?.populations.find((p) => p.name === name);
-  }
-
-  public getSpikeData(): SpikeData | null {
-    return this.data;
-  }
-
-  public destroy(): void {
-    this.file.close();
-  }
+  return { FS, filename };
 }

--- a/src/features/spike-viewer/spike-trace.worker.ts
+++ b/src/features/spike-viewer/spike-trace.worker.ts
@@ -1,0 +1,164 @@
+import * as Comlink from 'comlink';
+import { Dataset, File, Group, ready } from 'h5wasm';
+
+import type { SpikeData, SpikePopulation } from '@/features/spike-viewer/spike-trace';
+
+/** Convert any TypedArray from h5wasm to Float32Array without unnecessary copies. */
+function toFloat32(arr: ArrayLike<number | bigint>): Float32Array {
+  if (arr instanceof Float32Array) return arr;
+  if (arr instanceof Float64Array || arr instanceof Int32Array || arr instanceof Uint32Array) {
+    return new Float32Array(arr);
+  }
+  const result = new Float32Array(arr.length);
+  for (let i = 0; i < arr.length; i++) {
+    result[i] = Number(arr[i]);
+  }
+  return result;
+}
+
+/** Loop-based min/max that avoids stack overflow from Math.min/max spread on large arrays. */
+function float32MinMax(arr: Float32Array): [number, number] {
+  let min = arr[0];
+  let max = arr[0];
+  for (let i = 1; i < arr.length; i++) {
+    if (arr[i] < min) min = arr[i];
+    if (arr[i] > max) max = arr[i];
+  }
+  return [min, max];
+}
+
+function parseSpikeData(file: File): SpikeData {
+  const spikesGroup = file.get('spikes');
+  if (!(spikesGroup instanceof Group)) {
+    throw new Error('Invalid spike file: /spikes group not found');
+  }
+
+  const populations: SpikePopulation[] = [];
+  let globalMinTime = Infinity;
+  let globalMaxTime = -Infinity;
+  let globalMinNodeId = Infinity;
+  let globalMaxNodeId = -Infinity;
+
+  for (const popName of spikesGroup.keys()) {
+    const popGroup = spikesGroup.get(popName);
+    if (!(popGroup instanceof Group)) continue;
+
+    const nodeIdsDataset = popGroup.get('node_ids');
+    const timestampsDataset = popGroup.get('timestamps');
+
+    if (!(nodeIdsDataset instanceof Dataset) || !(timestampsDataset instanceof Dataset)) {
+      continue;
+    }
+
+    const rawNodeIds = nodeIdsDataset.to_array();
+    const rawTimestamps = timestampsDataset.to_array();
+    if (!rawNodeIds || !rawTimestamps) continue;
+
+    const nodeIds = toFloat32(rawNodeIds as ArrayLike<number | bigint>);
+    const timestamps = toFloat32(rawTimestamps as ArrayLike<number | bigint>);
+
+    let units: string | undefined;
+    try {
+      units = timestampsDataset.get_attribute('units', true) as string;
+    } catch {
+      // units attribute is optional
+    }
+
+    populations.push({ name: popName, nodeIds, timestamps, units });
+
+    if (timestamps.length > 0) {
+      const [minTime, maxTime] = float32MinMax(timestamps);
+      globalMinTime = Math.min(globalMinTime, minTime);
+      globalMaxTime = Math.max(globalMaxTime, maxTime);
+    }
+
+    if (nodeIds.length > 0) {
+      const [minNodeId, maxNodeId] = float32MinMax(nodeIds);
+      globalMinNodeId = Math.min(globalMinNodeId, minNodeId);
+      globalMaxNodeId = Math.max(globalMaxNodeId, maxNodeId);
+    }
+  }
+
+  return {
+    populations,
+    timeRange: {
+      min: globalMinTime === Infinity ? 0 : globalMinTime,
+      max: globalMaxTime === -Infinity ? 0 : globalMaxTime,
+    },
+    nodeIdRange: {
+      min: globalMinNodeId === Infinity ? 0 : globalMinNodeId,
+      max: globalMaxNodeId === -Infinity ? 0 : globalMaxNodeId,
+    },
+  };
+}
+
+const api = {
+  async parseSpikeFile(id: string, buffer: ArrayBuffer): Promise<SpikeData> {
+    const { FS } = await ready;
+    const filename = `${id}.h5`;
+
+    try {
+      FS.stat(filename);
+    } catch (error: unknown) {
+      if (error instanceof Error && error.message === 'FS error') {
+        FS.writeFile(filename, new Uint8Array(buffer));
+      }
+    }
+
+    let file: File | null = null;
+    try {
+      file = new File(filename, 'r');
+      const data = parseSpikeData(file);
+
+      // Transfer Float32Array buffers back to main thread (zero-copy)
+      const transferables: ArrayBuffer[] = [];
+      for (const pop of data.populations) {
+        const tsBuf = pop.timestamps.buffer as ArrayBuffer;
+        const idBuf = pop.nodeIds.buffer as ArrayBuffer;
+        transferables.push(tsBuf, idBuf);
+      }
+
+      return Comlink.transfer(data, transferables);
+    } finally {
+      file?.close();
+      try {
+        FS.unlink(filename);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+  },
+
+  async isSpikeFile(id: string, buffer: ArrayBuffer): Promise<boolean> {
+    const { FS } = await ready;
+    const filename = `${id}_check.h5`;
+
+    try {
+      FS.stat(filename);
+    } catch (error: unknown) {
+      if (error instanceof Error && error.message === 'FS error') {
+        FS.writeFile(filename, new Uint8Array(buffer));
+      }
+    }
+
+    try {
+      const file = new File(filename, 'r');
+      const spikesGroup = file.get('spikes');
+      const isSpike = spikesGroup instanceof Group;
+      file.close();
+      FS.unlink(filename);
+      return isSpike;
+    } catch {
+      try {
+        FS.unlink(filename);
+      } catch {
+        // ignore cleanup errors
+      }
+      return false;
+    }
+  },
+};
+
+export type SpikeTraceWorkerApi = typeof api;
+
+Comlink.expose(api);

--- a/src/features/spike-viewer/spike-trace.worker.ts
+++ b/src/features/spike-viewer/spike-trace.worker.ts
@@ -1,109 +1,13 @@
 import * as Comlink from 'comlink';
-import { Dataset, File, Group, ready } from 'h5wasm';
+import { File } from 'h5wasm';
 
-import type { SpikeData, SpikePopulation } from '@/features/spike-viewer/spike-trace';
+import { parseSpikeData, writeToEmscriptenFS } from '@/features/spike-viewer/spike-trace';
 
-/** Convert any TypedArray from h5wasm to Float32Array without unnecessary copies. */
-function toFloat32(arr: ArrayLike<number | bigint>): Float32Array {
-  if (arr instanceof Float32Array) return arr;
-  if (arr instanceof Float64Array || arr instanceof Int32Array || arr instanceof Uint32Array) {
-    return new Float32Array(arr);
-  }
-  const result = new Float32Array(arr.length);
-  for (let i = 0; i < arr.length; i++) {
-    result[i] = Number(arr[i]);
-  }
-  return result;
-}
-
-/** Loop-based min/max that avoids stack overflow from Math.min/max spread on large arrays. */
-function float32MinMax(arr: Float32Array): [number, number] {
-  let min = arr[0];
-  let max = arr[0];
-  for (let i = 1; i < arr.length; i++) {
-    if (arr[i] < min) min = arr[i];
-    if (arr[i] > max) max = arr[i];
-  }
-  return [min, max];
-}
-
-function parseSpikeData(file: File): SpikeData {
-  const spikesGroup = file.get('spikes');
-  if (!(spikesGroup instanceof Group)) {
-    throw new Error('Invalid spike file: /spikes group not found');
-  }
-
-  const populations: SpikePopulation[] = [];
-  let globalMinTime = Infinity;
-  let globalMaxTime = -Infinity;
-  let globalMinNodeId = Infinity;
-  let globalMaxNodeId = -Infinity;
-
-  for (const popName of spikesGroup.keys()) {
-    const popGroup = spikesGroup.get(popName);
-    if (!(popGroup instanceof Group)) continue;
-
-    const nodeIdsDataset = popGroup.get('node_ids');
-    const timestampsDataset = popGroup.get('timestamps');
-
-    if (!(nodeIdsDataset instanceof Dataset) || !(timestampsDataset instanceof Dataset)) {
-      continue;
-    }
-
-    const rawNodeIds = nodeIdsDataset.to_array();
-    const rawTimestamps = timestampsDataset.to_array();
-    if (!rawNodeIds || !rawTimestamps) continue;
-
-    const nodeIds = toFloat32(rawNodeIds as ArrayLike<number | bigint>);
-    const timestamps = toFloat32(rawTimestamps as ArrayLike<number | bigint>);
-
-    let units: string | undefined;
-    try {
-      units = timestampsDataset.get_attribute('units', true) as string;
-    } catch {
-      // units attribute is optional
-    }
-
-    populations.push({ name: popName, nodeIds, timestamps, units });
-
-    if (timestamps.length > 0) {
-      const [minTime, maxTime] = float32MinMax(timestamps);
-      globalMinTime = Math.min(globalMinTime, minTime);
-      globalMaxTime = Math.max(globalMaxTime, maxTime);
-    }
-
-    if (nodeIds.length > 0) {
-      const [minNodeId, maxNodeId] = float32MinMax(nodeIds);
-      globalMinNodeId = Math.min(globalMinNodeId, minNodeId);
-      globalMaxNodeId = Math.max(globalMaxNodeId, maxNodeId);
-    }
-  }
-
-  return {
-    populations,
-    timeRange: {
-      min: globalMinTime === Infinity ? 0 : globalMinTime,
-      max: globalMaxTime === -Infinity ? 0 : globalMaxTime,
-    },
-    nodeIdRange: {
-      min: globalMinNodeId === Infinity ? 0 : globalMinNodeId,
-      max: globalMaxNodeId === -Infinity ? 0 : globalMaxNodeId,
-    },
-  };
-}
+import type { SpikeData } from '@/features/spike-viewer/spike-trace';
 
 const api = {
   async parseSpikeFile(id: string, buffer: ArrayBuffer): Promise<SpikeData> {
-    const { FS } = await ready;
-    const filename = `${id}.h5`;
-
-    try {
-      FS.stat(filename);
-    } catch (error: unknown) {
-      if (error instanceof Error && error.message === 'FS error') {
-        FS.writeFile(filename, new Uint8Array(buffer));
-      }
-    }
+    const { FS, filename } = await writeToEmscriptenFS(id, buffer);
 
     let file: File | null = null;
     try {
@@ -126,35 +30,6 @@ const api = {
       } catch {
         // ignore cleanup errors
       }
-    }
-  },
-
-  async isSpikeFile(id: string, buffer: ArrayBuffer): Promise<boolean> {
-    const { FS } = await ready;
-    const filename = `${id}_check.h5`;
-
-    try {
-      FS.stat(filename);
-    } catch (error: unknown) {
-      if (error instanceof Error && error.message === 'FS error') {
-        FS.writeFile(filename, new Uint8Array(buffer));
-      }
-    }
-
-    try {
-      const file = new File(filename, 'r');
-      const spikesGroup = file.get('spikes');
-      const isSpike = spikesGroup instanceof Group;
-      file.close();
-      FS.unlink(filename);
-      return isSpike;
-    } catch {
-      try {
-        FS.unlink(filename);
-      } catch {
-        // ignore cleanup errors
-      }
-      return false;
     }
   },
 };

--- a/src/features/spike-viewer/spike-viewer.tsx
+++ b/src/features/spike-viewer/spike-viewer.tsx
@@ -17,20 +17,20 @@ type SpikeViewerProps = {
 };
 
 export default function SpikeViewer({ entityId, entityType, asset, ctx }: SpikeViewerProps) {
-  const [trace, error] = useSpikeTrace({ entityId, entityType, asset, ctx });
+  const [data, error] = useSpikeTrace({ entityId, entityType, asset, ctx });
 
   if (error) {
     return <Empty className="p-2em" description="There was a problem loading the spike data" />;
   }
 
-  if (!trace || !trace.data) {
+  if (!data) {
     return <Spin />;
   }
 
   return (
     <div className="flex h-full flex-col">
-      <ErrorBoundary FallbackComponent={SimpleErrorComponent} resetKeys={[trace]}>
-        <RasterPlot data={trace.data} />
+      <ErrorBoundary FallbackComponent={SimpleErrorComponent} resetKeys={[data]}>
+        <RasterPlot data={data} />
       </ErrorBoundary>
     </div>
   );


### PR DESCRIPTION
## High-Performance Spike Viewer (WebGL Raster Plot)

<kbd><img width="1169" height="1026" alt="image" src="https://github.com/user-attachments/assets/9351632a-2e32-441f-9ffe-5c0bfad01682" /></kbd>


### Summary
- Replaces the previous Canvas2D-based spike renderer with a WebGL2 raster plot capable of rendering multi-million spike reports at 60fps
- Offloads HDF5 (SONATA) file parsing to a Web Worker via Comlink for zero-copy data transfer back to the main thread
- Adds interactive pan/zoom with scroll-to-zoom, drag-to-pan, and double-click-to-reset, all clamped to data bounds
- Implements binary-search-based hover tooltip with edge-aware placement, hidden during pan gestures

### Architecture

```
spike-viewer/
├── index.tsx                     # Dynamic import entry (SSR disabled)
├── spike-viewer.tsx              # Top-level component (data fetching + error boundary)
├── spike-trace.ts                # SONATA HDF5 parser (h5wasm), Float32Array min/max utils
├── spike-trace.worker.ts         # Web Worker: parse + Comlink.transfer() zero-copy buffers
├── components/
│   └── raster-plot.tsx           # React wrapper: population checkboxes + canvas container
├── hooks/
│   ├── use-spike-trace.ts        # TanStack Query fetch → Worker parse pipeline
│   └── use-raster-renderer.ts    # Manages RasterRenderer lifecycle
└── renderer/
    ├── raster-renderer.ts        # Orchestrator: WebGL + axis + interaction + tooltip
    ├── webgl-points.ts           # WebGL2 point rendering (VAO per population, context loss recovery)
    ├── axis-overlay.ts           # 2D Canvas axis labels, grid, tick marks
    └── interaction.ts            # Pointer/wheel events → view bounds transforms
```

### Key design decisions
- **WebGL2 `gl.POINTS`** with vertical-tick fragment shader — one draw call per population, O(1) GPU cost regardless of spike count
- **Float32Array throughout** — avoids GC pressure; `toFloat32()` handles BigInt64/Float64 HDF5 datasets
- **Loop-based min/max** instead of `Math.min(...spread)` — prevents stack overflow on arrays with millions of elements
- **Sorted timestamps + binary search** for hover hit-testing — sub-millisecond nearest-point lookup even at 5M+ spikes
- **Density-aware point sizing** — auto-scales from 2px (dense) to 6px (sparse), with logarithmic zoom bonus up to 12px
- **ResizeObserver + RAF coalescing** — single render per frame, no redundant redraws
- **WebGL context loss/restore** — buffers and program rebuilt automatically

### Test plan
- [x] Load a simulation entity with a SONATA spike report (single population)
- [ ] ~~Load a multi-population spike report — verify checkboxes toggle population visibility~~ - couldn't find one, to be validated later
- [x] Verify scroll-to-zoom centers on cursor and clamps to data bounds
- [x] Verify drag-to-pan and double-click-to-reset
- [x] Hover over a spike — tooltip shows `{population}_{nodeId}: {time} ms`
- [x] Tooltip hides during pan gesture
- [x] Resize the browser window — plot redraws correctly
- [x] Load a large report (>1M spikes) — confirm no UI freeze during parse (worker) and smooth 60fps rendering