### PR TITLE
Clean up upload

### DIFF
--- a/src/ui/segments/contribute/experimental-bouton-density/steps/setup.tsx
+++ b/src/ui/segments/contribute/experimental-bouton-density/steps/setup.tsx
@@ -28,7 +28,7 @@ export function Setup() {
         <Input
           className="h-12 rounded-full placeholder:text-sm"
           size="large"
-          placeholder="Enter cell recording name"
+          placeholder="Enter bouton density name"
         />
       </Form.Item>
 
@@ -49,7 +49,7 @@ export function Setup() {
         <Input.TextArea
           rows={5}
           className="rounded-xl placeholder:text-sm"
-          placeholder="Enter cell recording description"
+          placeholder="Enter bouton density description"
         />
       </Form.Item>
 

--- a/src/ui/segments/contribute/experimental-neuron-density/steps/etype.tsx
+++ b/src/ui/segments/contribute/experimental-neuron-density/steps/etype.tsx
@@ -4,5 +4,5 @@ import { ExperimentalNeuronDensitySchema } from '@/ui/segments/contribute/experi
 import { ETypeClassificationSelector } from '@/ui/segments/contribute/shared/components/etype-selector';
 
 export function ETypeClassification() {
-  return <ETypeClassificationSelector schema={ExperimentalNeuronDensitySchema} />;
+  return <ETypeClassificationSelector schema={ExperimentalNeuronDensitySchema} required={false} />;
 }

--- a/src/ui/segments/contribute/experimental-neuron-density/steps/measurements.tsx
+++ b/src/ui/segments/contribute/experimental-neuron-density/steps/measurements.tsx
@@ -28,10 +28,7 @@ export function Measurements() {
 
   return (
     <div className="h-full w-full">
-      <Form.List
-        name="measurements"
-        initialValue={[{ name: undefined, unit: FIXED_UNIT, value: undefined }]}
-      >
+      <Form.List name="measurements">
         {(fields, { remove }) => (
           <>
             <div className="flex flex-col gap-4">

--- a/src/ui/segments/contribute/experimental-neuron-density/steps/mtype.tsx
+++ b/src/ui/segments/contribute/experimental-neuron-density/steps/mtype.tsx
@@ -4,5 +4,5 @@ import { ExperimentalNeuronDensitySchema } from '@/ui/segments/contribute/experi
 import { MTypeClassificationSelector } from '@/ui/segments/contribute/shared/components/mtype-selector';
 
 export function MTypeClassification() {
-  return <MTypeClassificationSelector schema={ExperimentalNeuronDensitySchema} />;
+  return <MTypeClassificationSelector schema={ExperimentalNeuronDensitySchema} required={false} />;
 }

--- a/src/ui/segments/contribute/experimental-neuron-density/steps/setup.tsx
+++ b/src/ui/segments/contribute/experimental-neuron-density/steps/setup.tsx
@@ -28,7 +28,7 @@ export function Setup() {
         <Input
           className="h-12 rounded-full placeholder:text-sm"
           size="large"
-          placeholder="Enter cell recording name"
+          placeholder="Enter neuron density name"
         />
       </Form.Item>
 
@@ -49,7 +49,7 @@ export function Setup() {
         <Input.TextArea
           rows={5}
           className="rounded-xl placeholder:text-sm"
-          placeholder="Enter cell recording description"
+          placeholder="Enter neuron density description"
         />
       </Form.Item>
 

--- a/src/ui/segments/contribute/shared/components/etype-selector.tsx
+++ b/src/ui/segments/contribute/shared/components/etype-selector.tsx
@@ -59,10 +59,12 @@ function CustomRenderer({ data, selected, onSelect }: ICustomRendererProps) {
 
 type Props<TSchema extends ZodObject<ZodRawShape>> = {
   schema: TSchema;
+  required?: boolean;
 };
 
 export function ETypeClassificationSelector<TSchema extends ZodObject<ZodRawShape>>({
   schema,
+  required = true,
 }: Props<TSchema>) {
   const form = Form.useFormInstance();
   const { virtualLabId, projectId } = useWorkspace();
@@ -95,10 +97,10 @@ export function ETypeClassificationSelector<TSchema extends ZodObject<ZodRawShap
     <>
       <Form.Item
         name="etype_class_id"
-        label={renderLabel('Etype classification', 'main', RequiredFieldMarker)}
+        label={renderLabel('Etype classification', 'main', required ? RequiredFieldMarker : undefined)}
         rules={[
           {
-            required: true,
+            required,
             validator: createZodFieldValidator(schema, 'etype_class_id', form),
           },
         ]}

--- a/src/ui/segments/contribute/shared/components/mtype-selector.tsx
+++ b/src/ui/segments/contribute/shared/components/mtype-selector.tsx
@@ -59,10 +59,12 @@ function CustomRenderer({ data, selected, onSelect }: ICustomRendererProps) {
 
 type Props<TSchema extends ZodObject<ZodRawShape>> = {
   schema: TSchema;
+  required?: boolean;
 };
 
 export function MTypeClassificationSelector<TSchema extends ZodObject<ZodRawShape>>({
   schema,
+  required = true,
 }: Props<TSchema>) {
   const form = Form.useFormInstance();
   const { virtualLabId, projectId } = useWorkspace();
@@ -95,10 +97,10 @@ export function MTypeClassificationSelector<TSchema extends ZodObject<ZodRawShap
     <>
       <Form.Item
         name="mtype_class_id"
-        label={renderLabel('Mtype classification', 'main', RequiredFieldMarker)}
+        label={renderLabel('Mtype classification', 'main', required ? RequiredFieldMarker : undefined)}
         rules={[
           {
-            required: true,
+            required,
             validator: createZodFieldValidator(schema, 'mtype_class_id', form),
           },
         ]}

--- a/src/ui/segments/contribute/synapses-per-connection/steps/setup.tsx
+++ b/src/ui/segments/contribute/synapses-per-connection/steps/setup.tsx
@@ -86,7 +86,7 @@ export function Setup() {
         <Input.TextArea
           rows={5}
           className="rounded-xl placeholder:text-sm"
-          placeholder="Enter cell recording description"
+          placeholder="Enter synapses-per-connection description"
         />
       </Form.Item>
       <BrainRegionFormField name="brain_region_id" label="Brain region" />


### PR DESCRIPTION
This PR removes the red required star from mtype and etype in the upload steps, in the cases in which it is optional. Also it corrects the text in name and description, removing the erroneous phrese "cell recording" when the entity is not that.