### PR TITLE
(DO_NOT_MERGE) feat: support multi-reference types in scan-config block references

### DIFF
--- a/src/features/scan-config/components/hooks/schema.ts
+++ b/src/features/scan-config/components/hooks/schema.ts
@@ -353,13 +353,34 @@ export function resetConfig(
   setAtomsMap(map);
 }
 
+/**
+ * builds a lookup map from reference type names to the block dictionaries that hold them
+ *
+ * a block dictionary declares which reference types it supports via `reference_types` (a list)
+ * for example, the `neuron_sets` dictionary might declare:
+ *   reference_types: ["BiophysicalNeuronSetReference", "VirtualNeuronSetReference", "PointNeuronSetReference"]
+ *
+ * this produces a map like:
+ *   {
+ *     "BiophysicalNeuronSetReference": [{ configKey: "neuron_sets", singularName: "Neuron Set" }],
+ *     "VirtualNeuronSetReference":     [{ configKey: "neuron_sets", singularName: "Neuron Set" }],
+ *     "PointNeuronSetReference":       [{ configKey: "neuron_sets", singularName: "Neuron Set" }],
+ *     "TimestampsReference":           [{ configKey: "timestamps",  singularName: "Timestamps" }],
+ *     ...
+ *   }
+ *
+ * the value is an array because multiple dictionaries could support the same reference type
+ *
+ * this map is consumed by the Reference dropdown component to find which dictionaries
+ * to pull options from, given a field's accepted `reference_types`
+ */
 export function useReferenceTypeDict(schema: ConfigSchema) {
   const referenceTypeDict: Record<
     string,
-    {
+    Array<{
       configKey: string;
       singularName: string;
-    }
+    }>
   > = {};
 
   if (!schema) return referenceTypeDict;
@@ -368,11 +389,16 @@ export function useReferenceTypeDict(schema: ConfigSchema) {
     const v = schema.properties[k];
 
     if (v.ui_element === ScanConfigUIElementDict.BlockDictionary) {
-      const refType = v.reference_type;
-      referenceTypeDict[refType] = {
-        configKey: k,
-        singularName: v.singular_name,
-      };
+      const refTypes = v.reference_types;
+      for (const refType of refTypes) {
+        if (!referenceTypeDict[refType]) {
+          referenceTypeDict[refType] = [];
+        }
+        referenceTypeDict[refType].push({
+          configKey: k,
+          singularName: v.singular_name,
+        });
+      }
     }
   });
 

--- a/src/features/scan-config/components/ui-blocks/block.tsx
+++ b/src/features/scan-config/components/ui-blocks/block.tsx
@@ -94,7 +94,9 @@ export default function Block({
                 !isType(paramSchema) &&
                 !paramSchema.ui_hidden &&
                 (paramSchema.ui_element !== ScanConfigUIElementDict.Reference ||
-                  Boolean(schema.default_block_reference_labels?.[paramSchema.reference_type]))
+                  paramSchema.reference_types.some(
+                    (refType) => !!schema.default_block_reference_labels?.[refType]
+                  ))
             )
             .map(([k, blockElementSchema]) => {
               if (isType(blockElementSchema)) return null;

--- a/src/features/scan-config/components/ui-elements/entity-property-dropdown.tsx
+++ b/src/features/scan-config/components/ui-elements/entity-property-dropdown.tsx
@@ -11,20 +11,22 @@ export default function EntityPropertyDropdown({
   property,
   disabled = false,
   schemaMappingConfig,
+  multiple = true,
 }: {
-  value: string[];
-  onChange: (v: string[]) => void;
+  value: string | Array<string>;
+  onChange: (v: string | Array<string>) => void;
   property: string;
   disabled?: boolean;
   schemaMappingConfig: TSchemaMappingConfiguration | undefined;
+  multiple?: boolean;
 }) {
-  const options = get(schemaMappingConfig?.properties, property, []) as string[];
+  const options = get(schemaMappingConfig?.properties, property, []) as Array<string>;
 
   return (
     <Select
-      data-scan-config-block-element={ScanConfigUIElementDict.EntityPropertyDropdown}
+      data-scan-config-block-element={`${ScanConfigUIElementDict.EntityPropertyDropdown}__${multiple ? 'multiple' : 'singular'}`}
       showSearch
-      mode="multiple"
+      mode={multiple ? 'multiple' : undefined}
       disabled={disabled}
       className="w-full"
       value={value}

--- a/src/features/scan-config/components/ui-elements/index.tsx
+++ b/src/features/scan-config/components/ui-elements/index.tsx
@@ -194,24 +194,44 @@ export function UIElementRender({
         entity: P.nonNullable,
       },
       ({ paramSchema }) => {
-        const getValue = (): string[] => {
-          if (Array.isArray(value) && value.every((v) => typeof v === 'string')) {
-            return value;
-          }
-          if (typeof value === 'string') return [value];
-          return [];
-        };
+        // detect if the field supports multiple values by checking for anyOf with an array type
+        const isMultiple = 'anyOf' in paramSchema;
+
+        if (isMultiple) {
+          const getValue = (): Array<string> => {
+            if (Array.isArray(value) && value.every((v) => typeof v === 'string')) {
+              return value;
+            }
+            if (typeof value === 'string') return [value];
+            return [];
+          };
+
+          return (
+            <EntityPropertyDropdown
+              multiple
+              disabled={disabled}
+              schemaMappingConfig={schemaMappingConfig}
+              value={getValue()}
+              onChange={(newV: string | Array<string>) => setState({ ...state, [k]: newV })}
+              property={paramSchema.property}
+            />
+          );
+        }
+
+        // single-value mode (e.g. population field with type: "string")
+        const singleValue = typeof value === 'string' ? value : undefined;
 
         return (
           <EntityPropertyDropdown
-            schemaMappingConfig={schemaMappingConfig}
+            multiple={false}
             disabled={disabled}
-            value={getValue()}
-            onChange={(newV: string[]) =>
+            schemaMappingConfig={schemaMappingConfig}
+            value={singleValue ?? ''}
+            onChange={(newV: string | string[]) =>
               setState({
                 ...state,
                 // NOTE: this is requested by James for IT'IS collaboration
-                node_set: Array.isArray(newV) && newV.length === 1 ? newV[0] : newV,
+                [k]: Array.isArray(newV) && newV.length === 1 ? newV[0] : newV,
               })
             }
             property={paramSchema.property}

--- a/src/features/scan-config/components/ui-elements/reference.tsx
+++ b/src/features/scan-config/components/ui-elements/reference.tsx
@@ -11,6 +11,38 @@ import type { Config } from '@/features/scan-config/components/components';
 import type { ConfigSchema } from '@/features/scan-config/types';
 
 const DEFAULT_SENTINEL = '__default_as_null__';
+const ALLOWED_BLOCK_TYPES = 'allowed_block_types';
+
+/**
+ * collects the set of block variant type names that are allowed by this reference field
+ *
+ * each reference field has an `anyOf` array where each item (except `{ type: "null" }`)
+ * is a reference type schema that may carry an `allowed_block_types` list, e.g.:
+ *
+ *   { title: "BiophysicalNeuronSetReference", allowed_block_types: ["BiophysicalIDNeuronSet", "BiophysicalPopulationNeuronSet"] }
+ *   { title: "PointNeuronSetReference",       allowed_block_types: ["PointIDNeuronSet", "PointPopulationNeuronSet"] }
+ *
+ * we collect all allowed block types into a single set so the dropdown can filter entries
+ * if no `allowed_block_types` are found (older schema), returns null to skip filtering
+ */
+function collectAllowedBlockTypes(referenceSchema: ReferenceSchema): Set<string> | null {
+  const anyOfItems = referenceSchema.anyOf;
+  if (!anyOfItems || !Array.isArray(anyOfItems)) return null;
+
+  const allowed = new Set<string>();
+  let hasAny = false;
+
+  for (const item of anyOfItems) {
+    if (ALLOWED_BLOCK_TYPES in item && Array.isArray(item.allowed_block_types)) {
+      hasAny = true;
+      for (const blockType of item.allowed_block_types) {
+        allowed.add(blockType);
+      }
+    }
+  }
+
+  return hasAny ? allowed : null;
+}
 
 export default function Reference({
   value,
@@ -28,31 +60,62 @@ export default function Reference({
   disabled: boolean;
 }) {
   const referenceTypeDict = useReferenceTypeDict(schema);
-  const configOptions = referenceTypeDict[referenceSchema.reference_type] ?? {
-    singularName: '',
-    configKey: '',
-  };
 
-  if (
-    !schema ||
-    !schema.default_block_reference_labels ||
-    !schema.default_block_reference_labels[referenceSchema.reference_type]
-  )
-    return null;
+  // collect all matching dictionaries across all accepted reference types
+  const matchingDicts: { configKey: string; singularName: string }[] = [];
+  for (const refType of referenceSchema.reference_types) {
+    const entries = referenceTypeDict[refType] ?? [];
+    for (const entry of entries) {
+      if (!matchingDicts.some((d) => d.configKey === entry.configKey)) {
+        matchingDicts.push(entry);
+      }
+    }
+  }
 
-  const options: { label: string; value: string }[] = Object.keys(
-    config[configOptions.configKey] ?? {}
-  ).map((k) => ({
-    label: k,
-    value: k,
-  }));
+  // check visibility: at least one reference type must have a default label
+  const hasDefaultLabel = referenceSchema.reference_types.some(
+    (refType) => schema?.default_block_reference_labels?.[refType]
+  );
+
+  if (!schema || !hasDefaultLabel) return null;
+
+  // collect the set of allowed block variant types from the anyOf schemas
+  // e.g. for targeted_neuron_set: {"BiophysicalIDNeuronSet", "BiophysicalPopulationNeuronSet", "PointIDNeuronSet", "PointPopulationNeuronSet"}
+  // if null, the schema doesn't provide allowed_block_types — skip filtering (backward compat)
+  const allowedBlockTypes = collectAllowedBlockTypes(referenceSchema);
+
+  // build dropdown options from all matching dictionaries
+  const options: Array<{ label: string; value: string }> = [];
+  // use the first configKey as the default for onChange (backward compat)
+  const primaryConfigKey = matchingDicts[0]?.configKey ?? '';
+
+  for (const dict of matchingDicts) {
+    const entries = config[dict.configKey] ?? {};
+    for (const [k, v] of Object.entries(entries)) {
+      if (options.some((o) => o.value === k)) continue;
+
+      // if the schema provides allowed_block_types, filter entries by their block variant type
+      if (allowedBlockTypes && typeof v === 'object' && v !== null && 'type' in v) {
+        const entryType = v.type as string;
+        if (!allowedBlockTypes.has(entryType)) continue;
+      }
+
+      options.push({ label: k, value: k });
+    }
+  }
+
+  // find the first available default label across accepted reference types
+  const defaultLabel =
+    referenceSchema.reference_types
+      .map((refType) => schema.default_block_reference_labels?.[refType])
+      .find(Boolean) ?? 'Default';
 
   options.unshift({
-    label: schema.default_block_reference_labels[referenceSchema.reference_type] ?? 'Default',
+    label: defaultLabel,
     value: DEFAULT_SENTINEL,
   });
 
-  // if The AI suggested a value that is not in the options add it
+  // if the ai suggested a value that is not in the options, add it
   if (typeof value === 'string' && !options.map((o) => o.value).includes(value)) {
     options.push({
       label: value,
@@ -60,13 +123,27 @@ export default function Reference({
     });
   }
 
+  // when user selects a value, find which dictionary it belongs to
+  const findConfigKeyForValue = (selectedValue: string): string => {
+    for (const dict of matchingDicts) {
+      const entries = config[dict.configKey];
+      if (entries && typeof entries === 'object' && selectedValue in entries) {
+        return dict.configKey;
+      }
+    }
+    return primaryConfigKey;
+  };
+
   return (
     <Select
       data-scan-config-block-element={ScanConfigUIElementDict.Reference}
       className="w-full"
       disabled={disabled}
       onChange={(newV: string) =>
-        onChange(newV === DEFAULT_SENTINEL ? null : newV, configOptions.configKey)
+        onChange(
+          newV === DEFAULT_SENTINEL ? null : newV,
+          newV === DEFAULT_SENTINEL ? null : findConfigKeyForValue(newV)
+        )
       }
       value={value ?? DEFAULT_SENTINEL}
       options={options}

--- a/src/features/scan-config/types.ts
+++ b/src/features/scan-config/types.ts
@@ -223,7 +223,16 @@ export interface IntParameterSweep extends TBlockElement {
 
 export interface Reference extends TBlockElement {
   ui_element: typeof ScanConfigUIElementDict.Reference;
-  reference_type: string;
+  reference_types: Array<string>;
+  anyOf?: Array<
+    | {
+        title?: string;
+        allowed_block_types?: Array<string>;
+        properties?: { type?: { const?: string } };
+        [key: string]: unknown;
+      }
+    | { type: 'null' }
+  >;
 }
 
 export interface EntityPropertyDropdown extends TBlockElement {
@@ -374,10 +383,10 @@ export interface IBlockSingle extends TRootElement, TBlock {
 
 export interface IBlockDictionary extends TRootElement {
   ui_element: typeof ScanConfigUIElementDict.BlockDictionary;
-  reference_type: string;
+  reference_types: Array<string>;
   singular_name: string;
   additionalProperties: {
-    oneOf: TBlock[];
+    oneOf: Array<TBlock>;
   };
 }
 


### PR DESCRIPTION
- rename reference_type (string) to reference_types (Array<string>) in types
- update `useReferenceTypeDict` to build many-to-many lookup map
- rewrite `Reference` dropdown to collect options from all matching dictionaries
- fix `block.tsx` visibility gate to check any reference type has a default label
- skip fields without ui_element (e.g. population with type: null)
- fix `EntityPropertyDropdown` onChange writing to wrong key (node_set -> [k])
- add single-select mode to `EntityPropertyDropdown` for string-typed fields