### PR TITLE
Scan config action and form fixes

### DIFF
--- a/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/simulate/configure/memodel/[id]/page.tsx
+++ b/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/simulate/configure/memodel/[id]/page.tsx
@@ -9,7 +9,7 @@ import {
   type TExtendedEntitiesTypeDict,
 } from '@/api/entitycore/types/extended-entity-type';
 import { ResponsiveSideViewer } from '@/components/responsive-side-viewer';
-import { resolveSimulationByCampaignId } from '@/entity-configuration/domain/simulation/small-microcircuit-simulation';
+import { resolveSimulationByCampaignId } from '@/entity-configuration/domain/simulation/memodel-circuit-simulation';
 import { ScanConfiguration } from '@/features/scan-config';
 import { WorkflowSimulateLayout } from '@/ui/layouts/workflow-simulate-layout';
 import { Header } from '@/ui/segments/workflows/simulate/single-neuron/shared/elements/header';
@@ -52,18 +52,23 @@ export default function Page({
     queryFn: () => getMEModel({ id: modelId, context: { virtualLabId, projectId } }),
   });
 
-  const { data: campaignData } = useQuery({
+  const { data: campaignData, isLoading: isCampaignLoading } = useQuery({
     queryKey: keyBuilder.simCampaign({ entityId: initialCampaignId }),
     queryFn: async () => {
       if (!initialCampaignId) return null;
       return await resolveSimulationByCampaignId({
         id: initialCampaignId,
         context: { virtualLabId, projectId },
+        populate: ['config'],
       });
     },
+    enabled: !!initialCampaignId,
   });
 
-  if (queryParams.dataType === ExtendedEntitiesTypeDict.MemodelCircuit) {
+  if (
+    queryParams.dataType === ExtendedEntitiesTypeDict.MemodelCircuit &&
+    (!initialCampaignId || (!isCampaignLoading && campaignData?.config.form))
+  ) {
     return (
       <div className="border-neutral-2 ml-2 h-full rounded-2xl border">
         <ScanConfiguration
@@ -76,6 +81,9 @@ export default function Page({
         />
       </div>
     );
+  }
+  if (queryParams.dataType === ExtendedEntitiesTypeDict.MemodelCircuit) {
+    return null;
   }
 
   return (

--- a/src/entity-configuration/domain/simulation/memodel-circuit-simulation.ts
+++ b/src/entity-configuration/domain/simulation/memodel-circuit-simulation.ts
@@ -1,8 +1,7 @@
 import { keyBy } from 'es-toolkit/compat';
 
-import { getMEModels } from '@/api/entitycore/queries';
+import { getMEModel, getMEModels } from '@/api/entitycore/queries';
 import { downloadAsset } from '@/api/entitycore/queries/assets';
-import { getCircuit } from '@/api/entitycore/queries/model/circuit';
 import {
   createSimulationCampaign,
   getSimulationCampaign,
@@ -25,7 +24,7 @@ import { EntitySlug } from '@/entity-configuration/domain/slug';
 
 import { count, rows as listSimulationRows } from './simulation-campaign';
 
-import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
+import type { IMEModel } from '@/api/entitycore/types/entities/me-model';
 import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
 import type { WorkspaceContext } from '@/types/common';
 
@@ -95,10 +94,10 @@ export async function resolveSimulationByCampaignId({
   if (!configAsset) throw Error('No campaign config asset found');
 
   let config = null;
-  let entity: ICircuit | null = null;
+  let entity: IMEModel | null = null;
 
   if (simulation?.entity_id && populate.includes('entity')) {
-    entity = await getCircuit({ id: simulation?.entity_id, context });
+    entity = await getMEModel({ id: simulation?.entity_id, context });
   }
 
   if (populate.includes('config')) {

--- a/src/features/scan-config/components/hooks/schema.ts
+++ b/src/features/scan-config/components/hooks/schema.ts
@@ -215,6 +215,22 @@ export function useAtomsMap({
             map[k][subK] = atom<Record<string, ConfigValue | Array<ConfigValue>>>(subV);
           });
         });
+
+      // TODO: Consider implementing schema versioning
+      // Fill in any schema-defined root keys that initialConfig omitted, so the
+      // hasInitializedMapForSchema guard above passes on the next render. Without
+      // this, the effect re-fires every render and triggers Maximum update depth.
+      for (const [k, v] of Object.entries(schema.properties)) {
+        if (isType(v) || k in map) continue;
+        if (
+          v.ui_element === ScanConfigUIElementDict.BlockSingle ||
+          v.ui_element === ScanConfigUIElementDict.BlockUnion
+        ) {
+          map[k] = atom<Record<string, ConfigValue | Array<ConfigValue>>>({});
+        } else {
+          map[k] = {};
+        }
+      }
     } else {
       Object.entries(schema.properties).forEach(([k, v]) => {
         if (isType(v)) return;

--- a/src/ui/segments/workflows/elements/workflow-activity.tsx
+++ b/src/ui/segments/workflows/elements/workflow-activity.tsx
@@ -418,6 +418,7 @@ export function WorkflowActivity() {
       navigate(
         `${config.ROOT_ROUTE}/${virtualLabId}/${projectId}/workflows/simulate/configure/${kebabCase(ExtendedEntitiesTypeDict.IonChannelModelSimulation)}?initialCampaignId=${selectedRow.id}`
       );
+      return;
     }
     if (selectedRow?.type === ExtendedEntitiesTypeDict.SimulationCampaign) {
       navigate(


### PR DESCRIPTION
Fixes the **Duplicate** action on **Simulate → Single neuron (beta)** and **Simulate → Ion channel (beta)** campaigns, plus a latent re-render loop in scan-config form initialization.

  ## Changes

  - **`workflow-activity.tsx`** — add missing `return` after the `IonChannelModelSimulation` navigate so the catch-all `SimulationCampaign` branch no longer overrides it with `/configure/circuit/${entity_id}`.
  - **`memodel-circuit-simulation.ts` resolver** — replace `getCircuit` with `getMEModel` for the entity branch. The campaign’s `entity_id` points to a MEModel, so `GET /circuit/{id}` was 404-ing and crashing the resolver.
  - **`memodel/[id]/page.tsx`**:
    - import `resolveSimulationByCampaignId` from the memodel domain instead of `small-microcircuit-simulation` (stale copy/paste).
    - pass `populate: ['config']` (entity is already fetched via `getMEModel` on the page).
    - gate `<ScanConfiguration>` rendering on the campaign query resolving when `initialCampaignId` is present, mirroring the ion-channel page. Without this, the form mounted with `initialConfig=undefined`, and `useAtomsMap`’s init-once guard ignored the late-arriving config — the form stayed empty even though the
  campaign config loaded.
  - **`scan-config/components/hooks/schema.ts`** — in the `initialConfig` branch of `useAtomsMap`, backfill schema-defined root keys that `initialConfig` omitted, so `hasInitializedMapForSchema` becomes true on the next render. Prevents an effect re-fire loop ("Maximum update depth").
