### PR TITLE
Update GH actions and package manager version

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.head_ref != 'develop' && !contains(join(github.event.pull_request.labels.*.name, ','), 'skip docs')
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -29,7 +29,7 @@ jobs:
       preview-url: ${{ steps.get-url.outputs.url }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.PREVIEW_DEPLOY_AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -78,7 +78,7 @@ jobs:
           echo "url=https://${{ steps.vars.outputs.domain-safe-branch }}.${{ env.PREVIEW_DOMAIN }}" >> $GITHUB_OUTPUT
 
       - name: Post initial comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           PREVIEW_URL: ${{ steps.get-url.outputs.url }}
         with:
@@ -127,13 +127,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.PREVIEW_DEPLOY_AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Monitor build and update comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           JOB_ID: ${{ needs.deploy.outputs.job-id }}
           BRANCH_NAME: ${{ needs.deploy.outputs.branch-name }}
@@ -240,7 +240,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- amplify-preview-comment -->';

--- a/.github/workflows/release-aws.yml
+++ b/.github/workflows/release-aws.yml
@@ -20,7 +20,7 @@ jobs:
           exit 1
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Get full history to check existing tags
 
@@ -59,7 +59,7 @@ jobs:
           echo "Using app version: ${APP_VERSION}"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.PUBLICECR_UPLOAD_ROLE_ARN }}
           aws-region: ${{ vars.PUBLICECR_REGION }}

--- a/.github/workflows/run-audit.yml
+++ b/.github/workflows/run-audit.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
-          version: 10
+          version: 11
 
       - name: Set-up Node
         uses: actions/setup-node@v6
@@ -36,7 +36,7 @@ jobs:
         run: cat pnpm-audit-output.json | jq .
 
       - name: Upload audit output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pnpm-audit-output.json
           path: pnpm-audit-output.json

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -21,17 +21,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
-          version: 10
+          version: 11
 
       - name: Set-up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "pnpm"
@@ -47,14 +47,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
-          version: 10
+          version: 11
 
       - name: Set-up Node
         uses: actions/setup-node@v6
@@ -63,7 +63,7 @@ jobs:
           cache: "pnpm"
 
       - name: Cache Next.js
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@10 --activate
+RUN corepack enable && corepack prepare pnpm@11 --activate
 
 # Install dependencies based on the preferred package manager
 COPY pnpm-lock.yaml package.json ./

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "author": "Blue Brain Project/EPFL",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@11.0.8",
   "scripts": {
     "dev": "APP_VERSION=$(make version) next dev",
     "dev:inspect": "APP_VERSION=$(make version) next dev --inspect",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "author": "Blue Brain Project/EPFL",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@11.0.8",
   "scripts": {
     "dev": "APP_VERSION=$(make version) next dev",
     "dev:inspect": "APP_VERSION=$(make version) next dev --inspect",


### PR DESCRIPTION
## Summary

  Bumps GitHub Actions to current stable majors and moves CI/Docker from pnpm 10 → 11.

  ### Action version bumps

  | Action | Before | After |
  |---|---|---|
  | `actions/checkout` | v4 | v6 |
  | `actions/setup-node` (lint job) | v4 | v6 |
  | `actions/cache` | v4 | v5 |
  | `pnpm/action-setup` | v4 (`version: 10`) | v6 (`version: 11`) |
  | `actions/github-script` | v7 | v9 |
  | `aws-actions/configure-aws-credentials` | v4 / v5 | v6 |
  | `actions/upload-artifact` | v4 | v7 |

  `aws-actions/amazon-ecr-login@v2` left as-is (already current major).

  ### Other changes
  - `Dockerfile`: `corepack prepare pnpm@10` → `pnpm@11` to keep production aligned with CI.
  - `run-checks.yml`: also normalizes `setup-node` from `@v4` → `@v6` in the lint job (build job was already on `@v6`).

  ### Compatibility notes
  - `github-script@v9` is ESM-only and removes `require('@actions/github')`. Inline scripts in `deploy-preview.yml` only use injected `github` / `context` / `core` plus `require('child_process')` (Node built-in), so no script edits required.
  - `cache@v5` and `configure-aws-credentials@v6` require runner ≥ 2.327.1 — GitHub-hosted runners satisfy this.
  - `pnpm-lock.yaml` is `lockfileVersion: '9.0'`, compatible with pnpm 11; no regeneration needed.