### PR TITLE
Fix SwipeableCardsList logic

### DIFF
--- a/src/components/LandingPage/components/swipeable-cards-list/swipeable-cards-list.tsx
+++ b/src/components/LandingPage/components/swipeable-cards-list/swipeable-cards-list.tsx
@@ -1,12 +1,11 @@
-/* eslint-disable react/no-array-index-key */
-/* eslint-disable no-param-reassign */
-import React, { CSSProperties, type JSX } from 'react';
+import { type CSSProperties, type JSX, useCallback, useEffect, useId, useState } from 'react';
+
+import { classNames } from '@/util/utils';
 
 import { IconChevronLeft } from '../../icons/IconChevronLeft';
 import { IconChevronRight } from '../../icons/IconChevronRight';
 import { styleButtonSquare } from '../../styles';
 
-import { classNames } from '@/util/utils';
 import styles from './swipeable-cards-list.module.css';
 
 interface SwipeableCardsListProps {
@@ -30,13 +29,13 @@ export default function SwipeableCardsList({
   gap = '48px',
   style = {},
 }: SwipeableCardsListProps) {
-  const id = React.useId();
-  const makeId = (index: number) => `${id}_${index}`;
-  const ref = React.useRef<HTMLDivElement | null>(null);
-  const [newsIndex, setNewsIndex] = React.useState(0);
+  const id = useId();
+  const makeId = useCallback((index: number) => `${id}_${index}`, [id]);
+  const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
+  const [newsIndex, setNewsIndex] = useState(0);
   const count = children.length;
-  const moveTo = useMoveTo(ref.current, count, makeId);
-  useScrollWatcher(ref.current, count, setNewsIndex, makeId);
+  const moveTo = useMoveTo(scrollEl, count, makeId);
+  useScrollWatcher(scrollEl, count, setNewsIndex, makeId);
   const handleMoveLeft = () => {
     moveTo((newsIndex + count - 1) % count);
   };
@@ -49,7 +48,7 @@ export default function SwipeableCardsList({
       className={classNames(className, styles.swipeableCardsList)}
       style={{ ...style, '--custom-gap': gap }}
     >
-      <div ref={ref} className={styles.scroll}>
+      <div ref={setScrollEl} className={styles.scroll}>
         {children.map((child, index) => {
           const key = makeId(index);
           return (
@@ -102,16 +101,15 @@ export default function SwipeableCardsList({
 }
 
 function useMoveTo(div: HTMLDivElement | null, count: number, makeId: (index: number) => string) {
-  return React.useCallback(
+  return useCallback(
     (index: number) => {
       if (!div || count === 0) return;
 
       const card = document.getElementById(makeId(index));
       if (!card) return;
 
-      // Calculate scroll position: card's left edge relative to container's left edge
-      // Since card is a direct child of the scroll container, offsetLeft gives us the position
-      const scrollPosition = card.offsetLeft;
+      const scrollPosition =
+        div.scrollLeft + card.getBoundingClientRect().left - div.getBoundingClientRect().left;
 
       div.scrollTo({
         left: scrollPosition,
@@ -128,7 +126,7 @@ function useScrollWatcher(
   setCardIndex: React.Dispatch<React.SetStateAction<number>>,
   makeId: (index: number) => string
 ) {
-  React.useEffect(() => {
+  useEffect(() => {
     if (!div || count === 0) return;
 
     const handleScroll = () => {


### PR DESCRIPTION
## Summary

Fixes two bugs in `SwipeableCardsList` that broke its navigation controls.

### 1. Arrow / pagination buttons did nothing & active dot never updated on scroll

`ref.current` was read during render and passed into the `useMoveTo` / `useScrollWatcher` hooks. On first render the ref is still `null`, so:

- `useMoveTo`'s `useCallback` captured `div = null` → click handlers hit the early `return` and did nothing.
- `useScrollWatcher`'s effect bailed out before attaching the `scroll` listener, so `newsIndex` never updated as the user scrolled.

The ref attached after commit, but since reading `ref.current` during render doesn't subscribe to changes, no re-render ever happened to feed the real node back into the hooks.

**Fix:** replace the `useRef` with a `useState`-backed callback ref (`setScrollEl`). The component re-renders when the node attaches, and both hooks receive the real DOM element. Also memoized `makeId` so effect deps are stable.

### 2. Clicking a pagination dot scrolled to the wrong card

`useMoveTo` used `card.offsetLeft` as the target scroll position. `offsetLeft` is relative to the nearest *positioned* ancestor — neither `.scroll` nor `.swipeableCardsList` is positioned, so the value included the container's own offset on the page, not the card's offset inside the scroller.

Symptoms:
- From index 1, clicking dot 0 was a no-op (target scroll equalled current scroll).
- From the last index, clicking dot 0 landed on dot 1.

**Fix:** compute the scroll target from bounding rects, which is independent of the offsetParent:

```ts
const scrollPosition =
  div.scrollLeft + card.getBoundingClientRect().left - div.getBoundingClientRect().left;
```