### PR TITLE
feat: normalize entity count queries to return totals

### DIFF
--- a/src/entity-configuration/domain/simulation/ion-channel-model-simulation.ts
+++ b/src/entity-configuration/domain/simulation/ion-channel-model-simulation.ts
@@ -160,15 +160,22 @@ export const IonChannelModelSimulation: EntityCoreTypeConfig<
           withFacets: params[0].withFacets,
           filters: {
             ...filters,
+            page: 1,
+            page_size: 1,
+            entity__type: ENTITY_TYPE,
+          },
+        }).then((response) => response.pagination.total_items);
+      },
+      list: (params: Parameters<typeof resolveSimulationCampaigns>[0]) => {
+        const filters = discardBrainRegionQueryParams(params.filters);
+        return resolveSimulationCampaigns({
+          ...params,
+          filters: {
+            ...filters,
             entity__type: ENTITY_TYPE,
           },
         });
       },
-      list: (params: Parameters<typeof resolveSimulationCampaigns>[0]) =>
-        resolveSimulationCampaigns({
-          ...params,
-          filters: { entity__type: ENTITY_TYPE },
-        }),
       one: getSimulationCampaign,
       create: createSimulationCampaign,
       resolve: resolveSimulationByCampaignId,

--- a/src/entity-configuration/domain/simulation/memodel-circuit-simulation.ts
+++ b/src/entity-configuration/domain/simulation/memodel-circuit-simulation.ts
@@ -205,9 +205,11 @@ export const MEModelCircuitSimulation: EntityCoreTypeConfig<
           withFacets: params[0].withFacets,
           filters: {
             ...filters,
+            page: 1,
+            page_size: 1,
             entity__type: ENTITY_TYPE,
           },
-        });
+        }).then((response) => response.pagination.total_items);
       },
       list: (params: Parameters<typeof resolveSimulationCampaigns>[0]) =>
         resolveSimulationCampaigns(params),

--- a/src/entity-configuration/domain/simulation/microcircuit-simulation.ts
+++ b/src/entity-configuration/domain/simulation/microcircuit-simulation.ts
@@ -211,9 +211,11 @@ export const MicrocircuitSimulation: EntityCoreTypeConfig<
           withFacets: params[0].withFacets,
           filters: {
             ...filters,
+            page: 1,
+            page_size: 1,
             circuit__scale: SCALE,
           },
-        });
+        }).then((response) => response.pagination.total_items);
       },
       list: (params: Parameters<typeof resolveSimulationCampaigns>[0]) =>
         resolveSimulationCampaigns({

--- a/src/entity-configuration/domain/simulation/paired-neurons-simulation.ts
+++ b/src/entity-configuration/domain/simulation/paired-neurons-simulation.ts
@@ -184,9 +184,11 @@ export const PairedNeuronCircuitSimulation: EntityCoreTypeConfig<
           withFacets: params[0].withFacets,
           filters: {
             ...filters,
+            page: 1,
+            page_size: 1,
             circuit__scale: SCALE,
           },
-        });
+        }).then((response) => response.pagination.total_items);
       },
       list: (params: Parameters<typeof resolveSimulationCampaigns>[0]) =>
         resolveSimulationCampaigns({

--- a/src/entity-configuration/domain/simulation/simulation-campaign.ts
+++ b/src/entity-configuration/domain/simulation/simulation-campaign.ts
@@ -227,6 +227,19 @@ export const SimulationCampaign: EntityCoreTypeConfig<
       ilikeSearchEnabled: true,
     },
     query: {
+      count: (...params) => {
+        const filters = discardBrainRegionQueryParams(params[0].filters);
+        return getSimulationCampaigns({
+          ...params,
+          context: params[0].context,
+          withFacets: params[0].withFacets,
+          filters: {
+            ...filters,
+            page: 1,
+            page_size: 1,
+          },
+        }).then((response) => response.pagination.total_items);
+      },
       list: resolveSimulationCampaigns,
       one: getSimulationCampaign,
       resolve: resolveSimulationByCampaignId,

--- a/src/entity-configuration/domain/simulation/single-neuron-circuit-simulation.ts
+++ b/src/entity-configuration/domain/simulation/single-neuron-circuit-simulation.ts
@@ -185,9 +185,11 @@ export const SingeNeuronCircuitSimulation: EntityCoreTypeConfig<
           withFacets: params[0].withFacets,
           filters: {
             ...filters,
+            page: 1,
+            page_size: 1,
             circuit__scale: SCALE,
           },
-        });
+        }).then((response) => response.pagination.total_items);
       },
       list: (params: Parameters<typeof resolveSimulationCampaigns>[0]) =>
         resolveSimulationCampaigns({

--- a/src/entity-configuration/domain/simulation/single-neuron-simulation.ts
+++ b/src/entity-configuration/domain/simulation/single-neuron-simulation.ts
@@ -5,6 +5,7 @@ import {
   getSingleNeuronSimulationIOResult,
   getSingleNeuronSimulations,
 } from '@/api/entitycore/queries/simulation/single-neuron-simulation';
+import { discardBrainRegionQueryParams } from '@/api/entitycore/transformers';
 import { EntityTypeDict } from '@/api/entitycore/types/entity-type';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { AssetLabel } from '@/api/entitycore/types/shared/global';
@@ -46,6 +47,19 @@ export const SingleNeuronSimulation: EntityCoreTypeConfig<ISingleNeuronSimulatio
       ilikeSearchEnabled: true,
     },
     query: {
+      count: (...params) => {
+        const filters = discardBrainRegionQueryParams(params[0].filters);
+        return getSingleNeuronSimulations({
+          ...params,
+          context: params[0].context,
+          withFacets: params[0].withFacets,
+          filters: {
+            ...filters,
+            page: 1,
+            page_size: 1,
+          },
+        }).then((response) => response.pagination.total_items);
+      },
       list: getSingleNeuronSimulations,
       one: getSingleNeuronSimulation,
       create: createSingleNeuronSimulation,

--- a/src/entity-configuration/domain/simulation/single-neuron-synaptome-simulation.ts
+++ b/src/entity-configuration/domain/simulation/single-neuron-synaptome-simulation.ts
@@ -6,6 +6,7 @@ import {
   getSingleNeuronSynaptomeSimulationIOResult,
   getSingleNeuronSynaptomeSimulations,
 } from '@/api/entitycore/queries/simulation/single-neuron-synaptome-simulation';
+import { discardBrainRegionQueryParams } from '@/api/entitycore/transformers';
 import { EntityTypeDict } from '@/api/entitycore/types/entity-type';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { AssetLabel } from '@/api/entitycore/types/shared/global';
@@ -61,6 +62,19 @@ export const SingleNeuronSynaptomeSimulation: EntityCoreTypeConfig<ISingleNeuron
         ilikeSearchEnabled: true,
       },
       query: {
+        count: (...params) => {
+          const filters = discardBrainRegionQueryParams(params[0].filters);
+          return getSingleNeuronSynaptomeSimulations({
+            ...params,
+            context: params[0].context,
+            withFacets: params[0].withFacets,
+            filters: {
+              ...filters,
+              page: 1,
+              page_size: 1,
+            },
+          }).then((response) => response.pagination.total_items);
+        },
         list: getSingleNeuronSynaptomeSimulations,
         one: getSingleNeuronSynaptomeSimulation,
         create: createSingleNeuronSynaptomeSimulation,

--- a/src/entity-configuration/domain/simulation/small-microcircuit-simulation.ts
+++ b/src/entity-configuration/domain/simulation/small-microcircuit-simulation.ts
@@ -214,9 +214,11 @@ export const SmallMicrocircuitSimulation: EntityCoreTypeConfig<
           withFacets: params[0].withFacets,
           filters: {
             ...filters,
+            page: 1,
+            page_size: 1,
             circuit__scale: SCALE,
           },
-        });
+        }).then((response) => response.pagination.total_items);
       },
       list: (params: Parameters<typeof resolveSimulationCampaigns>[0]) =>
         resolveSimulationCampaigns({

--- a/src/entity-configuration/domain/types.ts
+++ b/src/entity-configuration/domain/types.ts
@@ -42,7 +42,7 @@ export type EntityCoreTypeConfig<
     };
     query: {
       list?: (query: any) => Promise<EntityCoreResponse<T> | L>;
-      count?: (query: any) => Promise<EntityCoreResponse<T> | L>;
+      count?: (query: any) => Promise<number>;
       one: (
         query: {
           id: string;

--- a/src/ui/segments/explore/browse-link.tsx
+++ b/src/ui/segments/explore/browse-link.tsx
@@ -26,6 +26,7 @@ import { HydrateWrapper } from '@/wrappers/hydrate-wrapper';
 
 import type { ReactNode } from 'react';
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { TWorkspaceScope } from '@/constants';
 import type { WorkspaceContext } from '@/types/common';
 
@@ -191,6 +192,19 @@ function buildQuery({
   return { query, queryKey };
 }
 
+async function resolveEntityCount({
+  query,
+  entity,
+}: {
+  query: ReturnType<typeof buildQuery>['query'];
+  entity: ReturnType<typeof getEntityByExtendedType>;
+}) {
+  if (!entity) return undefined;
+  if (entity.api.query.count) return entity.api.query.count(query);
+  const response = await entity.api.query.list?.(query);
+  return (response as EntityCoreResponse<unknown> | undefined)?.pagination?.total_items;
+}
+
 export function BrowseLink({
   scope,
   enabled,
@@ -243,12 +257,9 @@ export function BrowseLink({
     isLoading: loadingFallback,
     data: fallbackData,
     isError: isFallbackError,
-  } = useQuery<{ pagination: { total_items: number } } | undefined>({
+  } = useQuery<number | undefined>({
     queryKey: fallbackQuery.queryKey,
-    queryFn: async () => {
-      if (entity?.api.query.count) return entity.api.query.count(fallbackQuery.query);
-      return entity?.api.query.list?.(fallbackQuery.query);
-    },
+    queryFn: () => resolveEntityCount({ query: fallbackQuery.query, entity }),
     // fetch for inactive entities and as bootstrap for active entities without cached table count yet
     enabled: !!currentBrainRegionId && enabled,
     staleTime: Infinity,
@@ -258,27 +269,23 @@ export function BrowseLink({
     isLoading: loadingRoot,
     data: root,
     isError: isRootError,
-  } = useQuery<{ pagination: { total_items: number } } | undefined>({
+  } = useQuery<number | undefined>({
     queryKey: rootQuery.queryKey,
-    queryFn: async () => {
-      if (entity?.api.query.count) return entity.api.query.count(rootQuery.query);
-      return entity?.api.query.list?.(rootQuery.query);
-    },
+    queryFn: () => resolveEntityCount({ query: rootQuery.query, entity }),
     enabled: !!defaultBrainRegionId && enabled,
     staleTime: Infinity,
   });
 
   // resolve current count: prioritize table query when active, fallback otherwise
-  const count = isActiveEntity && hasCachedData ? tableCount : fallbackData?.pagination.total_items;
+  const count = isActiveEntity && hasCachedData ? tableCount : fallbackData;
   const loadingCurrent = isActiveEntity && hasCachedData ? tableCountLoading : loadingFallback;
   const isCurrentError = isActiveEntity && hasCachedData ? isTableCountError : isFallbackError;
-  const rootCount = root?.pagination.total_items;
   const isLoading = loadingCurrent || loadingRoot;
 
   const countRenderer = match({
     isCurrentError,
     count,
-    rootCount,
+    rootCount: root,
     isRootError,
     enabled,
     isLoading,
@@ -287,7 +294,7 @@ export function BrowseLink({
       <span className="flex items-center justify-center gap-1">
         <span className="font-bold">{count}</span>
         <span className="font-light">of</span>
-        <span className="font-bold">{rootCount}</span>
+        <span className="font-bold">{root}</span>
       </span>
     ))
     .with(P.union({ isCurrentError: true }, { isRootError: true }), () => {


### PR DESCRIPTION
- align EntityCoreTypeConfig count contract to return numbers
- update simulation count handlers and browse link fallback logic to consume numeric totals consistently across scopes