### PR TITLE
Make project Costs page accessible for project members

### DIFF
--- a/src/app/app/virtual-lab/[virtualLabId]/[projectId]/(home)/credits/page.tsx
+++ b/src/app/app/virtual-lab/[virtualLabId]/[projectId]/(home)/credits/page.tsx
@@ -53,12 +53,8 @@ export default async function CreditsPage({
       queryFn: getUserGroups,
     });
 
-    const { isVirtualLabAdmin: isAdmin, isProjectAdmin } = makeRoles(
-      result,
-      virtualLabId,
-      projectId
-    );
-    if (!isAdmin && !isProjectAdmin) {
+    const { isProjectMember } = makeRoles(result, virtualLabId, projectId);
+    if (!isProjectMember) {
       throw new Error('User not allowed to access this page');
     }
   } catch {

--- a/src/ui/segments/project/balance.tsx
+++ b/src/ui/segments/project/balance.tsx
@@ -1,12 +1,10 @@
 import { WarningOutlined } from '@ant-design/icons';
-import { useQueries } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 import { match, P } from 'ts-pattern';
 
-import { getUserGroups } from '@/api/virtual-lab-svc/queries/user';
 import { CoinsIcon } from '@/components/icons/buttons';
 import { config } from '@/config';
-import { makeRoles } from '@/hooks/use-user-membership';
 import { getProjectAccountBalance } from '@/services/virtual-lab/projects';
 import { useDefaultBreakpoint } from '@/ui/hooks/create-break-point';
 import { useWorkspace } from '@/ui/hooks/use-workspace';
@@ -14,42 +12,27 @@ import { Badge } from '@/ui/molecules/badge';
 import { Skeleton } from '@/ui/molecules/skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/molecules/tooltip';
 import { keyBuilder } from '@/ui/use-query-keys/workspace';
-import { cn } from '@/utils/css-class';
 
-import type { VlmUserGroupsResponse } from '@/api/virtual-lab-svc/queries/types';
 import type { ProjectBalance } from '@/types/accounting';
 
 export function Wallet() {
   const breakpoint = useDefaultBreakpoint();
   const { virtualLabId, projectId } = useWorkspace();
-  const [{ data, isLoading, isError, isSuccess, error }, { data: roles, isLoading: loadingRoles }] =
-    useQueries({
-      queries: [
-        {
-          queryKey: keyBuilder.wallet({ virtualLabId, projectId }),
-          queryFn: () => getProjectAccountBalance({ virtualLabId, projectId }),
-          select: (res: ProjectBalance) => res.balance,
-        },
-        {
-          queryKey: keyBuilder.membership(),
-          queryFn: getUserGroups,
-          select: (res: VlmUserGroupsResponse) => makeRoles(res, virtualLabId, projectId),
-        },
-      ],
-    });
-
-  const isAdmin = roles?.isVirtualLabAdmin || roles?.isProjectAdmin;
+  const { data, isLoading, isError, isSuccess, error } = useQuery({
+    queryKey: keyBuilder.wallet({ virtualLabId, projectId }),
+    queryFn: () => getProjectAccountBalance({ virtualLabId, projectId }),
+    select: (res: ProjectBalance) => res.balance,
+  });
 
   const content = match({
     isError,
     isLoading,
-    loadingRoles,
     isSuccess,
     data,
     error,
   })
     .with(
-      P.when((s) => s.isLoading || s.loadingRoles),
+      P.when((s) => s.isLoading),
       () => <Skeleton className="h-5 w-14 rounded-full" />
     )
     .with({ isError: true, error: P.select() }, (err) => (
@@ -72,16 +55,10 @@ export function Wallet() {
           asChild
           rounded
           id="workspace-project-credits"
-          className={cn(
-            'min-w-16 font-bold bg-background select-none hover:shadow-sm hover:bg-background',
-            {
-              'cursor-not-allowed': !isAdmin,
-              'cursor-pointer': isAdmin,
-            }
-          )}
+          className="min-w-16 font-bold bg-background select-none hover:shadow-sm hover:bg-background"
           variant="outline"
           size={breakpoint === 'xl' ? 'lg' : 'md'}
-          aria-disabled={!isAdmin || loadingRoles || isLoading || isError}
+          aria-disabled={isLoading || isError}
         >
           <Link
             prefetch

--- a/src/ui/segments/project/credits/balance-card.tsx
+++ b/src/ui/segments/project/credits/balance-card.tsx
@@ -1,4 +1,4 @@
-import { SwapOutlined } from '@ant-design/icons';
+import { SwapOutlined, WarningOutlined } from '@ant-design/icons';
 import { useQuery } from '@tanstack/react-query';
 
 import { useWorkspaceMembership } from '@/hooks/use-user-membership';
@@ -6,7 +6,9 @@ import { getVirtualLabAccountBalance } from '@/services/virtual-lab/labs';
 import { useWorkspace } from '@/ui/hooks/use-workspace';
 import { Button } from '@/ui/molecules/button';
 import { Card, CardContent } from '@/ui/molecules/card';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/molecules/tooltip';
 import { keyBuilder } from '@/ui/use-query-keys/workspace';
+import { cn } from '@/utils/css-class';
 
 type Props = {
   onTransferCredits?: () => void;
@@ -27,28 +29,46 @@ export function BalanceCard({ onTransferCredits }: Props) {
     <Card shadowless>
       <CardContent className="flex items-center justify-between">
         <div className="flex items-center justify-center gap-10">
-          <div className="text-primary-9 flex flex-col gap-1.5">
-            <div className="font-light">Virtual lab credits</div>
-            <div className="text-xl font-bold">{virtualLabBalance}</div>
-          </div>
+          {isAdmin && (
+            <div className="text-primary-9 flex flex-col gap-1.5">
+              <div className="font-light">Virtual lab credits</div>
+              <div className="text-xl font-bold">{virtualLabBalance}</div>
+            </div>
+          )}
           <div className="text-primary-9 flex flex-col gap-1.5">
             <div className="font-light">Project credits</div>
             <div className="text-xl font-bold">{ProjectBalance?.balance}</div>
           </div>
         </div>
-        {isAdmin && (
-          <Button
-            rounded
-            borderless
-            className="group text-primary-9 hover:bg-primary-8 bg-white px-4 shadow-2xl select-none hover:border-white hover:text-white"
-            size="md"
-            variant="outline"
-            onClick={onTransferCredits}
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className={cn({ 'cursor-not-allowed': !isAdmin })}>
+              <Button
+                rounded
+                borderless
+                className="text-primary-9 hover:bg-primary-8 not-disabled:shadow-2xl hover:border-white hover:text-white disabled:text-gray-500"
+                size="md"
+                variant="outline"
+                onClick={isAdmin ? onTransferCredits : undefined}
+                disabled={!isAdmin}
+              >
+                Transfer credits
+                <SwapOutlined />
+              </Button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent
+            avoidCollisions
+            side="left"
+            sideOffset={1}
+            collisionPadding={{ bottom: 20 }}
+            className="text-primary-8 max-w-[200px] bg-white text-base text-balance shadow-lg"
+            arrowClassName="bg-white"
           >
-            Transfer credits
-            <SwapOutlined />
-          </Button>
-        )}
+            <WarningOutlined /> Only available to Virtual Lab admins
+          </TooltipContent>
+        </Tooltip>
       </CardContent>
     </Card>
   );

--- a/src/ui/segments/project/credits/balance-card.tsx
+++ b/src/ui/segments/project/credits/balance-card.tsx
@@ -41,7 +41,7 @@ export function BalanceCard({ onTransferCredits }: Props) {
           </div>
         </div>
 
-        <Tooltip>
+        <Tooltip open={isAdmin ? false : undefined}>
           <TooltipTrigger asChild>
             <span className={cn({ 'cursor-not-allowed': !isAdmin })}>
               <Button
@@ -50,7 +50,7 @@ export function BalanceCard({ onTransferCredits }: Props) {
                 className="text-primary-9 hover:bg-primary-8 not-disabled:shadow-2xl hover:border-white hover:text-white disabled:text-gray-500"
                 size="md"
                 variant="outline"
-                onClick={isAdmin ? onTransferCredits : undefined}
+                onClick={onTransferCredits}
                 disabled={!isAdmin}
               >
                 Transfer credits

--- a/src/ui/segments/project/credits/index.tsx
+++ b/src/ui/segments/project/credits/index.tsx
@@ -2,9 +2,9 @@
 
 import { useState } from 'react';
 
+import { BalanceCard } from '@/ui/segments/project/credits/balance-card';
 import { CreditsTransferModal } from '@/ui/segments/project/credits/credits-transfer-modal';
 import { JobReportList } from '@/ui/segments/project/credits/job-report-list';
-import { BalanceCard } from '@/ui/segments/project/credits/balance-card';
 
 export function Credits() {
   const [showCreditsManagement, setShowCreditsManagement] = useState(false);


### PR DESCRIPTION
## Summary

  - Project **Costs** page is now accessible to all project members (was: vlab/project admins only). Access check switched to `isProjectMember`.
  - **Wallet** badge in the workspace header is no longer role-gated — drops the user-groups query and admin-only `cursor`/`aria-disabled` styling. It just reflects the balance load state.
  - **BalanceCard** on the Costs page:
    - Hides the *Virtual lab credits* figure for non-vlab-admins (project balance still shown to everyone).
    - *Transfer credits* button is always rendered, but `disabled` for non-admins, with a tooltip: "Only available to Virtual Lab admins".

  ## Files

  - `src/app/app/virtual-lab/[virtualLabId]/[projectId]/(home)/credits/page.tsx` — access gate uses `isProjectMember`.
  - `src/ui/segments/project/balance.tsx` — remove role query, simplify wallet badge.
  - `src/ui/segments/project/credits/balance-card.tsx` — role-aware vlab balance + disabled transfer button with tooltip.
  - `src/ui/segments/project/credits/index.tsx` — import order only.

  ## Test plan

  - [x] As a **project member** (not admin): can open `/credits`, sees project balance, no vlab balance, transfer button disabled with tooltip.
  - [x] As a **project admin** (not vlab admin): same as above.
  - [x] As a **vlab admin**: sees both balances and an enabled transfer button.
  - [x] Wallet badge in the header loads/links correctly for all roles.