### PR TITLE
Hide non-simulatable circuits in simulate workflows

### DIFF
--- a/src/api/entitycore/types/entities/circuit.ts
+++ b/src/api/entitycore/types/entities/circuit.ts
@@ -85,6 +85,7 @@ interface CircuitBase {
   experiment_date: string | null;
   contact_email: string | null;
   published_in: string | null;
+  has_electrical_cell_models: boolean;
 }
 
 export interface ICircuit
@@ -107,7 +108,9 @@ export interface ICircuitFilter
     SharedFilter,
     PaginationFilter,
     CircuitScaleFilter,
-    IlikeSearchFilter {}
+    IlikeSearchFilter {
+  has_electrical_cell_models?: boolean;
+}
 
 export type SonataCircuitNetworkEdgeConfigItem = {
   edges_file: string;

--- a/src/entity-configuration/domain/index.ts
+++ b/src/entity-configuration/domain/index.ts
@@ -16,7 +16,7 @@ import { IonChannelModelingCampaign } from '@/entity-configuration/domain/model/
 import { MEmodel } from '@/entity-configuration/domain/model/me-model';
 import { MEModelCircuit } from '@/entity-configuration/domain/model/me-model-circuit';
 import { MEModelWithSynapsesCircuit } from '@/entity-configuration/domain/model/me-model-with-synapses';
-import { Microcircuit } from '@/entity-configuration/domain/model/mirocircuit';
+import { Microcircuit } from '@/entity-configuration/domain/model/microcircuit';
 import { PairedNeuronCircuit } from '@/entity-configuration/domain/model/paired-neurons';
 import { SingleNeuronCircuit } from '@/entity-configuration/domain/model/single-neuron-circuit';
 import { SingleNeuronSynaptome } from '@/entity-configuration/domain/model/single-neuron-synaptome';

--- a/src/entity-configuration/domain/model/circuit.ts
+++ b/src/entity-configuration/domain/model/circuit.ts
@@ -76,6 +76,7 @@ export const Circuit: EntityCoreTypeConfig<ICircuit> = {
         CircuitScaleDictionary.Single,
         CircuitScaleDictionary.PairNeuron,
         CircuitScaleDictionary.SmallMicrocircuit,
+        CircuitScaleDictionary.Microcircuit,
       ],
       entity.scale
     ),

--- a/src/entity-configuration/domain/model/circuit.ts
+++ b/src/entity-configuration/domain/model/circuit.ts
@@ -69,6 +69,14 @@ export const Circuit: EntityCoreTypeConfig<ICircuit> = {
   isBookmarkable: false,
   isDownloadable: true,
   isCopyable: true,
-  isSimulatable: (scale: TCircuitScaleDictionary) =>
-    includes([CircuitScaleDictionary.SmallMicrocircuit, CircuitScaleDictionary.PairNeuron], scale),
+  isSimulatable: (entity: ICircuit) =>
+    entity.has_electrical_cell_models &&
+    includes(
+      [
+        CircuitScaleDictionary.Single,
+        CircuitScaleDictionary.PairNeuron,
+        CircuitScaleDictionary.SmallMicrocircuit,
+      ],
+      entity.scale
+    ),
 } as const;

--- a/src/entity-configuration/domain/model/me-model-with-synapses.ts
+++ b/src/entity-configuration/domain/model/me-model-with-synapses.ts
@@ -47,5 +47,5 @@ export const MEModelWithSynapsesCircuit: EntityCoreTypeConfig<ICircuit> = {
   isBookmarkable: false,
   isDownloadable: true,
   isCopyable: true,
-  isSimulatable: true,
+  isSimulatable: (entity: ICircuit) => entity.has_electrical_cell_models,
 } as const;

--- a/src/entity-configuration/domain/model/microcircuit.ts
+++ b/src/entity-configuration/domain/model/microcircuit.ts
@@ -50,5 +50,5 @@ export const Microcircuit: EntityCoreTypeConfig<ICircuit> = {
   isBookmarkable: false,
   isDownloadable: true,
   isCopyable: true,
-  isSimulatable: false,
+  isSimulatable: (entity: ICircuit) => entity.has_electrical_cell_models,
 } as const;

--- a/src/entity-configuration/domain/model/paired-neurons.ts
+++ b/src/entity-configuration/domain/model/paired-neurons.ts
@@ -46,6 +46,6 @@ export const PairedNeuronCircuit: EntityCoreTypeConfig<ICircuit> = {
   isBookmarkable: false,
   isDownloadable: true,
   isCopyable: true,
-  isSimulatable: false,
+  isSimulatable: (entity: ICircuit) => entity.has_electrical_cell_models,
   isDeletable: false,
 } as const;

--- a/src/entity-configuration/domain/model/single-neuron-circuit.ts
+++ b/src/entity-configuration/domain/model/single-neuron-circuit.ts
@@ -1,3 +1,5 @@
+import { includes } from 'es-toolkit/compat';
+
 import { getCircuit, getCircuits } from '@/api/entitycore/queries/model/circuit';
 import { CircuitScaleDictionary, type ICircuit } from '@/api/entitycore/types/entities/circuit';
 import { EntityTypeDict } from '@/api/entitycore/types/entity-type';
@@ -51,5 +53,5 @@ export const SingleNeuronCircuit: EntityCoreTypeConfig<ICircuit> = {
   isBookmarkable: false,
   isDownloadable: true,
   isCopyable: true,
-  isSimulatable: false,
+  isSimulatable: (entity: ICircuit) => entity.has_electrical_cell_models,
 } as const;

--- a/src/entity-configuration/domain/model/single-neuron-circuit.ts
+++ b/src/entity-configuration/domain/model/single-neuron-circuit.ts
@@ -1,5 +1,3 @@
-import { includes } from 'es-toolkit/compat';
-
 import { getCircuit, getCircuits } from '@/api/entitycore/queries/model/circuit';
 import { CircuitScaleDictionary, type ICircuit } from '@/api/entitycore/types/entities/circuit';
 import { EntityTypeDict } from '@/api/entitycore/types/entity-type';

--- a/src/entity-configuration/domain/model/small-microcircuit.ts
+++ b/src/entity-configuration/domain/model/small-microcircuit.ts
@@ -51,5 +51,5 @@ export const SmallMicrocircuit: EntityCoreTypeConfig<ICircuit> = {
   isBookmarkable: false,
   isDownloadable: true,
   isCopyable: true,
-  isSimulatable: false,
+  isSimulatable: (entity: ICircuit) => entity.has_electrical_cell_models,
 } as const;

--- a/src/entity-configuration/domain/types.ts
+++ b/src/entity-configuration/domain/types.ts
@@ -1,5 +1,4 @@
 import type { TEntityTypeDict } from '@/api/entitycore/types';
-import type { TCircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit';
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { AssetLabel, EntityCoreIdentifiable } from '@/api/entitycore/types/shared/global';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
@@ -93,7 +92,7 @@ export type EntityCoreTypeConfig<
   isDownloadable?: boolean;
   isCopyable?: boolean;
   isDeletable?: boolean;
-  isSimulatable: boolean | ((scale: TCircuitScaleDictionary) => boolean);
+  isSimulatable: boolean | ((entity: T) => boolean);
   isContributionOption?: boolean;
   isContributable?: boolean;
 };

--- a/src/ui/segments/action-menu.tsx
+++ b/src/ui/segments/action-menu.tsx
@@ -16,7 +16,6 @@ import NextLink from 'next/link';
 import { notFound, useRouter } from 'next/navigation';
 
 import { deleteCellMorphology } from '@/api/entitycore/queries/experimental/cell-morphology';
-import { EntityTypeDict } from '@/api/entitycore/types/entity-type';
 import {
   ExtendedEntitiesTypeDict,
   type TExtendedEntitiesTypeDict,
@@ -128,14 +127,10 @@ export default function ActionMenu({
     },
   });
 
-  const isAnatomicalCircuit =
-    entityType.type === EntityTypeDict.Circuit &&
-    (entity as ICircuit).has_electrical_cell_models === false;
-
   const isSimulatable =
-    (typeof entityType.isSimulatable === 'boolean'
+    typeof entityType.isSimulatable === 'boolean'
       ? entityType.isSimulatable
-      : 'scale' in entity && entityType.isSimulatable(entity.scale)) && !isAnatomicalCircuit;
+      : (entityType.isSimulatable as (e: typeof entity) => boolean)(entity);
 
   return (
     <div className="text-primary-9 mt-10 flex flex-col gap-5 px-5 text-base font-bold">

--- a/src/ui/segments/action-menu.tsx
+++ b/src/ui/segments/action-menu.tsx
@@ -128,14 +128,14 @@ export default function ActionMenu({
     },
   });
 
+  const isAnatomicalCircuit =
+    entityType.type === EntityTypeDict.Circuit &&
+    (entity as ICircuit).has_electrical_cell_models === false;
+
   const isSimulatable =
     (typeof entityType.isSimulatable === 'boolean'
       ? entityType.isSimulatable
-      : 'scale' in entity && entityType.isSimulatable(entity.scale)) &&
-    !(
-      entityType.type === EntityTypeDict.Circuit &&
-      (entity as ICircuit).has_electrical_cell_models === false
-    );
+      : 'scale' in entity && entityType.isSimulatable(entity.scale)) && !isAnatomicalCircuit;
 
   return (
     <div className="text-primary-9 mt-10 flex flex-col gap-5 px-5 text-base font-bold">

--- a/src/ui/segments/action-menu.tsx
+++ b/src/ui/segments/action-menu.tsx
@@ -16,6 +16,7 @@ import NextLink from 'next/link';
 import { notFound, useRouter } from 'next/navigation';
 
 import { deleteCellMorphology } from '@/api/entitycore/queries/experimental/cell-morphology';
+import { EntityTypeDict } from '@/api/entitycore/types/entity-type';
 import {
   ExtendedEntitiesTypeDict,
   type TExtendedEntitiesTypeDict,
@@ -128,9 +129,13 @@ export default function ActionMenu({
   });
 
   const isSimulatable =
-    typeof entityType.isSimulatable === 'boolean'
+    (typeof entityType.isSimulatable === 'boolean'
       ? entityType.isSimulatable
-      : 'scale' in entity && entityType.isSimulatable(entity.scale);
+      : 'scale' in entity && entityType.isSimulatable(entity.scale)) &&
+    !(
+      entityType.type === EntityTypeDict.Circuit &&
+      (entity as ICircuit).has_electrical_cell_models === false
+    );
 
   return (
     <div className="text-primary-9 mt-10 flex flex-col gap-5 px-5 text-base font-bold">

--- a/src/ui/segments/workflows/config/activities/simulate.ts
+++ b/src/ui/segments/workflows/config/activities/simulate.ts
@@ -2,6 +2,8 @@ import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity
 
 import type { IWorkflowDescriptor } from '../types';
 
+const simulatableCircuitFilters = { has_electrical_cell_models: true } as const;
+
 export const SimulateWorkflows: readonly IWorkflowDescriptor[] = [
   {
     sourceType: ExtendedEntitiesTypeDict.Memodel,
@@ -38,7 +40,7 @@ export const SimulateWorkflows: readonly IWorkflowDescriptor[] = [
     configurationInputs: [
       {
         type: ExtendedEntitiesTypeDict.SingleNeuronCircuit,
-        filters: { has_electrical_cell_models: true },
+        filters: simulatableCircuitFilters,
       },
     ],
     order: 5,
@@ -50,7 +52,7 @@ export const SimulateWorkflows: readonly IWorkflowDescriptor[] = [
     configurationInputs: [
       {
         type: ExtendedEntitiesTypeDict.PairedNeuronCircuit,
-        filters: { has_electrical_cell_models: true },
+        filters: simulatableCircuitFilters,
       },
     ],
     order: 6,
@@ -62,7 +64,7 @@ export const SimulateWorkflows: readonly IWorkflowDescriptor[] = [
     configurationInputs: [
       {
         type: ExtendedEntitiesTypeDict.SmallMicrocircuit,
-        filters: { has_electrical_cell_models: true },
+        filters: simulatableCircuitFilters,
       },
     ],
     order: 7,
@@ -74,7 +76,7 @@ export const SimulateWorkflows: readonly IWorkflowDescriptor[] = [
     configurationInputs: [
       {
         type: ExtendedEntitiesTypeDict.Microcircuit,
-        filters: { has_electrical_cell_models: true },
+        filters: simulatableCircuitFilters,
       },
     ],
     disabled: false,
@@ -86,7 +88,7 @@ export const SimulateWorkflows: readonly IWorkflowDescriptor[] = [
     configurationInputs: [
       {
         type: ExtendedEntitiesTypeDict.BrainRegion,
-        filters: { has_electrical_cell_models: true },
+        filters: simulatableCircuitFilters,
       },
     ],
     disabled: false,

--- a/src/ui/segments/workflows/config/activities/simulate.ts
+++ b/src/ui/segments/workflows/config/activities/simulate.ts
@@ -35,35 +35,60 @@ export const SimulateWorkflows: readonly IWorkflowDescriptor[] = [
   {
     sourceType: ExtendedEntitiesTypeDict.SingleNeuronCircuit,
     targetType: ExtendedEntitiesTypeDict.SingleNeuronCircuitSimulation,
-    configurationInputs: [{ type: ExtendedEntitiesTypeDict.SingleNeuronCircuit }],
+    configurationInputs: [
+      {
+        type: ExtendedEntitiesTypeDict.SingleNeuronCircuit,
+        filters: { has_electrical_cell_models: true },
+      },
+    ],
     order: 5,
     disabled: false,
   },
   {
     sourceType: ExtendedEntitiesTypeDict.PairedNeuronCircuit,
     targetType: ExtendedEntitiesTypeDict.PairedNeuronCircuitSimulation,
-    configurationInputs: [{ type: ExtendedEntitiesTypeDict.PairedNeuronCircuit }],
+    configurationInputs: [
+      {
+        type: ExtendedEntitiesTypeDict.PairedNeuronCircuit,
+        filters: { has_electrical_cell_models: true },
+      },
+    ],
     order: 6,
     disabled: false,
   },
   {
     sourceType: ExtendedEntitiesTypeDict.SmallMicrocircuit,
     targetType: ExtendedEntitiesTypeDict.SmallMicrocircuitSimulation,
-    configurationInputs: [{ type: ExtendedEntitiesTypeDict.SmallMicrocircuit }],
+    configurationInputs: [
+      {
+        type: ExtendedEntitiesTypeDict.SmallMicrocircuit,
+        filters: { has_electrical_cell_models: true },
+      },
+    ],
     order: 7,
     disabled: false,
   },
   {
     sourceType: ExtendedEntitiesTypeDict.Microcircuit,
     targetType: ExtendedEntitiesTypeDict.MicrocircuitSimulation,
-    configurationInputs: [{ type: ExtendedEntitiesTypeDict.Microcircuit }],
+    configurationInputs: [
+      {
+        type: ExtendedEntitiesTypeDict.Microcircuit,
+        filters: { has_electrical_cell_models: true },
+      },
+    ],
     disabled: false,
     order: 8,
   },
   {
     sourceType: ExtendedEntitiesTypeDict.BrainRegion,
     targetType: ExtendedEntitiesTypeDict.RegionCircuitSimulation,
-    configurationInputs: [{ type: ExtendedEntitiesTypeDict.BrainRegion }],
+    configurationInputs: [
+      {
+        type: ExtendedEntitiesTypeDict.BrainRegion,
+        filters: { has_electrical_cell_models: true },
+      },
+    ],
     disabled: false,
     order: 9,
   },


### PR DESCRIPTION
## Summary

Circuit entities with `has_electrical_cell_models: false` (purely anatomical / EM reconstructions, e.g. `MICrONS_v1`, `H01_v1`) were appearing as selectable in Simulate workflow pickers and exposing the "Simulate" action on the Circuit detail view, even though launching a simulation against them fails.

## Changes

- **`ICircuitFilter` / `CircuitBase`** (`src/api/entitycore/types/entities/circuit.ts`) — surface `has_electrical_cell_models` on the entity and add it as an optional filter (mirrors the `has_segmented_spines` precedent in `CellMorphologyFilter`).
- **`EntityCoreTypeConfig.isSimulatable` contract** (`src/entity-configuration/domain/types.ts`) — broadened from `boolean | ((scale: TCircuitScaleDictionary) => boolean)` to `boolean | ((entity: T) => boolean)`, so each entity type can express its own simulatability rule against its full entity shape rather than just the circuit scale.
- **Per-entity simulatability rules colocated in entity config** (`src/entity-configuration/domain/model/*.ts`):
  - `SingleNeuronCircuit`, `SmallMicrocircuit`, `Microcircuit` — `(entity) => entity.has_electrical_cell_models` (previously hard-coded `false`).
  - `Circuit` (base) — `(entity) => entity.has_electrical_cell_models && scale ∈ {Single, PairNeuron, SmallMicrocircuit, Microcircuit}`.
- **Action menu** (`src/ui/segments/action-menu.tsx`) — function-form `isSimulatable` now receives the entity directly; the simulatability rule lives in entity config rather than at the call site.
- **Simulate workflow pickers** (`src/ui/segments/workflows/config/activities/simulate.ts`) — shared `simulatableCircuitFilters = { has_electrical_cell_models: true }` constant applied as `configurationInputs.filters` on the 5 Circuit-backed workflows: Single Neuron, Paired Neuron, Small Microcircuit, Microcircuit, Region Circuit (BrainRegion).
- **Typo fix** — `domain/model/mirocircuit.ts` → `microcircuit.ts`.

## Scope

Synaptomes are intentionally untouched — `ISingleNeuronSynaptome` has no `has_electrical_models` field; synaptomes are always simulatable per the team. The anatomical-looking entries flagged in the issue's synaptome reproducer are expected to be Circuits surfacing in the wrong picker, which the Circuit-side filter resolves.

## Test plan

- [x] Open each Simulate workflow (Single Neuron / Paired / Small Microcircuit / Microcircuit / Region) — request to `/circuit` includes `has_electrical_cell_models=true`; structural circuits (`MICrONS_v1`, `H01_v1`) no longer appear; simulatable circuits still appear.
- [x] On a Circuit detail page with `has_electrical_cell_models: false` — Simulate action is hidden.
- [x] On a Circuit detail page with `has_electrical_cell_models: true` (Small Microcircuit / Pair Neuron) — Simulate action is visible and navigates to the configure page.
- [x] General Models-library browses of Microcircuit / SmallMicrocircuit — structural circuits still appear (filter must not apply outside Simulate).

***

Relates to [Synaptome beta - models without electrical models are selectable](https://github.com/openbraininstitute/prod-singlecell-simulation/issues/279).