### PR TITLE
Handle calibration absence in ME-model

### DIFF
--- a/src/api/entitycore/types/entities/me-model.ts
+++ b/src/api/entitycore/types/entities/me-model.ts
@@ -60,7 +60,7 @@ export interface IMEModel
   etypes: Array<IEType> | null;
   morphology: ICellMorphology;
   emodel: IEModel;
-  calibration_result: {
+  calibration_result?: {
     rin: number;
   };
 }

--- a/src/features/model-analysis/explorer/use-input-resistance.tsx
+++ b/src/features/model-analysis/explorer/use-input-resistance.tsx
@@ -13,7 +13,7 @@ export function useInputResistance({ entity }: { entity: TRetrieveEntityOutput }
     queryKey: keyBuilder.meModel({ projectId, virtualLabId, entityId: entity.id }),
     queryFn: async () => {
       const model = await getMEModel({ context: { projectId, virtualLabId }, id: entity.id });
-      return model.calibration_result.rin;
+      return model.calibration_result?.rin;
     },
     enabled: entity.type === EntityTypeDict.Memodel,
   });


### PR DESCRIPTION
The `calibration_result` is normally registered with a short delay after an ME-model has been created, within that time window accessing `model.calibration_result.rin` throws an error due to `model.calibration_result` being `null`.

This change ensures the hook returns `RIN` as `undefined` while the calibration hasn't been registered.