### PR TITLE
Manage Amplify branches in GH actions

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -2,7 +2,7 @@ name: Preview
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [ opened, synchronize, reopened, closed ]
 
 permissions:
   id-token: write
@@ -175,6 +175,8 @@ jobs:
           fi
 
           SHORTHAND=$(echo "$UPDATED" | jq -r '.[] | "prefix=\(.prefix),branchName=\(.branchName)"' | tr '\n' ' ')
+
+          echo $SHORTHAND
 
           aws amplify update-domain-association \
             --app-id "$AMPLIFY_APP_ID" \

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -139,6 +139,50 @@ jobs:
               });
             }
 
+  domain-attach:
+    needs: deploy
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: amplify-domain-${{ vars.AMPLIFY_PREVIEW_APP_ID }}
+      cancel-in-progress: false
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.PREVIEW_DEPLOY_AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Attach preview subdomain
+        env:
+          BRANCH_NAME: ${{ needs.deploy.outputs.branch-name }}
+          PREFIX: ${{ needs.deploy.outputs.domain-safe-branch }}
+        run: |
+          set -euo pipefail
+
+          CURRENT=$(aws amplify get-domain-association \
+            --app-id "$AMPLIFY_APP_ID" \
+            --domain-name "$PREVIEW_DOMAIN" \
+            --query 'domainAssociation.subDomains[].subDomainSetting' \
+            --output json)
+
+          UPDATED=$(echo "$CURRENT" | jq --arg prefix "$PREFIX" --arg branch "$BRANCH_NAME" \
+            'map(select(.prefix != $prefix)) + [{prefix: $prefix, branchName: $branch}]')
+
+          if [ "$(echo "$CURRENT" | jq -S .)" = "$(echo "$UPDATED" | jq -S .)" ]; then
+            echo "Subdomain $PREFIX already attached to $BRANCH_NAME"
+            exit 0
+          fi
+
+          SHORTHAND=$(echo "$UPDATED" | jq -r '.[] | "prefix=\(.prefix),branchName=\(.branchName)"' | tr '\n' ' ')
+
+          aws amplify update-domain-association \
+            --app-id "$AMPLIFY_APP_ID" \
+            --domain-name "$PREVIEW_DOMAIN" \
+            --sub-domain-settings $SHORTHAND
+
+          echo "Attached $PREFIX -> $BRANCH_NAME"
+
   monitor:
     needs: deploy
     runs-on: ubuntu-latest
@@ -250,9 +294,62 @@ jobs:
             }
 
   # Branch auto-creation is disabled on the Amplify app (to stay under the 50-branch quota),
-  # so this job explicitly deletes the Amplify branch when the PR is closed.
+  # so on PR close we explicitly detach the preview subdomain (domain-detach) and then
+  # delete the Amplify branch (cleanup). The detach is serialized across PRs because
+  # update-domain-association rewrites a single shared resource.
+  domain-detach:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: amplify-domain-${{ vars.AMPLIFY_PREVIEW_APP_ID }}
+      cancel-in-progress: false
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.PREVIEW_DEPLOY_AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Detach preview subdomain
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+
+          PREFIX="${BRANCH_NAME//\//-}"
+          PREFIX="${PREFIX//./-}"
+          PREFIX="${PREFIX//_/-}"
+
+          CURRENT=$(aws amplify get-domain-association \
+            --app-id "$AMPLIFY_APP_ID" \
+            --domain-name "$PREVIEW_DOMAIN" \
+            --query 'domainAssociation.subDomains[].subDomainSetting' \
+            --output json)
+
+          UPDATED=$(echo "$CURRENT" | jq --arg prefix "$PREFIX" 'map(select(.prefix != $prefix))')
+
+          if [ "$(echo "$CURRENT" | jq -S .)" = "$(echo "$UPDATED" | jq -S .)" ]; then
+            echo "Subdomain $PREFIX already absent"
+            exit 0
+          fi
+
+          SHORTHAND=$(echo "$UPDATED" | jq -r '.[] | "prefix=\(.prefix),branchName=\(.branchName)"' | tr '\n' ' ')
+
+          if [ -z "$SHORTHAND" ]; then
+            echo "Refusing to update domain association to an empty subdomain list — skipping detach"
+            exit 0
+          fi
+
+          aws amplify update-domain-association \
+            --app-id "$AMPLIFY_APP_ID" \
+            --domain-name "$PREVIEW_DOMAIN" \
+            --sub-domain-settings $SHORTHAND
+
+          echo "Detached $PREFIX"
+
   cleanup:
     if: github.event.action == 'closed'
+    needs: domain-detach
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -87,7 +87,22 @@ jobs:
           echo "$ORPHANS" | jq .
           echo "Orphan count: $(echo "$ORPHANS" | jq 'length')"
 
-          echo "=== Skipping update-domain-association (debug only) ==="
+          SHORTHAND=$(echo "$UPDATED" | jq -r '.[] | "prefix=\(.prefix),branchName=\(.branchName)"' | tr '\n' ' ')
+
+          echo "=== Shorthand for --sub-domain-settings ==="
+          echo "$SHORTHAND"
+          echo "=== Token count ==="
+          echo "$SHORTHAND" | wc -w
+
+          echo "=== Calling aws amplify update-domain-association ==="
+          set -x
+          aws amplify update-domain-association \
+            --app-id "$AMPLIFY_APP_ID" \
+            --domain-name "$PREVIEW_DOMAIN" \
+            --sub-domain-settings $SHORTHAND
+          set +x
+
+          echo "=== Done: $ACTION $PREFIX ==="
 
   deploy:
     if: false

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -19,8 +19,77 @@ env:
   PREVIEW_DOMAIN: ${{ vars.AMPLIFY_PREVIEW_DOMAIN }}
 
 jobs:
-  deploy:
+  debug-domain:
     if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: amplify-domain-${{ vars.AMPLIFY_PREVIEW_APP_ID }}
+      cancel-in-progress: false
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.PREVIEW_DEPLOY_AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Toggle preview subdomain (debug)
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+
+          PREFIX="${BRANCH_NAME//\//-}"
+          PREFIX="${PREFIX//./-}"
+          PREFIX="${PREFIX//_/-}"
+
+          echo "=== Inputs ==="
+          echo "AMPLIFY_APP_ID=$AMPLIFY_APP_ID"
+          echo "PREVIEW_DOMAIN=$PREVIEW_DOMAIN"
+          echo "BRANCH_NAME=$BRANCH_NAME"
+          echo "PREFIX=$PREFIX"
+
+          CURRENT=$(aws amplify get-domain-association \
+            --app-id "$AMPLIFY_APP_ID" \
+            --domain-name "$PREVIEW_DOMAIN" \
+            --query 'domainAssociation.subDomains[].subDomainSetting' \
+            --output json)
+
+          echo "=== Current subdomains ==="
+          echo "$CURRENT" | jq .
+
+          if echo "$CURRENT" | jq -e --arg prefix "$PREFIX" 'any(.prefix == $prefix)' >/dev/null; then
+            ACTION="detach"
+            UPDATED=$(echo "$CURRENT" | jq --arg prefix "$PREFIX" \
+              'map(select(.prefix != $prefix))')
+          else
+            ACTION="attach"
+            UPDATED=$(echo "$CURRENT" | jq --arg prefix "$PREFIX" --arg branch "$BRANCH_NAME" \
+              'map(select(.prefix != $prefix)) + [{prefix: $prefix, branchName: $branch}]')
+          fi
+
+          echo "=== Action: $ACTION ==="
+          echo "=== Updated payload (JSON) ==="
+          echo "$UPDATED" | jq .
+
+          SHORTHAND=$(echo "$UPDATED" | jq -r '.[] | "prefix=\(.prefix),branchName=\(.branchName)"' | tr '\n' ' ')
+
+          echo "=== Shorthand for --sub-domain-settings ==="
+          echo "$SHORTHAND"
+          echo "=== Token count ==="
+          echo "$SHORTHAND" | wc -w
+
+          echo "=== Calling aws amplify update-domain-association ==="
+          set -x
+          aws amplify update-domain-association \
+            --app-id "$AMPLIFY_APP_ID" \
+            --domain-name "$PREVIEW_DOMAIN" \
+            --sub-domain-settings $SHORTHAND
+          set +x
+
+          echo "=== Done: $ACTION $PREFIX ==="
+
+  deploy:
+    if: false
     runs-on: ubuntu-latest
     outputs:
       job-id: ${{ steps.start-build.outputs.job-id }}
@@ -141,7 +210,7 @@ jobs:
 
   domain-attach:
     needs: deploy
-    if: github.event.action != 'closed'
+    if: false
     runs-on: ubuntu-latest
     concurrency:
       group: amplify-domain-${{ vars.AMPLIFY_PREVIEW_APP_ID }}
@@ -187,6 +256,7 @@ jobs:
 
   monitor:
     needs: deploy
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
@@ -300,7 +370,7 @@ jobs:
   # delete the Amplify branch (cleanup). The detach is serialized across PRs because
   # update-domain-association rewrites a single shared resource.
   domain-detach:
-    if: github.event.action == 'closed'
+    if: false
     runs-on: ubuntu-latest
     concurrency:
       group: amplify-domain-${{ vars.AMPLIFY_PREVIEW_APP_ID }}
@@ -350,7 +420,7 @@ jobs:
           echo "Detached $PREFIX"
 
   cleanup:
-    if: github.event.action == 'closed'
+    if: false
     needs: domain-detach
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -71,22 +71,23 @@ jobs:
           echo "=== Updated payload (JSON) ==="
           echo "$UPDATED" | jq .
 
-          SHORTHAND=$(echo "$UPDATED" | jq -r '.[] | "prefix=\(.prefix),branchName=\(.branchName)"' | tr '\n' ' ')
-
-          echo "=== Shorthand for --sub-domain-settings ==="
-          echo "$SHORTHAND"
-          echo "=== Token count ==="
-          echo "$SHORTHAND" | wc -w
-
-          echo "=== Calling aws amplify update-domain-association ==="
-          set -x
-          aws amplify update-domain-association \
+          echo "=== Existing Amplify branches ==="
+          EXISTING=$(aws amplify list-branches \
             --app-id "$AMPLIFY_APP_ID" \
-            --domain-name "$PREVIEW_DOMAIN" \
-            --sub-domain-settings $SHORTHAND
-          set +x
+            --query 'branches[].branchName' \
+            --output json)
+          echo "$EXISTING" | jq '. | sort'
+          echo "Branch count: $(echo "$EXISTING" | jq 'length')"
 
-          echo "=== Done: $ACTION $PREFIX ==="
+          echo "=== Orphans (in domain association but missing from Amplify branches) ==="
+          ORPHANS=$(jq -n --argjson updated "$UPDATED" --argjson existing "$EXISTING" '
+            ($existing | map({(.):true}) | add // {}) as $set
+            | $updated | map(select(.branchName | in($set) | not))
+          ')
+          echo "$ORPHANS" | jq .
+          echo "Orphan count: $(echo "$ORPHANS" | jq 'length')"
+
+          echo "=== Skipping update-domain-association (debug only) ==="
 
   deploy:
     if: false

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -44,6 +44,23 @@ jobs:
           echo "branch-name=$BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "domain-safe-branch=$DOMAIN_SAFE_BRANCH" >> $GITHUB_OUTPUT
 
+      - name: Ensure Amplify branch exists
+        run: |
+          if ! aws amplify get-branch \
+              --app-id "${{ env.AMPLIFY_APP_ID }}" \
+              --branch-name "${{ steps.vars.outputs.branch-name }}" \
+              >/dev/null 2>&1; then
+            echo "Branch not found in Amplify, creating..."
+            aws amplify create-branch \
+              --app-id "${{ env.AMPLIFY_APP_ID }}" \
+              --branch-name "${{ steps.vars.outputs.branch-name }}" \
+              --stage PULL_REQUEST \
+              --framework "Next.js - SSR" \
+              --no-enable-auto-build
+          else
+            echo "Branch already exists in Amplify"
+          fi
+
       - name: Cancel running builds
         run: |
           RUNNING_JOBS=$(aws amplify list-jobs \
@@ -232,13 +249,27 @@ jobs:
               await new Promise(resolve => setTimeout(resolve, 20000)); // Wait 20s
             }
 
-  # Note: Branch cleanup is handled automatically by:
-  # - AWS Amplify auto-disconnect for preview branches
-  # - GitHub auto-delete branch setting for merged PRs
+  # Branch auto-creation is disabled on the Amplify app (to stay under the 50-branch quota),
+  # so this job explicitly deletes the Amplify branch when the PR is closed.
   cleanup:
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.PREVIEW_DEPLOY_AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Delete Amplify branch
+        run: |
+          BRANCH_NAME="${{ github.head_ref }}"
+          echo "Deleting Amplify branch: $BRANCH_NAME"
+          aws amplify delete-branch \
+            --app-id "${{ env.AMPLIFY_APP_ID }}" \
+            --branch-name "$BRANCH_NAME" || \
+            echo "Branch already deleted or never existed — continuing"
+
       - name: Update comment
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -94,11 +94,38 @@ jobs:
           echo "=== Token count ==="
           echo "$SHORTHAND" | wc -w
 
+          echo "=== Reading current auto-subdomain config ==="
+          DA=$(aws amplify get-domain-association \
+            --app-id "$AMPLIFY_APP_ID" \
+            --domain-name "$PREVIEW_DOMAIN" \
+            --output json)
+          AUTO_ENABLED=$(echo "$DA" | jq -r '.domainAssociation.enableAutoSubDomain')
+          AUTO_ROLE=$(echo "$DA" | jq -r '.domainAssociation.autoSubDomainIAMRole // empty')
+          AUTO_PATTERNS=$(echo "$DA" | jq -r '.domainAssociation.autoSubDomainCreationPatterns // [] | join(" ")')
+          echo "enableAutoSubDomain=$AUTO_ENABLED"
+          echo "autoSubDomainIAMRole=$AUTO_ROLE"
+          echo "autoSubDomainCreationPatterns=$AUTO_PATTERNS"
+
+          AUTO_FLAGS=()
+          if [ "$AUTO_ENABLED" = "true" ]; then
+            AUTO_FLAGS+=(--enable-auto-sub-domain)
+          else
+            AUTO_FLAGS+=(--no-enable-auto-sub-domain)
+          fi
+          if [ -n "$AUTO_ROLE" ]; then
+            AUTO_FLAGS+=(--auto-sub-domain-iam-role "$AUTO_ROLE")
+          fi
+          if [ -n "$AUTO_PATTERNS" ]; then
+            # shellcheck disable=SC2206
+            AUTO_FLAGS+=(--auto-sub-domain-creation-patterns $AUTO_PATTERNS)
+          fi
+
           echo "=== Calling aws amplify update-domain-association ==="
           set -x
           aws amplify update-domain-association \
             --app-id "$AMPLIFY_APP_ID" \
             --domain-name "$PREVIEW_DOMAIN" \
+            "${AUTO_FLAGS[@]}" \
             --sub-domain-settings $SHORTHAND
           set +x
 


### PR DESCRIPTION
## Summary

Manage the AWS Amplify preview branch + subdomain lifecycle from GitHub Actions instead of relying on Amplify's auto-branch-creation. Auto-creation consumes the 50-branch app quota with non-PR branches; with ~25 open PRs we're already at the limit.

## Why disabling auto-branch-creation needs more than just `delete-branch`

Auto-branch-creation in Amplify also gates `enable_auto_sub_domain` — turning the first off disables the second. So the workflow has to own **both** lifecycles:

- **Branch lifecycle**: `create-branch` on PR open if missing, `delete-branch` on close.
- **Subdomain lifecycle**: read-modify-write on the app's `domain-association.subDomainSettings` to attach the prefix on deploy and detach it on close.

## Job structure

```
on PR open/sync/reopen:
  deploy ─┬─→ domain-attach   (cross-PR queue)
          └─→ monitor

on PR close:
  domain-detach ─→ cleanup    (detach queued cross-PR; delete-branch unconstrained)
```

Subdomain edits live in their own jobs — not inlined into `deploy`/`cleanup` — so the cross-PR mutex only covers the few seconds of domain editing rather than the multi-minute build path.

## Why a cross-PR concurrency group

`update-domain-association` is a *replace* operation against a **single shared resource** (one association per app+domain). Amplify does **not** appear to enforce optimistic concurrency on it, so concurrent edits silently last-write-wins and drop entries.

The reliable fix is GitHub-side serialization. Both `domain-attach` and `domain-detach` use:

\`\`\`yaml
concurrency:
  group: amplify-domain-\${{ vars.AMPLIFY_PREVIEW_APP_ID }}
  cancel-in-progress: false
\`\`\`

`cancel-in-progress: false` so PR B's edit *queues* behind PR A's instead of cancelling it — every PR must get its entry applied. The existing workflow-level \`preview-\${{ github.head_ref }}\` group still cancels superseded runs of the *same* PR.

## Other design choices

- `--stage PULL_REQUEST` on `create-branch` matches what auto-branch-creation produced for PR branches.
- `--no-enable-auto-build` since we explicitly invoke `start-job`; we don't want Amplify also auto-building on push.
- No `--environment-variables` on `create-branch`: app-level env vars apply automatically; only per-branch overrides need explicit values.
- Idempotency: attach/detach are no-ops if the entry is already in the desired state; `delete-branch` tolerates a missing branch via `|| echo`.
- Detach refuses to write an empty `subDomainSettings` list (Amplify rejects it, and it would orphan cert/DNS config).
- "Cancel running builds" remains *after* "Ensure Amplify branch exists" — `list-jobs` against a non-existent branch errors out.

## Required AWS-side changes (must land together with this PR)

The workflow alone won't fix the quota — these will have to be applied to the Amplify app + IAM role:

- [ ] Disable branch auto-creation on the Amplify app - **can be done after this PR is merged**
- [x] Extend the role behind `PREVIEW_DEPLOY_AWS_ROLE_ARN` with:
  - `amplify:GetBranch`, `amplify:CreateBranch`, `amplify:DeleteBranch`
  - `amplify:GetDomainAssociation`, `amplify:UpdateDomainAssociation`

## Test plan

- [ ] Open a fresh PR from a branch never seen by Amplify → `deploy` logs `Branch not found in Amplify, creating...`; `domain-attach` logs `Attached <prefix> -> <branch>`; `get-domain-association` shows the new prefix.
- [ ] After build completes → `https://<domain-safe-branch>.<PREVIEW_DOMAIN>` resolves and serves the preview.
- [ ] Push a follow-up commit → both `Branch already exists in Amplify` and `Subdomain <prefix> already attached` (idempotent).
- [ ] Close the PR → `domain-detach` logs `Detached <prefix>`; `cleanup` logs `Deleting Amplify branch`. Branch and prefix both gone in `list-branches` / `get-domain-association`.
- [ ] Reopen the PR → branch and subdomain recreated cleanly.
- [ ] (Optional) Open two PRs nearly simultaneously → in the Actions UI, one `domain-attach` runs while the other shows "Waiting for status" on the `amplify-domain-*` group, then runs sequentially. Both entries land in the final domain association (no lost writes).
- [ ] After a week of normal traffic, `aws amplify list-branches | jq '.branches | length'` tracks open-PR count, not lifetime branch count.