### PR TITLE
fix when change schema, old selected block keep stored cause ui_element in undefined

### DIFF
--- a/src/features/scan-config/components/ui-blocks/block-dictionary.tsx
+++ b/src/features/scan-config/components/ui-blocks/block-dictionary.tsx
@@ -1,5 +1,5 @@
 import { capitalize } from 'es-toolkit';
-import { get, lowerCase } from 'es-toolkit/compat';
+import { get } from 'es-toolkit/compat';
 import { atom, useAtomValue } from 'jotai';
 
 import {
@@ -201,7 +201,7 @@ export default function BlockDictionary({
                     ...atomsMap,
                     [selectedRootElement]: {
                       ...atomsMap[selectedRootElement],
-                      [newEntry]: atom<Record<string, ConfigValue>>(initial),
+                      [newEntry]: atom<Record<string, ConfigValue | ConfigValue[]>>(initial),
                     },
                   });
                 }}

--- a/src/features/scan-config/components/ui-blocks/block.tsx
+++ b/src/features/scan-config/components/ui-blocks/block.tsx
@@ -41,7 +41,7 @@ export default function Block({
   config: Config;
   blockSchema?: TBlock;
   entity: TSupportedEntitiesForScanConfiguration | Nullish;
-  stateAtom: ReturnType<typeof atom<Record<string, ConfigValue>>> | null;
+  stateAtom: ReturnType<typeof atom<Record<string, ConfigValue | ConfigValue[]>>> | null;
   hideTitle?: boolean;
   schemaMappingConfig: TSchemaMappingConfiguration | undefined;
   rootElement?: string;

--- a/src/features/scan-config/hooks/use-diff-preview-atom.ts
+++ b/src/features/scan-config/hooks/use-diff-preview-atom.ts
@@ -23,7 +23,7 @@ import type { ConfigValue } from '../types';
 export function useDiffPreviewAtom(
   selectedRootElement: string,
   selectedEntry?: string
-): ReturnType<typeof atom<Record<string, ConfigValue>>> | null {
+): ReturnType<typeof atom<Record<string, ConfigValue | ConfigValue[]>>> | null {
   const { aiConfig } = useAIConfig();
   const highlights = useAtomValue(configHighlightsAtom);
   const showingDiffs = highlights.length > 0;
@@ -43,7 +43,7 @@ export function useDiffPreviewAtom(
   }, [showingDiffs, aiConfig, selectedRootElement, selectedEntry]);
 
   return useMemo(
-    () => (previewData ? atom<Record<string, ConfigValue>>(previewData) : null),
+    () => (previewData ? atom<Record<string, ConfigValue | ConfigValue[]>>(previewData) : null),
     [previewData]
   );
 }

--- a/src/features/scan-config/template.tsx
+++ b/src/features/scan-config/template.tsx
@@ -2,7 +2,7 @@
 
 import { get } from 'es-toolkit/compat';
 import { useAtom } from 'jotai';
-import { Suspense, useState } from 'react';
+import { Suspense, useLayoutEffect, useState } from 'react';
 import { match } from 'ts-pattern';
 
 import { useEntries } from '@/features/scan-config/components/hooks';
@@ -19,6 +19,7 @@ import {
 } from '@/features/scan-config/helpers';
 import {
   type ConfigSchema,
+  isType,
   ScanConfigActivity,
   ScanConfigDefaultTab,
   ScanConfigTabs,
@@ -85,6 +86,20 @@ export function ScanConfigTemplate({
   const [selectedRootElement, setSelectedRootElement] = useAtom(selectedRootElementAtom);
   const [editing, setEditing] = useAtom(editingAtom);
   const [selectedEntry, setSelectedEntry] = useAtom(selectedEntryAtom);
+
+  useLayoutEffect(() => {
+    const firstRoot = Object.entries(schema.properties).find(([, spec]) => !isType(spec))?.[0];
+    if (!firstRoot) return;
+
+    const rootSpec = selectedRootElement ? schema.properties[selectedRootElement] : undefined;
+    const hasValidSelection =
+      Boolean(selectedRootElement) && rootSpec !== undefined && !isType(rootSpec);
+    if (hasValidSelection) return;
+
+    setSelectedRootElement(firstRoot);
+    setSelectedEntry('');
+  }, [schema, selectedRootElement, setSelectedEntry, setSelectedRootElement]);
+
   const [loading, setLoading] = useState(false);
   const [campaignId, setCampaignId] = useState(initialCampaignId ?? '');
   const [isEditingKey, setIsEditingKey] = useState(false);
@@ -96,6 +111,11 @@ export function ScanConfigTemplate({
     model: entity,
   });
   const config = useConfigAtom(schema, atomsMap);
+  const selectedSchemaCandidate = schema.properties[selectedRootElement];
+  const selectedSchema =
+    selectedSchemaCandidate !== undefined && !isType(selectedSchemaCandidate)
+      ? selectedSchemaCandidate
+      : undefined;
   const previousCampaignId = usePrevious(campaignId);
   const isCampaignIdChanged = previousCampaignId !== campaignId;
 
@@ -103,6 +123,7 @@ export function ScanConfigTemplate({
 
   const configurationTabId = ScanConfigTabs[activity].configuration;
   const isConfigurationTab = tab.id === configurationTabId;
+
   const results = match(activity)
     .with(ScanConfigActivity.Simulate, () => (
       <Suspense>
@@ -204,9 +225,9 @@ export function ScanConfigTemplate({
               'h-full min-w-0 overflow-x-hidden overflow-y-auto secondary-scrollbar border-r border-l border-gray-200 px-3'
             )}
           >
-            {editing && (
+            {editing && selectedSchema !== undefined && (
               <Middle
-                key={selectedRootElement + selectedEntry}
+                key={`${schemaName}_${selectedRootElement}_${selectedEntry}`}
                 schemaName={schemaName}
                 schema={schema}
                 selectedRootElement={selectedRootElement}
@@ -224,7 +245,7 @@ export function ScanConfigTemplate({
                   setNewKey('');
                   setIsEditingKey(false);
                 }}
-                selectedSchema={schema.properties[selectedRootElement]}
+                selectedSchema={selectedSchema}
                 schemaMappingConfig={schemaMappingConfig}
                 entityType={entityType}
               />


### PR DESCRIPTION
this is basically happen when the user in a specific scan configuration (let's say microcircuit sim)
and the user select a root block, then the user switch to another type of scan configuration and the previously selected root block is not available 

**TODO**: reset all atoms after the user quit a specific page of scan config