### PR TITLE
Bump CI actions version to latest available ones

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.head_ref != 'develop' && !contains(join(github.event.pull_request.labels.*.name, ','), 'skip docs')
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -29,7 +29,7 @@ jobs:
       preview-url: ${{ steps.get-url.outputs.url }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.PREVIEW_DEPLOY_AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -78,7 +78,7 @@ jobs:
           echo "url=https://${{ steps.vars.outputs.domain-safe-branch }}.${{ env.PREVIEW_DOMAIN }}" >> $GITHUB_OUTPUT
 
       - name: Post initial comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           PREVIEW_URL: ${{ steps.get-url.outputs.url }}
         with:
@@ -127,13 +127,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.PREVIEW_DEPLOY_AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Monitor build and update comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           JOB_ID: ${{ needs.deploy.outputs.job-id }}
           BRANCH_NAME: ${{ needs.deploy.outputs.branch-name }}
@@ -240,7 +240,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- amplify-preview-comment -->';

--- a/.github/workflows/release-aws.yml
+++ b/.github/workflows/release-aws.yml
@@ -20,7 +20,7 @@ jobs:
           exit 1
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Get full history to check existing tags
 
@@ -59,7 +59,7 @@ jobs:
           echo "Using app version: ${APP_VERSION}"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.PUBLICECR_UPLOAD_ROLE_ARN }}
           aws-region: ${{ vars.PUBLICECR_REGION }}

--- a/.github/workflows/run-audit.yml
+++ b/.github/workflows/run-audit.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
@@ -36,7 +36,7 @@ jobs:
         run: cat pnpm-audit-output.json | jq .
 
       - name: Upload audit output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pnpm-audit-output.json
           path: pnpm-audit-output.json

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -21,17 +21,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
       - name: Set-up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "pnpm"
@@ -47,12 +47,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
@@ -63,7 +63,7 @@ jobs:
           cache: "pnpm"
 
       - name: Cache Next.js
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache


### PR DESCRIPTION
Fixes warnings related to:

Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/github-script@v7, aws-actions/configure-aws-credentials@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/