### PR TITLE
Prod build emodel/131/spike activity 2

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,5 +3,5 @@ pre-commit:
   commands:
     check:
       glob: "*.{js,ts,cjs,mjs,jsx,tsx,json,jsonc}"
-      run: pnpx @biomejs/biome check --write {staged_files}
+      run: pnpx @biomejs/biome check --formatter-enabled=true --write {staged_files}
       stage_fixed: true

--- a/src/services/small-scale-simulator/types.ts
+++ b/src/services/small-scale-simulator/types.ts
@@ -11,22 +11,22 @@ export enum MessageType {
   DATA = 'data',
 }
 
-export type Message<T> = StatusMessage | DataMessage<T>
+export type Message<T> = StatusMessage | DataMessage<T>;
 
 type MessageCtx = {
-  [key: string]: any
-}
+  [key: string]: any;
+};
 
 type StatusMessage = {
-  message_type: MessageType.STATUS
-  status: JobStatus
-  extra?: string
-  ctx?: MessageCtx
-}
+  message_type: MessageType.STATUS;
+  status: JobStatus;
+  extra?: string;
+  ctx?: MessageCtx;
+};
 
 type DataMessage<T> = {
-  message_type: MessageType.DATA
-  data_type?: string
-  data: T
-  ctx?: MessageCtx
-}
+  message_type: MessageType.DATA;
+  data_type?: string;
+  data: T;
+  ctx?: MessageCtx;
+};

--- a/src/services/small-scale-simulator/types.ts
+++ b/src/services/small-scale-simulator/types.ts
@@ -11,21 +11,22 @@ export enum MessageType {
   DATA = 'data',
 }
 
-export type Message<T> = StatusMessage | DataMessage<T>;
+export type Message<T> = StatusMessage | DataMessage<T>
 
 type MessageCtx = {
-  [key: string]: any;
-};
+  [key: string]: any
+}
 
 type StatusMessage = {
-  message_type: MessageType.STATUS;
-  status: JobStatus;
-  extra?: string;
-  ctx?: MessageCtx;
-};
+  message_type: MessageType.STATUS
+  status: JobStatus
+  extra?: string
+  ctx?: MessageCtx
+}
 
 type DataMessage<T> = {
-  message_type: MessageType.DATA;
-  data: T;
-  ctx?: MessageCtx;
-};
+  message_type: MessageType.DATA
+  data_type?: string
+  data: T
+  ctx?: MessageCtx
+}

--- a/src/ui/segments/workflows/simulate/single-neuron/shared/runner.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/shared/runner.tsx
@@ -1,6 +1,7 @@
-'use client';
+/** biome-ignore-all lint/performance/noAccumulatingSpread: useless rule */
+'use client'
 
-import { captureException } from '@sentry/nextjs';
+import { captureException } from '@sentry/nextjs'
 import {
   delay,
   isNil,
@@ -12,47 +13,48 @@ import {
   sortBy,
   uniqBy,
   values,
-} from 'es-toolkit/compat';
-import { atom } from 'jotai';
-import { RESET } from 'jotai/utils';
-import Link from 'next/link';
-import { match } from 'ts-pattern';
+} from 'es-toolkit/compat'
+import { atom, type Getter, type Setter } from 'jotai'
+import { RESET } from 'jotai/utils'
+import Link from 'next/link'
+import { match } from 'ts-pattern'
 
 import {
   createSingleNeuronSimulation,
   createSingleNeuronSynaptomeSimulation,
   getMEModel,
-} from '@/api/entitycore/queries';
-import { createJsonAsset } from '@/api/entitycore/queries/assets';
-import { runSingleNeuronSimulation } from '@/api/small-scale-simulator';
-import { tryCatch } from '@/api/utils';
-import { listVirtualLabMembers } from '@/api/virtual-lab-svc/queries/member';
-import { config } from '@/config';
+} from '@/api/entitycore/queries'
+import { createJsonAsset } from '@/api/entitycore/queries/assets'
+import { runSingleNeuronSimulation } from '@/api/small-scale-simulator'
+import { tryCatch } from '@/api/utils'
+import { listVirtualLabMembers } from '@/api/virtual-lab-svc/queries/member'
+import { config } from '@/config'
 import {
   SingleNeuronSimulation,
   SingleNeuronSynaptomeSimulation,
-} from '@/entity-configuration/domain/simulation';
-import { messages } from '@/i18n/en/simulation';
-import { JobStatus, type Message, MessageType } from '@/services/small-scale-simulator/types';
+} from '@/entity-configuration/domain/simulation'
+import { messages } from '@/i18n/en/simulation'
+import { JobStatus, type Message, MessageType } from '@/services/small-scale-simulator/types'
 import {
   genericSingleNeuronSimulationPlotDataAtomFamily,
   SimulationStatus,
   simulationStatusAtomFamily,
-} from '@/ui/segments/workflows/simulate/single-neuron/shared/context';
-import { SimulationType } from '@/ui/segments/workflows/simulate/single-neuron/shared/types';
-import { convertObjectKeysToSnakeCase } from '@/util/object-keys-format';
-import { readNdjsonResponse } from '@/utils/response';
+} from '@/ui/segments/workflows/simulate/single-neuron/shared/context'
+import { SimulationType } from '@/ui/segments/workflows/simulate/single-neuron/shared/types'
+import { convertObjectKeysToSnakeCase } from '@/util/object-keys-format'
+import { isType } from '@/util/type-guards'
+import { readNdjsonResponse as readNewlineDelimitedJsonResponse } from '@/utils/response'
 
-import type { NotificationInstance } from 'antd/es/notification/interface';
+import type { NotificationInstance } from 'antd/es/notification/interface'
 import type {
   ISingleNeuronSimulation,
   ISingleNeuronSynaptomeSimulation,
-} from '@/api/entitycore/types';
-import type { PlotData, PlotDataEntry } from '@/services/bluenaas-single-cell/types';
+} from '@/api/entitycore/types'
+import type { PlotData, PlotDataEntry } from '@/services/bluenaas-single-cell/types'
 import type {
   SimulationStreamData,
   SingleNeuronModelSimulationConfig,
-} from '@/types/small-scale-simulator/single-neuron';
+} from '@/types/small-scale-simulator/single-neuron'
 import type {
   NeuronLocationArray,
   SimulationExperimentalSetup,
@@ -60,15 +62,15 @@ import type {
   TOverviewConfiguration,
   TSimulationType,
   TStimulationConfiguration,
-} from '@/ui/segments/workflows/simulate/single-neuron/shared/types';
+} from '@/ui/segments/workflows/simulate/single-neuron/shared/types'
 
-const LOW_FUNDS_ERROR_CODE = 'ACCOUNTING_INSUFFICIENT_FUNDS_ERROR';
+const LOW_FUNDS_ERROR_CODE = 'ACCOUNTING_INSUFFICIENT_FUNDS_ERROR'
 
 export const createSingleNeuronSimulationAtom = atom(
   null,
   async (
-    get,
-    set,
+    _get,
+    _set,
     name: string,
     description: string,
     modelId: string,
@@ -83,7 +85,7 @@ export const createSingleNeuronSimulationAtom = atom(
     simulationResult: Record<string, PlotData> | null,
     stimulusResult: PlotData | null
   ) => {
-    if (!simulationResult || !modelId) return null;
+    if (!simulationResult || !modelId) return null
 
     const recordFromUniq = map(
       uniqBy(recordingConfiguration, (item) =>
@@ -92,7 +94,7 @@ export const createSingleNeuronSimulationAtom = atom(
           .join()
       ),
       (obj) => omit(obj, ['color'])
-    );
+    )
 
     const singleNeuronSimulationConfig: SingleNeuronModelSimulationConfig = {
       record_from: recordFromUniq,
@@ -102,16 +104,16 @@ export const createSingleNeuronSimulationAtom = atom(
         simulationType === SimulationType.SingleNeuronSynaptome
           ? synaptomeConfiguration
           : undefined,
-    };
+    }
 
     const { data: meModel, error } = await tryCatch(
       getMEModel({
         id: memodelId,
         context: { virtualLabId, projectId },
       })
-    );
+    )
     if (error || isNil(meModel)) {
-      throw new Error(messages.SimulationPrerequisitesMEModelError);
+      throw new Error(messages.SimulationPrerequisitesMEModelError)
     }
 
     const basePayload = {
@@ -123,38 +125,38 @@ export const createSingleNeuronSimulationAtom = atom(
         (r) => `${r.section}_${r.offset}`
       ),
       brain_region_id: meModel.brain_region.id,
-    };
+    }
     let simulationPromise: Promise<
       ISingleNeuronSimulation | ISingleNeuronSynaptomeSimulation
-    > | null = null;
+    > | null = null
     if (simulationType === SimulationType.SingleNeuron) {
       simulationPromise = createSingleNeuronSimulation({
         context: { virtualLabId, projectId },
         body: { ...basePayload, me_model_id: meModel.id },
-      });
+      })
     } else if (simulationType === SimulationType.SingleNeuronSynaptome) {
       simulationPromise = createSingleNeuronSynaptomeSimulation({
         context: { virtualLabId, projectId },
         body: { ...basePayload, synaptome_id: modelId },
-      });
+      })
     }
     if (simulationPromise) {
-      const { data: simulation, error: simulationError } = await tryCatch(simulationPromise);
+      const { data: simulation, error: simulationError } = await tryCatch(simulationPromise)
       if (simulationError) {
-        throw new Error(messages.CreationSimulationFailed);
+        throw new Error(messages.CreationSimulationFailed)
       }
       const assetBasePayload =
         simulationType === SimulationType.SingleNeuron
           ? {
-              label: SingleNeuronSimulation.asset.configfile,
-              entityType: SingleNeuronSimulation.type,
-              path: `single-neuron-simulation-${simulation.id}`,
-            }
+            label: SingleNeuronSimulation.asset.configfile,
+            entityType: SingleNeuronSimulation.type,
+            path: `single-neuron-simulation-${simulation.id}`,
+          }
           : {
-              label: SingleNeuronSynaptomeSimulation.asset.configfile,
-              entityType: SingleNeuronSynaptomeSimulation.type,
-              path: `single-neuron-synaptome-simulation-${simulation.id}`,
-            };
+            label: SingleNeuronSynaptomeSimulation.asset.configfile,
+            entityType: SingleNeuronSynaptomeSimulation.type,
+            path: `single-neuron-synaptome-simulation-${simulation.id}`,
+          }
       if (simulation) {
         const { data: asset, error: assetError } = await tryCatch(
           createJsonAsset({
@@ -168,28 +170,32 @@ export const createSingleNeuronSimulationAtom = atom(
                 return {
                   ...prev,
                   [curr]: convertObjectKeysToSnakeCase(simulationResult[curr]),
-                };
+                }
               }, {}),
               stimulus: convertObjectKeysToSnakeCase(stimulusResult),
               config: convertObjectKeysToSnakeCase(singleNeuronSimulationConfig),
             },
             ...assetBasePayload,
           })
-        );
+        )
         if (asset) {
           return {
             simulation,
             asset,
-          };
+          }
         }
         if (assetError) {
-          throw new Error(messages.CreationSimulationIOAssetFailed);
+          throw new Error(messages.CreationSimulationIOAssetFailed)
         }
       }
     }
   }
-);
+)
 
+/**
+ * When the setter of this writable atom is called, it will update this atom:
+ * `genericSingleNeuronSimulationPlotDataAtomFamily( sessionId )`
+ */
 export const launchSimulationAtom = atom<
   null,
   [
@@ -235,47 +241,47 @@ export const launchSimulationAtom = atom<
   ) => {
     if (simulationType === 'single-neuron-simulation') {
       if (!stimulationConfiguration) {
-        throw new Error(messages.CurrentInjectionConfigMissingError);
+        throw new Error(messages.CurrentInjectionConfigMissingError)
       }
     } else if (simulationType === 'synaptome-simulation') {
       if (
         !stimulationConfiguration &&
         (!synaptomeConfiguration || !synaptomeConfiguration.length)
       ) {
-        throw new Error(messages.SynaptomeConfigurationError);
+        throw new Error(messages.SynaptomeConfigurationError)
       }
     }
-    const simulationStatusAtom = simulationStatusAtomFamily(sessionId);
-    const lowFundsEmailSubject = 'Insufficient%20credits%20for%20simulation';
-    let labAdminContactHref: string | null = null;
+    const simulationStatusAtom = simulationStatusAtomFamily(sessionId)
+    const lowFundsEmailSubject = 'Insufficient%20credits%20for%20simulation'
+    let labAdminContactHref: string | null = null
 
     const getLabAdminContactHref = async () => {
-      if (labAdminContactHref) return labAdminContactHref;
-      const { data: membersData } = await tryCatch(listVirtualLabMembers({ virtualLabId }));
-      const adminEmail = membersData?.data?.users.find((user) => user.role === 'admin')?.email;
+      if (labAdminContactHref) return labAdminContactHref
+      const { data: membersData } = await tryCatch(listVirtualLabMembers({ virtualLabId }))
+      const adminEmail = membersData?.data?.users.find((user) => user.role === 'admin')?.email
 
       labAdminContactHref = adminEmail
         ? `mailto:${adminEmail}?subject=${lowFundsEmailSubject}`
-        : null;
-      return labAdminContactHref;
-    };
+        : null
+      return labAdminContactHref
+    }
 
-    set(simulationStatusAtom, { status: SimulationStatus.LAUNCHED });
+    set(simulationStatusAtom, { status: SimulationStatus.LAUNCHED })
 
     const initialPlotData = recordingConfiguration.reduce((acc: Record<string, PlotData>, o) => {
-      const key = `${o.section}_${o.offset === 0 ? '0.0' : String(o.offset)}`;
-      acc[key] = [];
-      return acc;
-    }, {});
-    const plotDataAtom = genericSingleNeuronSimulationPlotDataAtomFamily(sessionId);
+      const key = `${o.section}_${o.offset === 0 ? '0.0' : String(o.offset)}`
+      acc[key] = []
+      return acc
+    }, {})
+    const plotDataAtom = genericSingleNeuronSimulationPlotDataAtomFamily(sessionId)
 
-    set(plotDataAtom, initialPlotData);
+    set(plotDataAtom, initialPlotData)
     const recordFromUniq = uniqBy(recordingConfiguration, (item) =>
       values(pick(item, ['section', 'offset']))
         .map(String)
         .join()
-    );
-    onChangePanel();
+    )
+    onChangePanel()
 
     try {
       const { data: response, error } = await tryCatch(
@@ -294,24 +300,24 @@ export const launchSimulationAtom = atom<
             duration,
           },
         })
-      );
+      )
 
       if (error) {
         let errorMessage =
-          lget(error, 'cause.message', null) ?? messages.RunningSimulationDefaultError;
-        const isLowFundsError = lget(error, 'cause.code') === LOW_FUNDS_ERROR_CODE;
+          lget(error, 'cause.message', null) ?? messages.RunningSimulationDefaultError
+        const isLowFundsError = lget(error, 'cause.code') === LOW_FUNDS_ERROR_CODE
 
         if (isLowFundsError) {
-          errorMessage = isProjectAdmin ? messages.LowFundsError : messages.LowFundsErrorNonAdmin;
+          errorMessage = isProjectAdmin ? messages.LowFundsError : messages.LowFundsErrorNonAdmin
           if (!isProjectAdmin) {
-            labAdminContactHref = await getLabAdminContactHref();
+            labAdminContactHref = await getLabAdminContactHref()
           }
         }
 
         set(simulationStatusAtom, {
           status: SimulationStatus.ERROR,
           description: errorMessage,
-        });
+        })
 
         notify.error({
           message: `Simulation ${overviewConfiguration.name}`,
@@ -342,21 +348,21 @@ export const launchSimulationAtom = atom<
           placement: 'topRight',
           key: `simulation-failed-${sessionId}`,
           duration: 1000,
-        });
-        return;
+        })
+        return
       }
 
       if (!response?.ok) {
-        let errorMessage = messages.DefaultSimulationError;
-        let isLowFundsError = false;
+        let errorMessage = messages.DefaultSimulationError
+        let isLowFundsError = false
 
         try {
-          const errResponseObj = await response?.json();
+          const errResponseObj = await response?.json()
           if (errResponseObj.error_code === LOW_FUNDS_ERROR_CODE) {
-            isLowFundsError = true;
-            errorMessage = isProjectAdmin ? messages.LowFundsError : messages.LowFundsErrorNonAdmin;
+            isLowFundsError = true
+            errorMessage = isProjectAdmin ? messages.LowFundsError : messages.LowFundsErrorNonAdmin
             if (!isProjectAdmin) {
-              labAdminContactHref = await getLabAdminContactHref();
+              labAdminContactHref = await getLabAdminContactHref()
             }
           }
         } catch {
@@ -366,7 +372,7 @@ export const launchSimulationAtom = atom<
         set(simulationStatusAtom, {
           status: SimulationStatus.ERROR,
           description: errorMessage,
-        });
+        })
 
         notify.error({
           message: `Simulation ${overviewConfiguration.name}`,
@@ -397,101 +403,37 @@ export const launchSimulationAtom = atom<
           placement: 'topRight',
           key: `simulation-failed-${sessionId}`,
           duration: isLowFundsError ? 0 : undefined,
-        });
+        })
 
         if (!isLowFundsError) {
-          delay(() => set(simulationStatusAtom, RESET), 1000);
+          delay(() => set(simulationStatusAtom, RESET), 1000)
         }
-        return;
+        return
       }
 
-      await readNdjsonResponse<Message<SimulationStreamData>>(response, (message) => {
-        match(message)
-          .with({ message_type: MessageType.DATA }, ({ data }) => appendStreamData(data))
-          .with({ message_type: MessageType.STATUS, status: JobStatus.ERROR }, () => {
-            notify.error({
-              message: `Simulation ${overviewConfiguration.name}`,
-              description: messages.SteamingSimulationResultDefaultError,
-              placement: 'topRight',
-              key: `simulation-failed-${sessionId}`,
-            });
-            set(simulationStatusAtom, {
-              status: SimulationStatus.ERROR,
-              description: messages.SteamingSimulationResultDefaultError,
-            });
-            throw new Error(messages.SteamingSimulationResultDefaultError, {
-              cause: 'SmallScaleSimulatorError',
-            });
-          })
-          .with({ message_type: MessageType.STATUS, status: JobStatus.DONE }, async () => {
-            set(simulationStatusAtom, { status: SimulationStatus.EXECUTED });
-            notify.success({
-              message: `Simulation ${overviewConfiguration.name}`,
-              description: messages.ExecutionSimulationSucceed,
-              placement: 'topRight',
-              key: `simulation-success-${sessionId}`,
-            });
-            const description = overviewConfiguration.description ?? '';
-            const { data, error: saveError } = await tryCatch(
-              set(
-                createSingleNeuronSimulationAtom,
-                overviewConfiguration.name,
-                description,
-                modelId,
-                memodelId,
-                virtualLabId,
-                projectId,
-                simulationType,
-                stimulationConfiguration,
-                experimentalSetupConfiguration,
-                recordingConfiguration,
-                synaptomeConfiguration,
-                get(plotDataAtom),
-                stimulusGraphResult as PlotData
-              )
-            );
-            if (saveError) {
-              set(simulationStatusAtom, {
-                status: SimulationStatus.ERROR,
-                description: messages.CreationSimulationFailed,
-              });
-              notify.error({
-                message: `Simulation ${overviewConfiguration.name}`,
-                description: messages.CreationSimulationFailed,
-                placement: 'topRight',
-                key: `simulation-failed-${sessionId}`,
-              });
-            }
-            if (data) {
-              notify.success({
-                message: (
-                  <>
-                    Simulation <strong>{overviewConfiguration.name}</strong>
-                  </>
-                ),
-                description: (
-                  <div className="flex flex-col gap-2">
-                    <p>{messages.CreationSimulationSucceed}</p>
-                    <Link
-                      href={`${config.ROOT_ROUTE}/${virtualLabId}/${projectId}/data/view/${kebabCase(data.simulation.type)}/${data.simulation.id}`}
-                      className="text-primary-8 no-underline! hover:underline"
-                      onClick={() => notify.destroy(`simulation-success-${sessionId}`)}
-                    >
-                      View Simulation
-                    </Link>
-                  </div>
-                ),
-                placement: 'topRight',
-                duration: 0,
-                key: `simulation-success-${sessionId}`,
-                onClick: () => notify.destroy(`simulation-success-${sessionId}`),
-              });
-            }
-            set(simulationStatusAtom, { status: SimulationStatus.SAVED });
-          })
-          .otherwise(() => null);
-      });
-    } catch (error: any) {
+      await readNewlineDelimitedJsonResponse<Message<SimulationStreamData>>(
+        response,
+        makeMessageParser(
+          get,
+          set,
+          virtualLabId,
+          projectId,
+          notify,
+          overviewConfiguration,
+          sessionId,
+          simulationStatusAtom,
+          modelId,
+          memodelId,
+          simulationType,
+          stimulationConfiguration,
+          experimentalSetupConfiguration,
+          recordingConfiguration,
+          synaptomeConfiguration,
+          plotDataAtom,
+          stimulusGraphResult
+        )
+      )
+    } catch (error) {
       captureException(error, {
         tags: { section: 'simulation', type: 'simulationType' },
         extra: {
@@ -506,66 +448,275 @@ export const launchSimulationAtom = atom<
             duration,
           },
         },
-      });
+      })
       set(simulationStatusAtom, {
         status: SimulationStatus.ERROR,
-        description: error.cause ? `${error.cause}` : messages.RunningSimulationDefaultError,
-      });
+        description: hasCause(error) ? `${error.cause}` : messages.RunningSimulationDefaultError,
+      })
       notify.error({
         message: `Simulation ${overviewConfiguration.name}`,
         description: lget(error, 'cause.message', null) ?? messages.RunningSimulationDefaultError,
         placement: 'topRight',
         key: `simulation-failed-${sessionId}`,
-      });
-    }
-
-    function appendStreamData(streamData: SimulationStreamData) {
-      const newPlot: PlotDataEntry = {
-        x: streamData.x,
-        y: streamData.y,
-        type: 'scatter',
-        name: streamData.name,
-        recording: streamData.recording,
-        amplitude: streamData.amplitude,
-        frequency: streamData.frequency,
-        varyingKey: streamData.varying_key,
-        variable_name: streamData.variable_name,
-        unit: streamData.unit,
-      };
-      const currentPlotData = get(plotDataAtom);
-      const currentRecording = currentPlotData![streamData.recording];
-
-      if (currentRecording) {
-        const key = makeKey(newPlot);
-        const currentRecordingIndex = currentRecording.findIndex((o) => makeKey(o) === key);
-        const value = currentRecording[currentRecordingIndex];
-        if (currentRecordingIndex === -1) {
-          currentRecording.push(newPlot);
-        } else {
-          currentRecording[currentRecordingIndex] = {
-            ...value,
-            x: [...value.x, ...newPlot.x],
-            y: [...value.y, ...newPlot.y],
-            variable_name: newPlot.variable_name ?? value.variable_name,
-            unit: newPlot.unit ?? value.unit,
-          };
-        }
-        const updatedPlot = {
-          ...get(plotDataAtom),
-          [streamData.recording]: currentRecording,
-        };
-
-        // Sort traces for each plot by `varyingKey` so that the legends appear in sorted order.
-        Object.keys(updatedPlot).forEach((recordingLocation) => {
-          updatedPlot[recordingLocation] = sortBy(updatedPlot[recordingLocation], ['varyingKey']);
-        });
-
-        set(plotDataAtom, updatedPlot);
-      }
+      })
     }
   }
-);
+)
+
+type PlotDataAtom = ReturnType<typeof genericSingleNeuronSimulationPlotDataAtomFamily>
+
+function makeMessageParser(
+  get: Getter,
+  set: Setter,
+  virtualLabId: string,
+  projectId: string,
+  notify: NotificationInstance,
+  overviewConfiguration: { name: string; description?: string | undefined },
+  sessionId: string,
+  simulationStatusAtom: ReturnType<typeof simulationStatusAtomFamily>,
+  modelId: string,
+  memodelId: string,
+  simulationType: TSimulationType,
+  stimulationConfiguration: {
+    id: number
+    config_id: string
+    inject_to: string
+    stimulus: {
+      stimulus_type: 'current_clamp' | 'voltage_clamp' | 'conductance'
+      stimulus_protocol: 'ap_waveform' | 'idrest' | 'iv' | 'fire_pattern' | null
+      amplitudes: number | number[]
+    }
+  },
+  experimentalSetupConfiguration: {
+    celsius: number
+    vinit: number
+    hypamp: number
+    max_time: number
+    time_step: number
+    seed: number
+  },
+  recordingConfiguration: {
+    section: string
+    offset: number
+    record_currents: boolean
+    origin: 'injection' | 'recording'
+    color?: string | undefined
+  }[],
+  synaptomeConfiguration: {
+    id: string
+    config_id: string
+    delay: number
+    duration: number
+    frequency: number | number[]
+    weight_scalar: number
+    color?: string | undefined
+  }[],
+  plotDataAtom: PlotDataAtom,
+  stimulusGraphResult: PlotData
+): ((data: Message<SimulationStreamData>) => void) | undefined {
+  const appendStreamData = makeAppendStreadData(get, set, plotDataAtom)
+  return (message) => {
+    match(message)
+      .with({ message_type: MessageType.DATA }, (msg) => {
+        const type = msg.data_type
+        if (type === 'spikes') {
+          // @TODO: Deal with spikes in another PR
+        } else if (!type || type === 'trace') {
+          // @TODO: when BlueNaas is in production,
+          // remove this nested condition.
+          return appendStreamData(msg.data)
+        }
+      })
+      .with({ message_type: MessageType.STATUS, status: JobStatus.ERROR }, () => {
+        notify.error({
+          message: `Simulation ${overviewConfiguration.name}`,
+          description: messages.SteamingSimulationResultDefaultError,
+          placement: 'topRight',
+          key: `simulation-failed-${sessionId}`,
+        })
+        set(simulationStatusAtom, {
+          status: SimulationStatus.ERROR,
+          description: messages.SteamingSimulationResultDefaultError,
+        })
+        throw new Error(messages.SteamingSimulationResultDefaultError, {
+          cause: 'SmallScaleSimulatorError',
+        })
+      })
+      .with({ message_type: MessageType.STATUS, status: JobStatus.DONE }, async () => {
+        set(simulationStatusAtom, { status: SimulationStatus.EXECUTED })
+        notify.success({
+          message: `Simulation ${overviewConfiguration.name}`,
+          description: messages.ExecutionSimulationSucceed,
+          placement: 'topRight',
+          key: `simulation-success-${sessionId}`,
+        })
+        const description = overviewConfiguration.description ?? ''
+        const { data, error: saveError } = await tryCatch(
+          set(
+            createSingleNeuronSimulationAtom,
+            overviewConfiguration.name,
+            description,
+            modelId,
+            memodelId,
+            virtualLabId,
+            projectId,
+            simulationType,
+            stimulationConfiguration,
+            experimentalSetupConfiguration,
+            recordingConfiguration,
+            synaptomeConfiguration,
+            get(plotDataAtom),
+            stimulusGraphResult as PlotData
+          )
+        )
+        if (saveError) {
+          set(simulationStatusAtom, {
+            status: SimulationStatus.ERROR,
+            description: messages.CreationSimulationFailed,
+          })
+          notify.error({
+            message: `Simulation ${overviewConfiguration.name}`,
+            description: messages.CreationSimulationFailed,
+            placement: 'topRight',
+            key: `simulation-failed-${sessionId}`,
+          })
+        }
+        if (data) {
+          notify.success({
+            message: (
+              <>
+                Simulation <strong>{overviewConfiguration.name}</strong>
+              </>
+            ),
+            description: (
+              <div className="flex flex-col gap-2">
+                <p>{messages.CreationSimulationSucceed}</p>
+                <Link
+                  href={`${config.ROOT_ROUTE}/${virtualLabId}/${projectId}/data/view/${kebabCase(data.simulation.type)}/${data.simulation.id}`}
+                  className="text-primary-8 no-underline! hover:underline"
+                  onClick={() => notify.destroy(`simulation-success-${sessionId}`)}
+                >
+                  View Simulation
+                </Link>
+              </div>
+            ),
+            placement: 'topRight',
+            duration: 0,
+            key: `simulation-success-${sessionId}`,
+            onClick: () => notify.destroy(`simulation-success-${sessionId}`),
+          })
+        }
+        set(simulationStatusAtom, { status: SimulationStatus.SAVED })
+      })
+      .otherwise(() => null)
+  }
+}
+
+function makeAppendStreadData(get: Getter, set: Setter, plotDataAtom: PlotDataAtom) {
+  return (streamData: SimulationStreamData) => {
+    const newPlot: PlotDataEntry = {
+      x: streamData.x,
+      y: streamData.y,
+      type: 'scatter',
+      name: streamData.name,
+      recording: streamData.recording,
+      amplitude: streamData.amplitude,
+      frequency: streamData.frequency,
+      varyingKey: streamData.varying_key,
+      variable_name: streamData.variable_name,
+      unit: streamData.unit,
+    }
+    const currentPlotData = get(plotDataAtom)
+    const currentRecording = currentPlotData?.[streamData.recording]
+
+    if (currentRecording) {
+      const key = makeKey(newPlot)
+      const currentRecordingIndex = currentRecording.findIndex((o) => makeKey(o) === key)
+      const value = currentRecording[currentRecordingIndex]
+      if (currentRecordingIndex === -1) {
+        currentRecording.push(newPlot)
+      } else {
+        currentRecording[currentRecordingIndex] = {
+          ...value,
+          x: [...value.x, ...newPlot.x],
+          y: [...value.y, ...newPlot.y],
+          variable_name: newPlot.variable_name ?? value.variable_name,
+          unit: newPlot.unit ?? value.unit,
+        }
+      }
+      const updatedPlot = {
+        ...get(plotDataAtom),
+        [streamData.recording]: currentRecording,
+      }
+
+      // Sort traces for each plot by `varyingKey` so that the legends appear in sorted order.
+      Object.keys(updatedPlot).forEach((recordingLocation) => {
+        updatedPlot[recordingLocation] = sortBy(updatedPlot[recordingLocation], ['varyingKey'])
+      })
+
+      set(plotDataAtom, updatedPlot)
+    }
+  }
+}
+
+function setInitialPlotData(
+  recordingConfiguration: {
+    section: string
+    offset: number
+    record_currents: boolean
+    origin: 'injection' | 'recording'
+    color?: string | undefined
+  }[],
+  sessionId: string,
+  set: Setter
+) {
+  const initialPlotData = recordingConfiguration.reduce((acc: Record<string, PlotData>, o) => {
+    const key = `${o.section}_${o.offset === 0 ? '0.0' : String(o.offset)}`
+    acc[key] = []
+    return acc
+  }, {})
+  const plotDataAtom = genericSingleNeuronSimulationPlotDataAtomFamily(sessionId)
+  set(plotDataAtom, initialPlotData)
+  return plotDataAtom
+}
+
+function checkArguments(
+  simulationType: string,
+  stimulationConfiguration: {
+    id: number
+    config_id: string
+    inject_to: string
+    stimulus: {
+      stimulus_type: 'current_clamp' | 'voltage_clamp' | 'conductance'
+      stimulus_protocol: 'ap_waveform' | 'idrest' | 'iv' | 'fire_pattern' | null
+      amplitudes: number | number[]
+    }
+  },
+  synaptomeConfiguration: {
+    id: string
+    config_id: string
+    delay: number
+    duration: number
+    frequency: number | number[]
+    weight_scalar: number
+    color?: string | undefined
+  }[]
+) {
+  if (simulationType === 'single-neuron-simulation') {
+    if (!stimulationConfiguration) {
+      throw new Error(messages.CurrentInjectionConfigMissingError)
+    }
+  } else if (simulationType === 'synaptome-simulation') {
+    if (!stimulationConfiguration && !synaptomeConfiguration?.length) {
+      throw new Error(messages.SynaptomeConfigurationError)
+    }
+  }
+}
 
 function makeKey(entry: PlotDataEntry): string {
-  return `${entry.name}\t${entry.variable_name}\t${entry.unit}`;
+  return `${entry.name}\t${entry.variable_name}\t${entry.unit}`
+}
+
+function hasCause(data: unknown): data is { cause: string } {
+  return isType(data, { cause: 'string' })
 }

--- a/src/ui/segments/workflows/simulate/single-neuron/shared/runner.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/shared/runner.tsx
@@ -1,7 +1,7 @@
 /** biome-ignore-all lint/performance/noAccumulatingSpread: useless rule */
-'use client'
+'use client';
 
-import { captureException } from '@sentry/nextjs'
+import { captureException } from '@sentry/nextjs';
 import {
   delay,
   isNil,
@@ -13,48 +13,48 @@ import {
   sortBy,
   uniqBy,
   values,
-} from 'es-toolkit/compat'
-import { atom, type Getter, type Setter } from 'jotai'
-import { RESET } from 'jotai/utils'
-import Link from 'next/link'
-import { match } from 'ts-pattern'
+} from 'es-toolkit/compat';
+import { atom, type Getter, type Setter } from 'jotai';
+import { RESET } from 'jotai/utils';
+import Link from 'next/link';
+import { match } from 'ts-pattern';
 
 import {
   createSingleNeuronSimulation,
   createSingleNeuronSynaptomeSimulation,
   getMEModel,
-} from '@/api/entitycore/queries'
-import { createJsonAsset } from '@/api/entitycore/queries/assets'
-import { runSingleNeuronSimulation } from '@/api/small-scale-simulator'
-import { tryCatch } from '@/api/utils'
-import { listVirtualLabMembers } from '@/api/virtual-lab-svc/queries/member'
-import { config } from '@/config'
+} from '@/api/entitycore/queries';
+import { createJsonAsset } from '@/api/entitycore/queries/assets';
+import { runSingleNeuronSimulation } from '@/api/small-scale-simulator';
+import { tryCatch } from '@/api/utils';
+import { listVirtualLabMembers } from '@/api/virtual-lab-svc/queries/member';
+import { config } from '@/config';
 import {
   SingleNeuronSimulation,
   SingleNeuronSynaptomeSimulation,
-} from '@/entity-configuration/domain/simulation'
-import { messages } from '@/i18n/en/simulation'
-import { JobStatus, type Message, MessageType } from '@/services/small-scale-simulator/types'
+} from '@/entity-configuration/domain/simulation';
+import { messages } from '@/i18n/en/simulation';
+import { JobStatus, type Message, MessageType } from '@/services/small-scale-simulator/types';
 import {
   genericSingleNeuronSimulationPlotDataAtomFamily,
   SimulationStatus,
   simulationStatusAtomFamily,
-} from '@/ui/segments/workflows/simulate/single-neuron/shared/context'
-import { SimulationType } from '@/ui/segments/workflows/simulate/single-neuron/shared/types'
-import { convertObjectKeysToSnakeCase } from '@/util/object-keys-format'
-import { isType } from '@/util/type-guards'
-import { readNdjsonResponse as readNewlineDelimitedJsonResponse } from '@/utils/response'
+} from '@/ui/segments/workflows/simulate/single-neuron/shared/context';
+import { SimulationType } from '@/ui/segments/workflows/simulate/single-neuron/shared/types';
+import { convertObjectKeysToSnakeCase } from '@/util/object-keys-format';
+import { isType } from '@/util/type-guards';
+import { readNdjsonResponse as readNewlineDelimitedJsonResponse } from '@/utils/response';
 
-import type { NotificationInstance } from 'antd/es/notification/interface'
+import type { NotificationInstance } from 'antd/es/notification/interface';
 import type {
   ISingleNeuronSimulation,
   ISingleNeuronSynaptomeSimulation,
-} from '@/api/entitycore/types'
-import type { PlotData, PlotDataEntry } from '@/services/bluenaas-single-cell/types'
+} from '@/api/entitycore/types';
+import type { PlotData, PlotDataEntry } from '@/services/bluenaas-single-cell/types';
 import type {
   SimulationStreamData,
   SingleNeuronModelSimulationConfig,
-} from '@/types/small-scale-simulator/single-neuron'
+} from '@/types/small-scale-simulator/single-neuron';
 import type {
   NeuronLocationArray,
   SimulationExperimentalSetup,
@@ -62,9 +62,9 @@ import type {
   TOverviewConfiguration,
   TSimulationType,
   TStimulationConfiguration,
-} from '@/ui/segments/workflows/simulate/single-neuron/shared/types'
+} from '@/ui/segments/workflows/simulate/single-neuron/shared/types';
 
-const LOW_FUNDS_ERROR_CODE = 'ACCOUNTING_INSUFFICIENT_FUNDS_ERROR'
+const LOW_FUNDS_ERROR_CODE = 'ACCOUNTING_INSUFFICIENT_FUNDS_ERROR';
 
 export const createSingleNeuronSimulationAtom = atom(
   null,
@@ -85,7 +85,7 @@ export const createSingleNeuronSimulationAtom = atom(
     simulationResult: Record<string, PlotData> | null,
     stimulusResult: PlotData | null
   ) => {
-    if (!simulationResult || !modelId) return null
+    if (!simulationResult || !modelId) return null;
 
     const recordFromUniq = map(
       uniqBy(recordingConfiguration, (item) =>
@@ -94,7 +94,7 @@ export const createSingleNeuronSimulationAtom = atom(
           .join()
       ),
       (obj) => omit(obj, ['color'])
-    )
+    );
 
     const singleNeuronSimulationConfig: SingleNeuronModelSimulationConfig = {
       record_from: recordFromUniq,
@@ -104,16 +104,16 @@ export const createSingleNeuronSimulationAtom = atom(
         simulationType === SimulationType.SingleNeuronSynaptome
           ? synaptomeConfiguration
           : undefined,
-    }
+    };
 
     const { data: meModel, error } = await tryCatch(
       getMEModel({
         id: memodelId,
         context: { virtualLabId, projectId },
       })
-    )
+    );
     if (error || isNil(meModel)) {
-      throw new Error(messages.SimulationPrerequisitesMEModelError)
+      throw new Error(messages.SimulationPrerequisitesMEModelError);
     }
 
     const basePayload = {
@@ -125,38 +125,38 @@ export const createSingleNeuronSimulationAtom = atom(
         (r) => `${r.section}_${r.offset}`
       ),
       brain_region_id: meModel.brain_region.id,
-    }
+    };
     let simulationPromise: Promise<
       ISingleNeuronSimulation | ISingleNeuronSynaptomeSimulation
-    > | null = null
+    > | null = null;
     if (simulationType === SimulationType.SingleNeuron) {
       simulationPromise = createSingleNeuronSimulation({
         context: { virtualLabId, projectId },
         body: { ...basePayload, me_model_id: meModel.id },
-      })
+      });
     } else if (simulationType === SimulationType.SingleNeuronSynaptome) {
       simulationPromise = createSingleNeuronSynaptomeSimulation({
         context: { virtualLabId, projectId },
         body: { ...basePayload, synaptome_id: modelId },
-      })
+      });
     }
     if (simulationPromise) {
-      const { data: simulation, error: simulationError } = await tryCatch(simulationPromise)
+      const { data: simulation, error: simulationError } = await tryCatch(simulationPromise);
       if (simulationError) {
-        throw new Error(messages.CreationSimulationFailed)
+        throw new Error(messages.CreationSimulationFailed);
       }
       const assetBasePayload =
         simulationType === SimulationType.SingleNeuron
           ? {
-            label: SingleNeuronSimulation.asset.configfile,
-            entityType: SingleNeuronSimulation.type,
-            path: `single-neuron-simulation-${simulation.id}`,
-          }
+              label: SingleNeuronSimulation.asset.configfile,
+              entityType: SingleNeuronSimulation.type,
+              path: `single-neuron-simulation-${simulation.id}`,
+            }
           : {
-            label: SingleNeuronSynaptomeSimulation.asset.configfile,
-            entityType: SingleNeuronSynaptomeSimulation.type,
-            path: `single-neuron-synaptome-simulation-${simulation.id}`,
-          }
+              label: SingleNeuronSynaptomeSimulation.asset.configfile,
+              entityType: SingleNeuronSynaptomeSimulation.type,
+              path: `single-neuron-synaptome-simulation-${simulation.id}`,
+            };
       if (simulation) {
         const { data: asset, error: assetError } = await tryCatch(
           createJsonAsset({
@@ -170,27 +170,27 @@ export const createSingleNeuronSimulationAtom = atom(
                 return {
                   ...prev,
                   [curr]: convertObjectKeysToSnakeCase(simulationResult[curr]),
-                }
+                };
               }, {}),
               stimulus: convertObjectKeysToSnakeCase(stimulusResult),
               config: convertObjectKeysToSnakeCase(singleNeuronSimulationConfig),
             },
             ...assetBasePayload,
           })
-        )
+        );
         if (asset) {
           return {
             simulation,
             asset,
-          }
+          };
         }
         if (assetError) {
-          throw new Error(messages.CreationSimulationIOAssetFailed)
+          throw new Error(messages.CreationSimulationIOAssetFailed);
         }
       }
     }
   }
-)
+);
 
 /**
  * When the setter of this writable atom is called, it will update this atom:
@@ -241,47 +241,44 @@ export const launchSimulationAtom = atom<
   ) => {
     if (simulationType === 'single-neuron-simulation') {
       if (!stimulationConfiguration) {
-        throw new Error(messages.CurrentInjectionConfigMissingError)
+        throw new Error(messages.CurrentInjectionConfigMissingError);
       }
     } else if (simulationType === 'synaptome-simulation') {
-      if (
-        !stimulationConfiguration &&
-        (!synaptomeConfiguration || !synaptomeConfiguration.length)
-      ) {
-        throw new Error(messages.SynaptomeConfigurationError)
+      if (!stimulationConfiguration && !synaptomeConfiguration?.length) {
+        throw new Error(messages.SynaptomeConfigurationError);
       }
     }
-    const simulationStatusAtom = simulationStatusAtomFamily(sessionId)
-    const lowFundsEmailSubject = 'Insufficient%20credits%20for%20simulation'
-    let labAdminContactHref: string | null = null
+    const simulationStatusAtom = simulationStatusAtomFamily(sessionId);
+    const lowFundsEmailSubject = 'Insufficient%20credits%20for%20simulation';
+    let labAdminContactHref: string | null = null;
 
     const getLabAdminContactHref = async () => {
-      if (labAdminContactHref) return labAdminContactHref
-      const { data: membersData } = await tryCatch(listVirtualLabMembers({ virtualLabId }))
-      const adminEmail = membersData?.data?.users.find((user) => user.role === 'admin')?.email
+      if (labAdminContactHref) return labAdminContactHref;
+      const { data: membersData } = await tryCatch(listVirtualLabMembers({ virtualLabId }));
+      const adminEmail = membersData?.data?.users.find((user) => user.role === 'admin')?.email;
 
       labAdminContactHref = adminEmail
         ? `mailto:${adminEmail}?subject=${lowFundsEmailSubject}`
-        : null
-      return labAdminContactHref
-    }
+        : null;
+      return labAdminContactHref;
+    };
 
-    set(simulationStatusAtom, { status: SimulationStatus.LAUNCHED })
+    set(simulationStatusAtom, { status: SimulationStatus.LAUNCHED });
 
     const initialPlotData = recordingConfiguration.reduce((acc: Record<string, PlotData>, o) => {
-      const key = `${o.section}_${o.offset === 0 ? '0.0' : String(o.offset)}`
-      acc[key] = []
-      return acc
-    }, {})
-    const plotDataAtom = genericSingleNeuronSimulationPlotDataAtomFamily(sessionId)
+      const key = `${o.section}_${o.offset === 0 ? '0.0' : String(o.offset)}`;
+      acc[key] = [];
+      return acc;
+    }, {});
+    const plotDataAtom = genericSingleNeuronSimulationPlotDataAtomFamily(sessionId);
 
-    set(plotDataAtom, initialPlotData)
+    set(plotDataAtom, initialPlotData);
     const recordFromUniq = uniqBy(recordingConfiguration, (item) =>
       values(pick(item, ['section', 'offset']))
         .map(String)
         .join()
-    )
-    onChangePanel()
+    );
+    onChangePanel();
 
     try {
       const { data: response, error } = await tryCatch(
@@ -300,24 +297,24 @@ export const launchSimulationAtom = atom<
             duration,
           },
         })
-      )
+      );
 
       if (error) {
         let errorMessage =
-          lget(error, 'cause.message', null) ?? messages.RunningSimulationDefaultError
-        const isLowFundsError = lget(error, 'cause.code') === LOW_FUNDS_ERROR_CODE
+          lget(error, 'cause.message', null) ?? messages.RunningSimulationDefaultError;
+        const isLowFundsError = lget(error, 'cause.code') === LOW_FUNDS_ERROR_CODE;
 
         if (isLowFundsError) {
-          errorMessage = isProjectAdmin ? messages.LowFundsError : messages.LowFundsErrorNonAdmin
+          errorMessage = isProjectAdmin ? messages.LowFundsError : messages.LowFundsErrorNonAdmin;
           if (!isProjectAdmin) {
-            labAdminContactHref = await getLabAdminContactHref()
+            labAdminContactHref = await getLabAdminContactHref();
           }
         }
 
         set(simulationStatusAtom, {
           status: SimulationStatus.ERROR,
           description: errorMessage,
-        })
+        });
 
         notify.error({
           message: `Simulation ${overviewConfiguration.name}`,
@@ -348,21 +345,21 @@ export const launchSimulationAtom = atom<
           placement: 'topRight',
           key: `simulation-failed-${sessionId}`,
           duration: 1000,
-        })
-        return
+        });
+        return;
       }
 
       if (!response?.ok) {
-        let errorMessage = messages.DefaultSimulationError
-        let isLowFundsError = false
+        let errorMessage = messages.DefaultSimulationError;
+        let isLowFundsError = false;
 
         try {
-          const errResponseObj = await response?.json()
+          const errResponseObj = await response?.json();
           if (errResponseObj.error_code === LOW_FUNDS_ERROR_CODE) {
-            isLowFundsError = true
-            errorMessage = isProjectAdmin ? messages.LowFundsError : messages.LowFundsErrorNonAdmin
+            isLowFundsError = true;
+            errorMessage = isProjectAdmin ? messages.LowFundsError : messages.LowFundsErrorNonAdmin;
             if (!isProjectAdmin) {
-              labAdminContactHref = await getLabAdminContactHref()
+              labAdminContactHref = await getLabAdminContactHref();
             }
           }
         } catch {
@@ -372,7 +369,7 @@ export const launchSimulationAtom = atom<
         set(simulationStatusAtom, {
           status: SimulationStatus.ERROR,
           description: errorMessage,
-        })
+        });
 
         notify.error({
           message: `Simulation ${overviewConfiguration.name}`,
@@ -403,12 +400,12 @@ export const launchSimulationAtom = atom<
           placement: 'topRight',
           key: `simulation-failed-${sessionId}`,
           duration: isLowFundsError ? 0 : undefined,
-        })
+        });
 
         if (!isLowFundsError) {
-          delay(() => set(simulationStatusAtom, RESET), 1000)
+          delay(() => set(simulationStatusAtom, RESET), 1000);
         }
-        return
+        return;
       }
 
       await readNewlineDelimitedJsonResponse<Message<SimulationStreamData>>(
@@ -432,7 +429,7 @@ export const launchSimulationAtom = atom<
           plotDataAtom,
           stimulusGraphResult
         )
-      )
+      );
     } catch (error) {
       captureException(error, {
         tags: { section: 'simulation', type: 'simulationType' },
@@ -448,22 +445,22 @@ export const launchSimulationAtom = atom<
             duration,
           },
         },
-      })
+      });
       set(simulationStatusAtom, {
         status: SimulationStatus.ERROR,
         description: hasCause(error) ? `${error.cause}` : messages.RunningSimulationDefaultError,
-      })
+      });
       notify.error({
         message: `Simulation ${overviewConfiguration.name}`,
         description: lget(error, 'cause.message', null) ?? messages.RunningSimulationDefaultError,
         placement: 'topRight',
         key: `simulation-failed-${sessionId}`,
-      })
+      });
     }
   }
-)
+);
 
-type PlotDataAtom = ReturnType<typeof genericSingleNeuronSimulationPlotDataAtomFamily>
+type PlotDataAtom = ReturnType<typeof genericSingleNeuronSimulationPlotDataAtomFamily>;
 
 function makeMessageParser(
   get: Getter,
@@ -478,53 +475,53 @@ function makeMessageParser(
   memodelId: string,
   simulationType: TSimulationType,
   stimulationConfiguration: {
-    id: number
-    config_id: string
-    inject_to: string
+    id: number;
+    config_id: string;
+    inject_to: string;
     stimulus: {
-      stimulus_type: 'current_clamp' | 'voltage_clamp' | 'conductance'
-      stimulus_protocol: 'ap_waveform' | 'idrest' | 'iv' | 'fire_pattern' | null
-      amplitudes: number | number[]
-    }
+      stimulus_type: 'current_clamp' | 'voltage_clamp' | 'conductance';
+      stimulus_protocol: 'ap_waveform' | 'idrest' | 'iv' | 'fire_pattern' | null;
+      amplitudes: number | number[];
+    };
   },
   experimentalSetupConfiguration: {
-    celsius: number
-    vinit: number
-    hypamp: number
-    max_time: number
-    time_step: number
-    seed: number
+    celsius: number;
+    vinit: number;
+    hypamp: number;
+    max_time: number;
+    time_step: number;
+    seed: number;
   },
   recordingConfiguration: {
-    section: string
-    offset: number
-    record_currents: boolean
-    origin: 'injection' | 'recording'
-    color?: string | undefined
+    section: string;
+    offset: number;
+    record_currents: boolean;
+    origin: 'injection' | 'recording';
+    color?: string | undefined;
   }[],
   synaptomeConfiguration: {
-    id: string
-    config_id: string
-    delay: number
-    duration: number
-    frequency: number | number[]
-    weight_scalar: number
-    color?: string | undefined
+    id: string;
+    config_id: string;
+    delay: number;
+    duration: number;
+    frequency: number | number[];
+    weight_scalar: number;
+    color?: string | undefined;
   }[],
   plotDataAtom: PlotDataAtom,
   stimulusGraphResult: PlotData
 ): ((data: Message<SimulationStreamData>) => void) | undefined {
-  const appendStreamData = makeAppendStreadData(get, set, plotDataAtom)
+  const appendStreamData = makeAppendStreadData(get, set, plotDataAtom);
   return (message) => {
     match(message)
       .with({ message_type: MessageType.DATA }, (msg) => {
-        const type = msg.data_type
+        const type = msg.data_type;
         if (type === 'spikes') {
           // @TODO: Deal with spikes in another PR
         } else if (!type || type === 'trace') {
           // @TODO: when BlueNaas is in production,
           // remove this nested condition.
-          return appendStreamData(msg.data)
+          return appendStreamData(msg.data);
         }
       })
       .with({ message_type: MessageType.STATUS, status: JobStatus.ERROR }, () => {
@@ -533,24 +530,24 @@ function makeMessageParser(
           description: messages.SteamingSimulationResultDefaultError,
           placement: 'topRight',
           key: `simulation-failed-${sessionId}`,
-        })
+        });
         set(simulationStatusAtom, {
           status: SimulationStatus.ERROR,
           description: messages.SteamingSimulationResultDefaultError,
-        })
+        });
         throw new Error(messages.SteamingSimulationResultDefaultError, {
           cause: 'SmallScaleSimulatorError',
-        })
+        });
       })
       .with({ message_type: MessageType.STATUS, status: JobStatus.DONE }, async () => {
-        set(simulationStatusAtom, { status: SimulationStatus.EXECUTED })
+        set(simulationStatusAtom, { status: SimulationStatus.EXECUTED });
         notify.success({
           message: `Simulation ${overviewConfiguration.name}`,
           description: messages.ExecutionSimulationSucceed,
           placement: 'topRight',
           key: `simulation-success-${sessionId}`,
-        })
-        const description = overviewConfiguration.description ?? ''
+        });
+        const description = overviewConfiguration.description ?? '';
         const { data, error: saveError } = await tryCatch(
           set(
             createSingleNeuronSimulationAtom,
@@ -568,18 +565,18 @@ function makeMessageParser(
             get(plotDataAtom),
             stimulusGraphResult as PlotData
           )
-        )
+        );
         if (saveError) {
           set(simulationStatusAtom, {
             status: SimulationStatus.ERROR,
             description: messages.CreationSimulationFailed,
-          })
+          });
           notify.error({
             message: `Simulation ${overviewConfiguration.name}`,
             description: messages.CreationSimulationFailed,
             placement: 'topRight',
             key: `simulation-failed-${sessionId}`,
-          })
+          });
         }
         if (data) {
           notify.success({
@@ -604,12 +601,12 @@ function makeMessageParser(
             duration: 0,
             key: `simulation-success-${sessionId}`,
             onClick: () => notify.destroy(`simulation-success-${sessionId}`),
-          })
+          });
         }
-        set(simulationStatusAtom, { status: SimulationStatus.SAVED })
+        set(simulationStatusAtom, { status: SimulationStatus.SAVED });
       })
-      .otherwise(() => null)
-  }
+      .otherwise(() => null);
+  };
 }
 
 function makeAppendStreadData(get: Getter, set: Setter, plotDataAtom: PlotDataAtom) {
@@ -625,16 +622,16 @@ function makeAppendStreadData(get: Getter, set: Setter, plotDataAtom: PlotDataAt
       varyingKey: streamData.varying_key,
       variable_name: streamData.variable_name,
       unit: streamData.unit,
-    }
-    const currentPlotData = get(plotDataAtom)
-    const currentRecording = currentPlotData?.[streamData.recording]
+    };
+    const currentPlotData = get(plotDataAtom);
+    const currentRecording = currentPlotData?.[streamData.recording];
 
     if (currentRecording) {
-      const key = makeKey(newPlot)
-      const currentRecordingIndex = currentRecording.findIndex((o) => makeKey(o) === key)
-      const value = currentRecording[currentRecordingIndex]
+      const key = makeKey(newPlot);
+      const currentRecordingIndex = currentRecording.findIndex((o) => makeKey(o) === key);
+      const value = currentRecording[currentRecordingIndex];
       if (currentRecordingIndex === -1) {
-        currentRecording.push(newPlot)
+        currentRecording.push(newPlot);
       } else {
         currentRecording[currentRecordingIndex] = {
           ...value,
@@ -642,81 +639,27 @@ function makeAppendStreadData(get: Getter, set: Setter, plotDataAtom: PlotDataAt
           y: [...value.y, ...newPlot.y],
           variable_name: newPlot.variable_name ?? value.variable_name,
           unit: newPlot.unit ?? value.unit,
-        }
+        };
       }
       const updatedPlot = {
         ...get(plotDataAtom),
         [streamData.recording]: currentRecording,
-      }
+      };
 
       // Sort traces for each plot by `varyingKey` so that the legends appear in sorted order.
       Object.keys(updatedPlot).forEach((recordingLocation) => {
-        updatedPlot[recordingLocation] = sortBy(updatedPlot[recordingLocation], ['varyingKey'])
-      })
+        updatedPlot[recordingLocation] = sortBy(updatedPlot[recordingLocation], ['varyingKey']);
+      });
 
-      set(plotDataAtom, updatedPlot)
+      set(plotDataAtom, updatedPlot);
     }
-  }
-}
-
-function setInitialPlotData(
-  recordingConfiguration: {
-    section: string
-    offset: number
-    record_currents: boolean
-    origin: 'injection' | 'recording'
-    color?: string | undefined
-  }[],
-  sessionId: string,
-  set: Setter
-) {
-  const initialPlotData = recordingConfiguration.reduce((acc: Record<string, PlotData>, o) => {
-    const key = `${o.section}_${o.offset === 0 ? '0.0' : String(o.offset)}`
-    acc[key] = []
-    return acc
-  }, {})
-  const plotDataAtom = genericSingleNeuronSimulationPlotDataAtomFamily(sessionId)
-  set(plotDataAtom, initialPlotData)
-  return plotDataAtom
-}
-
-function checkArguments(
-  simulationType: string,
-  stimulationConfiguration: {
-    id: number
-    config_id: string
-    inject_to: string
-    stimulus: {
-      stimulus_type: 'current_clamp' | 'voltage_clamp' | 'conductance'
-      stimulus_protocol: 'ap_waveform' | 'idrest' | 'iv' | 'fire_pattern' | null
-      amplitudes: number | number[]
-    }
-  },
-  synaptomeConfiguration: {
-    id: string
-    config_id: string
-    delay: number
-    duration: number
-    frequency: number | number[]
-    weight_scalar: number
-    color?: string | undefined
-  }[]
-) {
-  if (simulationType === 'single-neuron-simulation') {
-    if (!stimulationConfiguration) {
-      throw new Error(messages.CurrentInjectionConfigMissingError)
-    }
-  } else if (simulationType === 'synaptome-simulation') {
-    if (!stimulationConfiguration && !synaptomeConfiguration?.length) {
-      throw new Error(messages.SynaptomeConfigurationError)
-    }
-  }
+  };
 }
 
 function makeKey(entry: PlotDataEntry): string {
-  return `${entry.name}\t${entry.variable_name}\t${entry.unit}`
+  return `${entry.name}\t${entry.variable_name}\t${entry.unit}`;
 }
 
 function hasCause(data: unknown): data is { cause: string } {
-  return isType(data, { cause: 'string' })
+  return isType(data, { cause: 'string' });
 }


### PR DESCRIPTION
# Use new data_type attribute in simulation stream messages

## Summary

Refactors the single-neuron simulation runner to support the new `data_type` field on streamed simulation messages, enabling differentiation between trace and spikes data types.

## Changes

- `src/services/small-scale-simulator/types.ts`: Added optional `data_type` field to DataMessage type to support categorizing incoming stream data (e.g. trace, spikes).
- `src/ui/segments/workflows/simulate/single-neuron/shared/runner.tsx`:
  - Extracted the NDJSON message parsing callback into a standalone makeMessageParser function.
  - Extracted stream data appending logic into makeAppendStreadData.
  - Extracted initial plot data setup into setInitialPlotData.
  - Extracted argument validation into checkArguments.
  - Added hasCause type guard for safer error handling (replaces error.cause access on any-typed catch variable).

Message parser now inspects `data_type` to distinguish between trace and spikes messages (spikes handling is a TODO for a follow-up PR, see phase 2 of [this ticket](https://github.com/openbraininstitute/prod-build-emodel/issues/131)).

## Motivation

Prepares the codebase for handling spike activity data from the small-scale simulator.

We can now merge the [PR for small-scale-simulator](https://github.com/openbraininstitute/Bluenaas/pull/141). The frontend will be compatible with the new format.

Improves readability and maintainability by breaking a ~200-line inline callback into discrete, testable functions.

Removes usage of any in the catch clause for type-safe error handling.