### PR TITLE
Make UX for spike viewer consistent with the rest of plots

### DIFF
--- a/src/features/spike-viewer/components/raster-plot.tsx
+++ b/src/features/spike-viewer/components/raster-plot.tsx
@@ -71,7 +71,7 @@ export default function RasterPlot({ data }: RasterPlotProps) {
           ))
         )}
         <span className="ml-auto text-xs text-gray-400">
-          Scroll to zoom · Drag to pan · Double-click to reset
+          Drag to zoom · Shift+drag to pan · Double-click to reset
         </span>
       </div>
       <div ref={containerRef} className="min-h-0 flex-1" />

--- a/src/features/spike-viewer/renderer/axis-overlay.ts
+++ b/src/features/spike-viewer/renderer/axis-overlay.ts
@@ -62,7 +62,7 @@ export class AxisOverlay {
     const xTickCount = Math.max(2, Math.floor(plotRect.width / 80));
     const yTickCount = Math.max(2, Math.floor(plotRect.height / 30));
     const xTicks = computeTicks(bounds.xMin, bounds.xMax, xTickCount);
-    const yTicks = computeTicks(bounds.yMin, bounds.yMax, yTickCount, true);
+    const yTicks = computeTicks(bounds.yMin, bounds.yMax, yTickCount, true).filter((v) => v >= 0);
 
     ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
     ctx.save();

--- a/src/features/spike-viewer/renderer/axis-overlay.ts
+++ b/src/features/spike-viewer/renderer/axis-overlay.ts
@@ -14,8 +14,8 @@ export type PlotRect = {
 
 export const MARGIN = { top: 20, right: 20, bottom: 60, left: 70 };
 
-/** Compute nice tick values for an axis range. */
-function computeTicks(min: number, max: number, targetCount: number): number[] {
+/** Compute nice tick values for an axis range. When integer is true, step is constrained to an integer >= 1. */
+function computeTicks(min: number, max: number, targetCount: number, integer = false): number[] {
   const range = max - min;
   if (range <= 0) return [min];
 
@@ -28,6 +28,8 @@ function computeTicks(min: number, max: number, targetCount: number): number[] {
   else if (residual <= 3.5) niceStep = 2 * magnitude;
   else if (residual <= 7.5) niceStep = 5 * magnitude;
   else niceStep = 10 * magnitude;
+
+  if (integer) niceStep = Math.max(1, Math.round(niceStep));
 
   const ticks: number[] = [];
   const start = Math.ceil(min / niceStep) * niceStep;
@@ -57,8 +59,10 @@ export class AxisOverlay {
     const ctx = this.ctx;
     const dpr = window.devicePixelRatio || 1;
 
-    const xTicks = computeTicks(bounds.xMin, bounds.xMax, 6);
-    const yTicks = computeTicks(bounds.yMin, bounds.yMax, 6);
+    const xTickCount = Math.max(2, Math.floor(plotRect.width / 80));
+    const yTickCount = Math.max(2, Math.floor(plotRect.height / 30));
+    const xTicks = computeTicks(bounds.xMin, bounds.xMax, xTickCount);
+    const yTicks = computeTicks(bounds.yMin, bounds.yMax, yTickCount, true);
 
     ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
     ctx.save();

--- a/src/features/spike-viewer/renderer/interaction.ts
+++ b/src/features/spike-viewer/renderer/interaction.ts
@@ -1,7 +1,9 @@
+import { MARGIN } from '@/features/spike-viewer/renderer/axis-overlay';
+
 import type { PlotRect, ViewBounds } from '@/features/spike-viewer/renderer/axis-overlay';
 
-const ZOOM_FACTOR = 0.1;
 const MIN_RANGE = 1e-6;
+const MIN_DRAG_PX = 5;
 
 export type HoverInfo = {
   dataX: number;
@@ -10,28 +12,48 @@ export type HoverInfo = {
   pixelY: number;
 };
 
+type DragMode = 'pan' | 'zoom-x' | 'zoom-y' | 'zoom-xy';
+
+type DragState = {
+  mode: DragMode;
+  startClient: { x: number; y: number };
+  lastClient: { x: number; y: number };
+  pointerId: number;
+};
+
 export class InteractionManager {
   private view: ViewBounds = { xMin: 0, xMax: 1, yMin: 0, yMax: 1 };
   private initialView: ViewBounds = { xMin: 0, xMax: 1, yMin: 0, yMax: 1 };
   private plotRect: PlotRect = { x: 0, y: 0, width: 1, height: 1 };
   private element: HTMLElement;
+  private selectionEl: HTMLDivElement;
 
-  private isDragging = false;
-  private lastMouse: { x: number; y: number } | null = null;
+  private drag: DragState | null = null;
 
   onViewChange: ((bounds: ViewBounds) => void) | null = null;
   onHover: ((info: HoverInfo | null) => void) | null = null;
 
   constructor(element: HTMLElement) {
     this.element = element;
-    element.addEventListener('wheel', this.handleWheel, { passive: false });
     element.addEventListener('pointerdown', this.handlePointerDown);
     element.addEventListener('pointermove', this.handlePointerMove);
     element.addEventListener('pointerup', this.handlePointerUp);
+    element.addEventListener('pointercancel', this.handlePointerUp);
     element.addEventListener('pointerleave', this.handlePointerLeave);
     element.addEventListener('dblclick', this.handleDblClick);
     element.style.cursor = 'crosshair';
     element.style.touchAction = 'none';
+
+    this.selectionEl = document.createElement('div');
+    Object.assign(this.selectionEl.style, {
+      position: 'absolute',
+      pointerEvents: 'none',
+      display: 'none',
+      background: 'rgba(0, 132, 180, 0.2)',
+      border: '1px solid #0d76a8',
+      boxSizing: 'border-box',
+    } satisfies Partial<CSSStyleDeclaration>);
+    element.appendChild(this.selectionEl);
   }
 
   setInitialView(bounds: ViewBounds) {
@@ -43,93 +65,164 @@ export class InteractionManager {
     this.plotRect = rect;
   }
 
-  resetView() {
-    this.view = { ...this.initialView };
+  resetView(axis: 'x' | 'y' | 'both' = 'both') {
+    if (axis === 'x' || axis === 'both') {
+      this.view.xMin = this.initialView.xMin;
+      this.view.xMax = this.initialView.xMax;
+    }
+    if (axis === 'y' || axis === 'both') {
+      this.view.yMin = this.initialView.yMin;
+      this.view.yMax = this.initialView.yMax;
+    }
     this.onViewChange?.(this.view);
   }
 
-  private isInPlotArea(clientX: number, clientY: number): boolean {
+  private elementPoint(clientX: number, clientY: number): { x: number; y: number } {
     const rect = this.element.getBoundingClientRect();
-    const px = clientX - rect.left;
-    const py = clientY - rect.top;
+    return { x: clientX - rect.left, y: clientY - rect.top };
+  }
+
+  private isInPlotArea(clientX: number, clientY: number): boolean {
+    const { x: px, y: py } = this.elementPoint(clientX, clientY);
     const { x, y, width, height } = this.plotRect;
     return px >= x && px <= x + width && py >= y && py <= y + height;
   }
 
+  private isInXAxisArea(clientX: number, clientY: number): boolean {
+    const { x: px, y: py } = this.elementPoint(clientX, clientY);
+    const { x, y, width, height } = this.plotRect;
+    return px >= x && px <= x + width && py > y + height && py <= y + height + MARGIN.bottom;
+  }
+
+  private isInYAxisArea(clientX: number, clientY: number): boolean {
+    const { x: px, y: py } = this.elementPoint(clientX, clientY);
+    const { x, y, width: _w, height } = this.plotRect;
+    return px >= x - MARGIN.left && px < x && py >= y && py <= y + height;
+  }
+
   private pixelToData(clientX: number, clientY: number): { x: number; y: number } {
-    const rect = this.element.getBoundingClientRect();
-    const px = clientX - rect.left;
-    const py = clientY - rect.top;
+    const { x: px, y: py } = this.elementPoint(clientX, clientY);
     const { x, y, width, height } = this.plotRect;
     const normX = (px - x) / width;
-    const normY = 1 - (py - y) / height; // Flip Y: pixel Y goes down, data Y goes up
+    const normY = 1 - (py - y) / height;
     return {
       x: this.view.xMin + normX * (this.view.xMax - this.view.xMin),
       y: this.view.yMin + normY * (this.view.yMax - this.view.yMin),
     };
   }
 
-  private readonly handleWheel = (e: WheelEvent) => {
-    e.preventDefault();
-    if (!this.isInPlotArea(e.clientX, e.clientY)) return;
+  private clamp(value: number, min: number, max: number): number {
+    return Math.max(min, Math.min(max, value));
+  }
 
-    const direction = e.deltaY > 0 ? 1 : -1;
-    const factor = 1 + ZOOM_FACTOR * direction;
-    const cursor = this.pixelToData(e.clientX, e.clientY);
+  private updateSelectionRect() {
+    if (!this.drag || this.drag.mode === 'pan') {
+      this.selectionEl.style.display = 'none';
+      return;
+    }
 
-    const xRange = this.view.xMax - this.view.xMin;
-    const yRange = this.view.yMax - this.view.yMin;
+    const start = this.elementPoint(this.drag.startClient.x, this.drag.startClient.y);
+    const cur = this.elementPoint(this.drag.lastClient.x, this.drag.lastClient.y);
+    const { x, y, width, height } = this.plotRect;
 
-    // Zoom centered on cursor position
-    const xRatio = (cursor.x - this.view.xMin) / xRange;
-    const yRatio = (cursor.y - this.view.yMin) / yRange;
+    let left: number;
+    let top: number;
+    let w: number;
+    let h: number;
 
-    const newXRange = Math.max(MIN_RANGE, xRange * factor);
-    const newYRange = Math.max(MIN_RANGE, yRange * factor);
+    if (this.drag.mode === 'zoom-x') {
+      const x1 = this.clamp(start.x, x, x + width);
+      const x2 = this.clamp(cur.x, x, x + width);
+      left = Math.min(x1, x2);
+      w = Math.abs(x2 - x1);
+      top = y;
+      h = height;
+    } else if (this.drag.mode === 'zoom-y') {
+      const y1 = this.clamp(start.y, y, y + height);
+      const y2 = this.clamp(cur.y, y, y + height);
+      top = Math.min(y1, y2);
+      h = Math.abs(y2 - y1);
+      left = x;
+      w = width;
+    } else {
+      const x1 = this.clamp(start.x, x, x + width);
+      const x2 = this.clamp(cur.x, x, x + width);
+      const y1 = this.clamp(start.y, y, y + height);
+      const y2 = this.clamp(cur.y, y, y + height);
+      left = Math.min(x1, x2);
+      top = Math.min(y1, y2);
+      w = Math.abs(x2 - x1);
+      h = Math.abs(y2 - y1);
+    }
 
-    this.view = {
-      xMin: cursor.x - xRatio * newXRange,
-      xMax: cursor.x + (1 - xRatio) * newXRange,
-      yMin: cursor.y - yRatio * newYRange,
-      yMax: cursor.y + (1 - yRatio) * newYRange,
-    };
+    this.selectionEl.style.left = `${left}px`;
+    this.selectionEl.style.top = `${top}px`;
+    this.selectionEl.style.width = `${w}px`;
+    this.selectionEl.style.height = `${h}px`;
+    this.selectionEl.style.display = 'block';
+  }
 
-    this.clampView();
-    this.onViewChange?.(this.view);
-  };
+  private cursorForRegion(clientX: number, clientY: number, shiftKey: boolean): string {
+    if (this.isInPlotArea(clientX, clientY)) return shiftKey ? 'grab' : 'crosshair';
+    if (this.isInXAxisArea(clientX, clientY)) return 'col-resize';
+    if (this.isInYAxisArea(clientX, clientY)) return 'row-resize';
+    return 'default';
+  }
 
   private readonly handlePointerDown = (e: PointerEvent) => {
     if (e.button !== 0) return;
-    if (!this.isInPlotArea(e.clientX, e.clientY)) return;
 
-    this.isDragging = true;
+    let mode: DragMode | null = null;
+    if (this.isInPlotArea(e.clientX, e.clientY)) {
+      mode = e.shiftKey ? 'pan' : 'zoom-xy';
+    } else if (this.isInXAxisArea(e.clientX, e.clientY)) {
+      mode = 'zoom-x';
+    } else if (this.isInYAxisArea(e.clientX, e.clientY)) {
+      mode = 'zoom-y';
+    }
+    if (!mode) return;
+
+    e.preventDefault();
+    this.drag = {
+      mode,
+      startClient: { x: e.clientX, y: e.clientY },
+      lastClient: { x: e.clientX, y: e.clientY },
+      pointerId: e.pointerId,
+    };
     this.onHover?.(null);
-    this.lastMouse = { x: e.clientX, y: e.clientY };
     this.element.setPointerCapture(e.pointerId);
-    this.element.style.cursor = 'grabbing';
+    this.element.style.cursor = mode === 'pan' ? 'grabbing' : 'crosshair';
   };
 
   private readonly handlePointerMove = (e: PointerEvent) => {
-    if (this.isDragging && this.lastMouse) {
-      const dx = e.clientX - this.lastMouse.x;
-      const dy = e.clientY - this.lastMouse.y;
-      this.lastMouse = { x: e.clientX, y: e.clientY };
+    if (this.drag) {
+      const dx = e.clientX - this.drag.lastClient.x;
+      const dy = e.clientY - this.drag.lastClient.y;
+      this.drag.lastClient = { x: e.clientX, y: e.clientY };
 
-      const xRange = this.view.xMax - this.view.xMin;
-      const yRange = this.view.yMax - this.view.yMin;
-      const dataX = -(dx / this.plotRect.width) * xRange;
-      const dataY = (dy / this.plotRect.height) * yRange; // Flip Y
+      if (this.drag.mode === 'pan') {
+        const xRange = this.view.xMax - this.view.xMin;
+        const yRange = this.view.yMax - this.view.yMin;
+        const dataX = -(dx / this.plotRect.width) * xRange;
+        const dataY = (dy / this.plotRect.height) * yRange;
 
-      this.view = {
-        xMin: this.view.xMin + dataX,
-        xMax: this.view.xMax + dataX,
-        yMin: this.view.yMin + dataY,
-        yMax: this.view.yMax + dataY,
-      };
+        this.view = {
+          xMin: this.view.xMin + dataX,
+          xMax: this.view.xMax + dataX,
+          yMin: this.view.yMin + dataY,
+          yMax: this.view.yMax + dataY,
+        };
+        this.clampView();
+        this.onViewChange?.(this.view);
+      } else {
+        this.updateSelectionRect();
+      }
+      return;
+    }
 
-      this.clampView();
-      this.onViewChange?.(this.view);
-    } else if (this.isInPlotArea(e.clientX, e.clientY)) {
+    this.element.style.cursor = this.cursorForRegion(e.clientX, e.clientY, e.shiftKey);
+
+    if (this.isInPlotArea(e.clientX, e.clientY)) {
       const rect = this.element.getBoundingClientRect();
       const data = this.pixelToData(e.clientX, e.clientY);
       this.onHover?.({
@@ -144,28 +237,72 @@ export class InteractionManager {
   };
 
   private readonly handlePointerUp = (e: PointerEvent) => {
-    if (this.isDragging) {
-      this.isDragging = false;
-      this.lastMouse = null;
+    if (!this.drag || this.drag.pointerId !== e.pointerId) return;
+
+    const drag = this.drag;
+    this.drag = null;
+    if (this.element.hasPointerCapture(e.pointerId)) {
       this.element.releasePointerCapture(e.pointerId);
-      this.element.style.cursor = 'crosshair';
     }
+    this.element.style.cursor = this.cursorForRegion(e.clientX, e.clientY, e.shiftKey);
+
+    if (drag.mode === 'pan') return;
+
+    this.selectionEl.style.display = 'none';
+
+    const dx = Math.abs(drag.lastClient.x - drag.startClient.x);
+    const dy = Math.abs(drag.lastClient.y - drag.startClient.y);
+    const significant =
+      drag.mode === 'zoom-x'
+        ? dx >= MIN_DRAG_PX
+        : drag.mode === 'zoom-y'
+          ? dy >= MIN_DRAG_PX
+          : dx >= MIN_DRAG_PX || dy >= MIN_DRAG_PX;
+    if (!significant) return;
+
+    const d1 = this.pixelToData(drag.startClient.x, drag.startClient.y);
+    const d2 = this.pixelToData(drag.lastClient.x, drag.lastClient.y);
+    const next: ViewBounds = { ...this.view };
+
+    if (drag.mode === 'zoom-x' || drag.mode === 'zoom-xy') {
+      const xMin = Math.min(d1.x, d2.x);
+      const xMax = Math.max(d1.x, d2.x);
+      if (xMax - xMin >= MIN_RANGE) {
+        next.xMin = xMin;
+        next.xMax = xMax;
+      }
+    }
+    if (drag.mode === 'zoom-y' || drag.mode === 'zoom-xy') {
+      const yMin = Math.min(d1.y, d2.y);
+      const yMax = Math.max(d1.y, d2.y);
+      if (yMax - yMin >= MIN_RANGE) {
+        next.yMin = yMin;
+        next.yMax = yMax;
+      }
+    }
+
+    this.view = next;
+    this.clampView();
+    this.onViewChange?.(this.view);
   };
 
   private readonly handlePointerLeave = () => {
-    this.onHover?.(null);
+    if (!this.drag) this.onHover?.(null);
   };
 
   private readonly handleDblClick = (e: MouseEvent) => {
     if (this.isInPlotArea(e.clientX, e.clientY)) {
-      this.resetView();
+      this.resetView('both');
+    } else if (this.isInXAxisArea(e.clientX, e.clientY)) {
+      this.resetView('x');
+    } else if (this.isInYAxisArea(e.clientX, e.clientY)) {
+      this.resetView('y');
     }
   };
 
   private clampView() {
     const iv = this.initialView;
 
-    // X axis
     const xRange = this.view.xMax - this.view.xMin;
     const xDataRange = iv.xMax - iv.xMin;
     if (xRange >= xDataRange) {
@@ -182,7 +319,6 @@ export class InteractionManager {
       }
     }
 
-    // Y axis
     const yRange = this.view.yMax - this.view.yMin;
     const yDataRange = iv.yMax - iv.yMin;
     if (yRange >= yDataRange) {
@@ -202,11 +338,14 @@ export class InteractionManager {
 
   destroy() {
     const el = this.element;
-    el.removeEventListener('wheel', this.handleWheel);
     el.removeEventListener('pointerdown', this.handlePointerDown);
     el.removeEventListener('pointermove', this.handlePointerMove);
     el.removeEventListener('pointerup', this.handlePointerUp);
+    el.removeEventListener('pointercancel', this.handlePointerUp);
     el.removeEventListener('pointerleave', this.handlePointerLeave);
     el.removeEventListener('dblclick', this.handleDblClick);
+    if (this.selectionEl.parentElement === el) {
+      el.removeChild(this.selectionEl);
+    }
   }
 }

--- a/src/features/spike-viewer/renderer/interaction.ts
+++ b/src/features/spike-viewer/renderer/interaction.ts
@@ -26,6 +26,7 @@ export class InteractionManager {
   private initialView: ViewBounds = { xMin: 0, xMax: 1, yMin: 0, yMax: 1 };
   private plotRect: PlotRect = { x: 0, y: 0, width: 1, height: 1 };
   private element: HTMLElement;
+  private selectionMask: HTMLDivElement;
   private selectionEl: HTMLDivElement;
 
   private drag: DragState | null = null;
@@ -44,16 +45,28 @@ export class InteractionManager {
     element.style.cursor = 'crosshair';
     element.style.touchAction = 'none';
 
+    // Wrapping mask clips the selection's huge box-shadow to the plot area,
+    // so the dim overlay covers only the chart and not the axis labels.
+    this.selectionMask = document.createElement('div');
+    Object.assign(this.selectionMask.style, {
+      position: 'absolute',
+      pointerEvents: 'none',
+      overflow: 'hidden',
+      opacity: '0',
+      transition: 'opacity 300ms ease-out',
+    } satisfies Partial<CSSStyleDeclaration>);
+
     this.selectionEl = document.createElement('div');
     Object.assign(this.selectionEl.style, {
       position: 'absolute',
       pointerEvents: 'none',
-      display: 'none',
-      background: 'rgba(0, 132, 180, 0.2)',
-      border: '1px solid #0d76a8',
+      border: '1px solid #eee',
       boxSizing: 'border-box',
+      boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.4)',
     } satisfies Partial<CSSStyleDeclaration>);
-    element.appendChild(this.selectionEl);
+
+    this.selectionMask.appendChild(this.selectionEl);
+    element.appendChild(this.selectionMask);
   }
 
   setInitialView(bounds: ViewBounds) {
@@ -117,7 +130,7 @@ export class InteractionManager {
 
   private updateSelectionRect() {
     if (!this.drag || this.drag.mode === 'pan') {
-      this.selectionEl.style.display = 'none';
+      this.selectionMask.style.opacity = '0';
       return;
     }
 
@@ -155,11 +168,16 @@ export class InteractionManager {
       h = Math.abs(y2 - y1);
     }
 
-    this.selectionEl.style.left = `${left}px`;
-    this.selectionEl.style.top = `${top}px`;
+    this.selectionMask.style.left = `${x}px`;
+    this.selectionMask.style.top = `${y}px`;
+    this.selectionMask.style.width = `${width}px`;
+    this.selectionMask.style.height = `${height}px`;
+    this.selectionMask.style.opacity = '1';
+
+    this.selectionEl.style.left = `${left - x}px`;
+    this.selectionEl.style.top = `${top - y}px`;
     this.selectionEl.style.width = `${w}px`;
     this.selectionEl.style.height = `${h}px`;
-    this.selectionEl.style.display = 'block';
   }
 
   private cursorForRegion(clientX: number, clientY: number, shiftKey: boolean): string {
@@ -248,7 +266,7 @@ export class InteractionManager {
 
     if (drag.mode === 'pan') return;
 
-    this.selectionEl.style.display = 'none';
+    this.selectionMask.style.opacity = '0';
 
     const dx = Math.abs(drag.lastClient.x - drag.startClient.x);
     const dy = Math.abs(drag.lastClient.y - drag.startClient.y);
@@ -344,8 +362,8 @@ export class InteractionManager {
     el.removeEventListener('pointercancel', this.handlePointerUp);
     el.removeEventListener('pointerleave', this.handlePointerLeave);
     el.removeEventListener('dblclick', this.handleDblClick);
-    if (this.selectionEl.parentElement === el) {
-      el.removeChild(this.selectionEl);
+    if (this.selectionMask.parentElement === el) {
+      el.removeChild(this.selectionMask);
     }
   }
 }

--- a/src/features/spike-viewer/renderer/raster-renderer.ts
+++ b/src/features/spike-viewer/renderer/raster-renderer.ts
@@ -166,7 +166,7 @@ export class RasterRenderer {
     // Density-aware base: large for sparse data, small for dense
     const visibleArea = this.plotRect.width * this.plotRect.height;
     const density = this.visibleSpikes / Math.max(1, visibleArea);
-    const baseSize = Math.min(6, Math.max(2, 4 - Math.log10(Math.max(1e-4, density))));
+    const baseSize = Math.min(9, Math.max(4, 6 - Math.log10(Math.max(1e-4, density))));
 
     // Zoom scaling: grows as user zooms in
     const xZoom =
@@ -176,7 +176,7 @@ export class RasterRenderer {
     const zoom = Math.min(xZoom, yZoom);
     const zoomBonus = Math.log2(Math.max(1, zoom));
 
-    return Math.min(12, baseSize + zoomBonus);
+    return Math.min(14, baseSize + zoomBonus);
   }
 
   private handleHover(info: HoverInfo | null) {

--- a/src/features/spike-viewer/renderer/raster-renderer.ts
+++ b/src/features/spike-viewer/renderer/raster-renderer.ts
@@ -163,20 +163,17 @@ export class RasterRenderer {
   }
 
   private computePointSize(): number {
-    // Density-aware base: large for sparse data, small for dense
-    const visibleArea = this.plotRect.width * this.plotRect.height;
-    const density = this.visibleSpikes / Math.max(1, visibleArea);
-    const baseSize = Math.min(9, Math.max(4, 6 - Math.log10(Math.max(1e-4, density))));
+    const baseSize = 8;
+    const factor = countFactor(this.visibleSpikes);
 
     // Zoom scaling: grows as user zooms in
     const xZoom =
       (this.initialView.xMax - this.initialView.xMin) / (this.view.xMax - this.view.xMin);
     const yZoom =
       (this.initialView.yMax - this.initialView.yMin) / (this.view.yMax - this.view.yMin);
-    const zoom = Math.min(xZoom, yZoom);
-    const zoomBonus = Math.log2(Math.max(1, zoom));
+    const zoomBonus = Math.log2(Math.max(1, Math.min(xZoom, yZoom)));
 
-    return Math.min(14, baseSize + zoomBonus);
+    return Math.min(14, baseSize * factor + zoomBonus);
   }
 
   private handleHover(info: HoverInfo | null) {
@@ -310,6 +307,21 @@ export class RasterRenderer {
     this.interactionLayer.remove();
     this.tooltipEl.remove();
   }
+}
+
+/**
+ * Multiplier that shrinks point size as the dataset grows. 1.0 below 1k spikes,
+ * 0.5 at/above 100k, smoothly interpolated in log-space between — count spans
+ * orders of magnitude, so log-space puts the visible transition where users
+ * actually feel it (1k → 10k → 100k) rather than compressed near the cap.
+ */
+function countFactor(n: number): number {
+  const lo = 1_000;
+  const hi = 100_000;
+  if (n <= lo) return 1.0;
+  if (n >= hi) return 0.5;
+  const t = Math.log10(n / lo) / Math.log10(hi / lo);
+  return 1.0 - 0.5 * t;
 }
 
 /** Sort timestamps and nodeIds arrays together by timestamp (ascending). */

--- a/src/features/spike-viewer/renderer/webgl-points.ts
+++ b/src/features/spike-viewer/renderer/webgl-points.ts
@@ -4,7 +4,7 @@ const VERTEX_SHADER = `#version 300 es
 layout(location = 0) in float a_x;
 layout(location = 1) in float a_y;
 uniform vec4 u_bounds; // xMin, yMin, xMax, yMax
-uniform float u_pointSize;
+uniform mediump float u_pointSize;
 
 void main() {
   float x = 2.0 * (a_x - u_bounds.x) / (u_bounds.z - u_bounds.x) - 1.0;
@@ -16,13 +16,21 @@ void main() {
 const FRAGMENT_SHADER = `#version 300 es
 precision mediump float;
 uniform vec4 u_color;
+uniform float u_pointSize;
 out vec4 fragColor;
 
 void main() {
-  // Vertical tick mark: only draw the center strip
+  // Vertical tick mark with soft edges (~1 px wide on every side) so
+  // subpixel jitter shows as an opacity falloff instead of a ±1 px
+  // step in width or height.
+  float feather = 1.0 / max(u_pointSize, 1.0);
   float dx = abs(gl_PointCoord.x - 0.5);
-  if (dx > 0.2) discard;
-  fragColor = u_color;
+  float dy = abs(gl_PointCoord.y - 0.5);
+  float alphaX = 1.0 - smoothstep(0.2 - feather, 0.2 + feather, dx);
+  float alphaY = 1.0 - smoothstep(0.5 - feather, 0.5, dy);
+  float alpha = alphaX * alphaY;
+  if (alpha <= 0.001) discard;
+  fragColor = vec4(u_color.rgb, u_color.a * alpha);
 }`;
 
 type PopulationBuffer = {
@@ -91,7 +99,7 @@ export class WebGLPoints {
     // biome-ignore lint/correctness/useHookAtTopLevel: WebGL API, not a React hook
     gl.useProgram(this.program);
     gl.uniform4f(this.uBounds, bounds.xMin, bounds.yMin, bounds.xMax, bounds.yMax);
-    gl.uniform1f(this.uPointSize, pointSize * (window.devicePixelRatio || 1));
+    gl.uniform1f(this.uPointSize, Math.round(pointSize * (window.devicePixelRatio || 1)));
 
     for (const pop of this.populations) {
       if (!pop.visible || pop.count === 0) continue;

--- a/src/features/spike-viewer/renderer/webgl-points.ts
+++ b/src/features/spike-viewer/renderer/webgl-points.ts
@@ -20,13 +20,15 @@ uniform float u_pointSize;
 out vec4 fragColor;
 
 void main() {
-  // Vertical tick mark with soft edges (~1 px wide on every side) so
-  // subpixel jitter shows as an opacity falloff instead of a ±1 px
-  // step in width or height.
+  // Vertical tick: solid core with ~1 px outer feather so subpixel
+  // jitter shows as opacity falloff at the edge instead of a ±1 px
+  // size step. Keeping the feather *outside* the core preserves a
+  // fully opaque body so dense overlapping ticks read as solid colour
+  // rather than accumulating a translucent haze.
   float feather = 1.0 / max(u_pointSize, 1.0);
   float dx = abs(gl_PointCoord.x - 0.5);
   float dy = abs(gl_PointCoord.y - 0.5);
-  float alphaX = 1.0 - smoothstep(0.2 - feather, 0.2 + feather, dx);
+  float alphaX = 1.0 - smoothstep(0.2, 0.2 + feather, dx);
   float alphaY = 1.0 - smoothstep(0.5 - feather, 0.5, dy);
   float alpha = alphaX * alphaY;
   if (alpha <= 0.001) discard;
@@ -135,7 +137,11 @@ export class WebGLPoints {
     this.uColor = glRequire(gl.getUniformLocation(this.program, 'u_color'), 'u_color');
     this.uPointSize = glRequire(gl.getUniformLocation(this.program, 'u_pointSize'), 'u_pointSize');
     gl.enable(gl.BLEND);
-    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    // Separate blend for color vs alpha: standard "over" for colour, but
+    // accumulate destination alpha toward 1.0 so the canvas stays opaque
+    // in dense regions. Without this, overlapping feathered edges keep
+    // dst.a < 1 and the browser composites pale blue over the white page.
+    gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
   }
 
   private initBuffers(populations: SpikePopulation[], colors: string[]) {


### PR DESCRIPTION
## Summary

Aligns the spike-viewer raster plot's interaction model with the Plotly charts used elsewhere in the app, makes the Y-axis tick rendering more appropriate for neuron IDs, fixes inconsistent spike tick sizes caused by subpixel rasterization, and tunes point sizing + selection visuals.

## Interaction changes (`interaction.ts`, `raster-plot.tsx`)

Replaces the divergent gestures (scroll-zoom + drag-to-pan) with Plotly defaults:

- **Drag inside plot** → box-zoom (5px threshold).
- **Shift+drag inside plot** → pan.
- **Drag in x-tick band** → x-only zoom; **drag in y-tick band** → y-only zoom.
- **Scroll wheel** → no longer zooms.
- **Double-click** → resets axes: on plot resets both, on a single axis resets only that axis.
- Cursor reflects the region/modifier (`crosshair` / `grab` / `col-resize` / `row-resize`).
- Help text updated to `Drag to zoom · Shift+drag to pan · Double-click to reset`.

The selection rectangle is rendered as a DOM overlay: the active drag region shows as a light-bordered rect while everything outside is dimmed via a large `box-shadow` clipped by a wrapping mask (so axis labels stay legible). Opacity fades in/out (300ms) to avoid a hard pop on click. The WebGL/canvas render path is untouched.

## Axis changes (`axis-overlay.ts`)

- Y-axis labels are integers — `computeTicks` accepts an `integer` flag that floors the step to `Math.max(1, round(step))`, preventing fractional Neuron IDs and duplicate-rounded labels.
- Y-axis filters out negative ticks — neuron IDs are non-negative, so negative gridlines/labels would never be meaningful.
- Tick counts are dynamic from `plotRect`: ~80px per tick on X, ~30px per tick on Y (min 2). Larger viewports surface more IDs without crowding small ones.

## Point-size consistency fix (`webgl-points.ts`, `raster-renderer.ts`)

Spike ticks were rendering at visibly different widths/heights because `gl_POINTS` rasterization is sensitive to subpixel position and the fragment shader used a hard `discard` cutoff.

- `gl_PointSize` is rounded to an integer before being passed to the GPU, eliminating size jitter from fractional sizing.
- Fragment shader replaces the hard cutoff with a `smoothstep` alpha falloff. The feather sits *outside* the solid core (`smoothstep(0.2, 0.2 + feather, dx)`) so the body stays fully opaque and dense overlapping ticks read as solid colour rather than accumulating a translucent haze.
- Blend func switched to `blendFuncSeparate` so destination alpha accumulates toward 1.0 in dense regions — fixes pale-blue compositing over the white page when feathered edges overlap.
- `u_pointSize` uniform is qualified `mediump` in the vertex shader to match the fragment shader's precision.

## Dynamic point sizing (`raster-renderer.ts`)

`computePointSize` now multiplies a fixed `baseSize = 8` by a count-based factor and adds the existing zoom bonus, capped at 14 px. The factor scales the dot size down as the dataset grows so dense rasters stay readable while sparse ones get bigger ticks:

- 1.0× at ≤ 1k spikes → 0.5× at ≥ 100k spikes, log-interpolated between (count spans orders of magnitude, so log-space puts the visible transition where users feel it).
- Recalculates on population toggle — hiding a dense population enlarges the remaining ticks.

## Test plan

- [x] Drag inside plot draws rectangle with dimmed surround; release zooms; <5px drag does nothing.
- [x] Drag in x-tick band zooms X only; drag in y-tick band zooms Y only.
- [x] Shift+drag pans; scroll over plot does not zoom.
- [x] Double-click on plot resets both axes; on x-axis resets X only; on y-axis resets Y only.
- [x] Hover tooltip still works when not dragging.
- [x] Y-axis labels are non-negative integers at all zoom levels; tick density scales with window size.
- [x] Cross-check gestures against another Plotly chart (e.g. ephys-viewer) — feel matches.
- [x] Spike ticks render at uniform width/height across the plot at multiple zoom levels.
- [x] Dot size visibly shrinks for >100k-spike populations and grows for sparse ones; toggling a dense population off enlarges the rest.