### PR TITLE
allow immediate running of notebook after upload

### DIFF
--- a/src/ui/segments/contribute/analysis-notebook-template/pipeline.ts
+++ b/src/ui/segments/contribute/analysis-notebook-template/pipeline.ts
@@ -33,20 +33,22 @@ export function useAnalysisNotebookTemplatePipeline({
   const { projectId, virtualLabId } = useWorkspace();
 
   const invalidateNotebookQueries = () =>
-    Promise.all([
-      queryClient.invalidateQueries({
-        predicate: (query) =>
-          query.queryKey[0] === `data-entity-count-${ExtendedEntitiesTypeDict.Notebook}`,
-      }),
-      queryClient.invalidateQueries({
-        predicate: (query) =>
+    queryClient.invalidateQueries({
+      predicate: (query) => {
+        const firstKeySegment = query.queryKey[0];
+
+        const matchesEntityCount =
+          firstKeySegment === `data-entity-count-${ExtendedEntitiesTypeDict.Notebook}`;
+
+        const matchesExtendedEntity =
           get(
-            (query.queryKey as ExtendedEntityTypeQueryKey)[0],
+            firstKeySegment as ExtendedEntityTypeQueryKey[0],
             'context.extendedEntityType'
-          ) === ExtendedEntitiesTypeDict.Notebook,
-      }),
-      queryClient.invalidateQueries(),
-    ]);
+          ) === ExtendedEntitiesTypeDict.Notebook;
+
+        return matchesEntityCount || matchesExtendedEntity;
+      },
+    });
 
   const createNotebookAsync = useMutation({
     mutationFn: (values: TAnalysisNotebookTemplateForm) =>

--- a/src/ui/segments/contribute/analysis-notebook-template/pipeline.ts
+++ b/src/ui/segments/contribute/analysis-notebook-template/pipeline.ts
@@ -32,6 +32,22 @@ export function useAnalysisNotebookTemplatePipeline({
   const queryClient = useQueryClient();
   const { projectId, virtualLabId } = useWorkspace();
 
+  const invalidateNotebookQueries = () =>
+    Promise.all([
+      queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === `data-entity-count-${ExtendedEntitiesTypeDict.Notebook}`,
+      }),
+      queryClient.invalidateQueries({
+        predicate: (query) =>
+          get(
+            (query.queryKey as ExtendedEntityTypeQueryKey)[0],
+            'context.extendedEntityType'
+          ) === ExtendedEntitiesTypeDict.Notebook,
+      }),
+      queryClient.invalidateQueries(),
+    ]);
+
   const createNotebookAsync = useMutation({
     mutationFn: (values: TAnalysisNotebookTemplateForm) =>
       createAnalysisNotebookTemplate({
@@ -42,20 +58,7 @@ export function useAnalysisNotebookTemplatePipeline({
           scale: values.setup.scale,
         },
       }),
-    onSettled: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          predicate: (query) =>
-            query.queryKey[0] === `data-entity-count-${ExtendedEntitiesTypeDict.Notebook}`,
-        }),
-        queryClient.invalidateQueries({
-          predicate: (query) =>
-            get((query.queryKey as ExtendedEntityTypeQueryKey)[0], 'context.extendedEntityType') ===
-            ExtendedEntitiesTypeDict.Notebook,
-        }),
-        queryClient.invalidateQueries(),
-      ]);
-    },
+    onSettled: invalidateNotebookQueries,
   });
 
   const deleteNotebookAsync = useMutation({
@@ -102,6 +105,7 @@ export function useAnalysisNotebookTemplatePipeline({
         });
       }
     },
+    onSettled: invalidateNotebookQueries,
   });
 
   const createContributionAsync = useMutation({


### PR DESCRIPTION
## Fix: Run button fails on newly uploaded notebooks without page refresh

### Problem

After contributing a new analysis notebook template, clicking **Run** in the action popover would silently do nothing. A full page refresh was required before the button worked.

### Root cause

`createNotebookAsync.onSettled` fired a query invalidation immediately after the notebook entity was created — before `uploadAssetsAsync` had run. The table re-fetched at that point and rendered the new row with `notebook.assets = []`.

In `ActionPopover`, `handleRunNotebook` does:

```ts
const asset = notebook.assets.find((n) => n.label === 'jupyter_notebook');
if (!asset) return;
```

With an empty `assets` array, `asset` was always `undefined` and the handler returned early with no error and no notification. A page refresh forced a fetch *after* the uploads had completed on the server, which is why it worked around the issue.

### Fix

Extracted the invalidation logic into a shared `invalidateNotebookQueries` helper and added `onSettled: invalidateNotebookQueries` to `uploadAssetsAsync`. This triggers a second query invalidation once all asset uploads have settled, ensuring the table row is re-fetched with a populated `assets` array before the user can interact with it.

No changes were needed in `ActionPopover` — its logic was correct throughout.

### Files changed

- `pipeline.ts` — added post-upload invalidation; extracted shared invalidation helper