### PR TITLE
fix scan-config tab state reset and atom typing consistency

### DIFF
--- a/src/features/scan-config/components/block-dictionary-entries.tsx
+++ b/src/features/scan-config/components/block-dictionary-entries.tsx
@@ -93,6 +93,7 @@ export default function BlockDictionaryEntries({
   isChatReady,
   setEditing,
   setSelectedEntry,
+  setSelectedRootElement,
   singularName,
   allEntries,
   newKey,
@@ -118,6 +119,7 @@ export default function BlockDictionaryEntries({
   isChatReady: boolean;
   setEditing: (editing: boolean) => void;
   setSelectedEntry: (entry: string) => void;
+  setSelectedRootElement: (rootElement: string) => void;
   singularName: string;
   allEntries: Set<string>;
   newKey: string;
@@ -169,7 +171,7 @@ export default function BlockDictionaryEntries({
       typeof configInitialize.node_set.block_name === 'string' &&
       configInitialize.node_set.block_name === selectedEntry
     ) {
-      atomsMap.initialize = atom<Record<string, ConfigValue>>({
+      atomsMap.initialize = atom<Record<string, ConfigValue | Array<ConfigValue>>>({
         ...configInitialize,
         node_set: { ...configInitialize.node_set, block_name: newKey },
       });
@@ -209,7 +211,8 @@ export default function BlockDictionaryEntries({
     setNewKey('');
   };
 
-  function renderBlockTab(entry: string, isDeleted = false) {
+  // FIXME: @Nicolas, do we need this isDeleted flag?
+  function renderBlockTab(entry: string, isDeleted: boolean = false) {
     const isSelected = selectedRootElement === rootElement && entry === selectedEntry;
     const entryDiffClass = getEntryDiffClass(entry, isSelected);
 
@@ -376,7 +379,9 @@ export default function BlockDictionaryEntries({
                                         typeof configInitialize.node_set.block_name === 'string' &&
                                         configInitialize.node_set.block_name === subkey
                                       ) {
-                                        atomsMap.initialize = atom<Record<string, ConfigValue>>({
+                                        atomsMap.initialize = atom<
+                                          Record<string, ConfigValue | Array<ConfigValue>>
+                                        >({
                                           ...configInitialize,
                                           node_set: null,
                                         });
@@ -405,11 +410,13 @@ export default function BlockDictionaryEntries({
 
                                               // Deleting the reference to current object
 
-                                              delete entryV[fieldK]; //eslint-disable-line
+                                              delete entryV[fieldK];
 
                                               // The atom that has a reference to current object
                                               atomsMap[configK][entryKey] =
-                                                atom<Record<string, ConfigValue>>(entryV);
+                                                atom<
+                                                  Record<string, ConfigValue | Array<ConfigValue>>
+                                                >(entryV);
                                             });
                                           });
                                         });
@@ -468,6 +475,7 @@ export default function BlockDictionaryEntries({
               )}
               type="button"
               onClick={() => {
+                setSelectedRootElement(rootElement);
                 setEditing(true);
                 setSelectedEntry('');
               }}

--- a/src/features/scan-config/components/root-element.tsx
+++ b/src/features/scan-config/components/root-element.tsx
@@ -71,7 +71,7 @@ export function RootElement({
   isEditingKey: boolean;
   setIsEditingKey: (k: boolean) => void;
 }) {
-  const { aiConfig, isChatReady } = useAIConfig();
+  const { isChatReady } = useAIConfig();
   const setExpandedRootElements = useSetAtom(expandedRootElementsAtom);
   const { highlights, hasHighlights, isExpanded, diffClass } = useRootElementDiff(rootElement);
   const hasFieldErrors = useFieldErrorsForPath(rootElement);
@@ -204,6 +204,7 @@ export function RootElement({
             isChatReady={isChatReady}
             setEditing={setEditing}
             setSelectedEntry={setSelectedEntry}
+            setSelectedRootElement={setSelectedRootElement}
             singularName={rootElementSchema.singular_name}
             allEntries={allEntries}
             newKey={newKey}

--- a/src/features/scan-config/template.tsx
+++ b/src/features/scan-config/template.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { get } from 'es-toolkit/compat';
-import { useAtom } from 'jotai';
-import { Suspense, useState } from 'react';
+import { useAtom, useSetAtom } from 'jotai';
+import { Suspense, useEffect, useState } from 'react';
 import { match } from 'ts-pattern';
 
 import { useEntries } from '@/features/scan-config/components/hooks';
@@ -35,7 +35,12 @@ import { SkeletonizationTab } from '@/features/scan-config/use-cases/skeletoniza
 import { usePrevious } from '@/hooks/hooks';
 import { messages } from '@/i18n/en/scan-config';
 import { useAgentState } from '@/services/ai-agent';
-import { editingAtom, selectedEntryAtom, selectedRootElementAtom } from '@/state/config-highlights';
+import {
+  editingAtom,
+  expandedRootElementsAtom,
+  selectedEntryAtom,
+  selectedRootElementAtom,
+} from '@/state/config-highlights';
 import { ButtonCopyId } from '@/ui/molecules/button-copy-id';
 import { cn } from '@/utils/css-class';
 
@@ -89,6 +94,7 @@ export function ScanConfigTemplate({
   const [campaignId, setCampaignId] = useState(initialCampaignId ?? '');
   const [isEditingKey, setIsEditingKey] = useState(false);
   const [newKey, setNewKey] = useState('');
+  const setExpandedRootElements = useSetAtom(expandedRootElementsAtom);
   const allEntries = useEntries({ initialConfig, schema });
   const [atomsMap, setAtomsMap] = useAtomsMap({
     schema,
@@ -98,6 +104,16 @@ export function ScanConfigTemplate({
   const config = useConfigAtom(schema, atomsMap);
   const previousCampaignId = usePrevious(campaignId);
   const isCampaignIdChanged = previousCampaignId !== campaignId;
+
+  useEffect(() => {
+    // reset all scan config state when leaving the page
+    return () => {
+      setExpandedRootElements(new Set(['info']));
+      setSelectedRootElement('info');
+      setSelectedEntry('');
+      setEditing(true);
+    };
+  }, [setEditing, setExpandedRootElements, setSelectedEntry, setSelectedRootElement]);
 
   useAgentState(aiEnabled ? ACTIVITY_AI_CONFIG_MAP[activity] : '', config);
 


### PR DESCRIPTION
- reset scan-config UI selection state on template unmount
- keep block dictionary atom assignments aligned with the AtomsMap value type to avoid type mismatches
- the scan-config tabs expand state was cached when creating a new workflow

this is a bug in stg, prod reported by Ayima, the "add singular" for block dictionary was displaying the old options from the previously selected root element 



https://github.com/user-attachments/assets/62eb4731-e102-49cb-b0f5-aa8f1a60c998

