### PR TITLE
Correctly setup circuit config file to be supported by file viewer

### DIFF
--- a/src/features/scan-config/components/simulation-files/index.tsx
+++ b/src/features/scan-config/components/simulation-files/index.tsx
@@ -151,6 +151,7 @@ function useInputFiles(
         entity,
         asset: sonataCircuitAsset,
         assetPath: 'circuit_config.json',
+        enforcedRenderType: AssetContentType.json,
         renderer: ActivityCustomFileRenderer.Default,
       });
     }


### PR DESCRIPTION
As the content type for sonata circuit asset is 'vnd.directory' it was not picked up by the file viewer, newly added `enforcedRenderType` fixes that limitation. This PR correctly sets that property to json.

Relates to [[Small m.circuit] "JSON files not supported yet" error](https://github.com/openbraininstitute/obi-one/issues/651).