### PR TITLE
Enforce module boundaries with noPrivateImports from Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -28,7 +28,8 @@
         "useButtonType": "error"
       },
       "correctness": {
-        "noUnusedVariables": "error"
+        "noUnusedVariables": "error",
+        "noPrivateImports": "error"
       },
       "style": {
         "noParameterAssign": "error",


### PR DESCRIPTION
## Summary

- Enables Biome's [`noPrivateImports`](https://biomejs.dev/linter/rules/no-private-imports/) lint rule at `error` level to enforce module boundaries at the file system level.

## What this does

`noPrivateImports` prevents importing symbols that are **not re-exported** from a directory's `index.ts` (barrel file). If a module exposes a public API via `index.ts`, other modules can only import what's explicitly re-exported — direct imports of internal files (e.g., `@/components/foo/internal-helper`) become lint errors.

## Why

- **Enforces module encapsulation** — internal implementation details stay internal without relying on naming conventions or code review alone.
- **Makes refactoring safer** — renaming or restructuring files within a module won't break external consumers as long as the barrel export stays the same.
- **Catches accidental coupling early** — at lint time rather than during review.

## How to use

The rule recognizes the JSDoc tags `@public`, `@package`, and `@private` so that you are free to set the visibility of exports. Exports without tag have a default visibility of public, but this can be configured.
The `@access` tag is also supported if it’s used with one of the values public, package, or private.

### Public visibility

Public visibility is the default and means there are no restrictions for importing a given symbol. In other words, without this rule, all exported symbols are implicitly public.

### Package visibility

Within the context of this rule, package visibility means that a symbol is visible within the same “package”, which means that any module that resides in the same folder, or one of its subfolders, is allowed to import the symbol. Modules that only share a common folder higher up in the hierarchy are not allowed to import the symbol.
For a visual explanation, see [this illustration](https://github.com/uhyo/eslint-plugin-import-access?tab=readme-ov-file#what).

### Private visibility

Private visibility means that a symbol may not be imported from other modules.
The key thing to understanding the usefulness of `@private` is that this rule doesn’t treat modules and files as one and the same thing. While files are indeed modules, folders are considered modules too, with their files and subfolders being submodules. Therefore, symbols exported as `@private` from an index file, such as `index.js`, can still be imported from other submodules in that same module.