### PR TITLE
Harden pnpm against supply chain attacks

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,8 @@ allowBuilds:
   esbuild: true
   lefthook: true
   sharp: true
+
+minimumReleaseAge: 10080
+minimumReleaseAgeStrict: true
+blockExoticSubdeps: true
+verifyDepsBeforeRun: error


### PR DESCRIPTION
## Summary

Adds four supply-chain hardening keys to `pnpm-workspace.yaml`. No code or lockfile changes.

## Changes

| Setting | Value | Effect |
|---|---|---|
| `minimumReleaseAge` | `10080` | Quarantines package versions <7 days old at resolution time |
| `minimumReleaseAgeStrict` | `true` | Fails install if no version satisfies the range, instead of silently falling back |
| `blockExoticSubdeps` | `true` | Refuses transitive deps resolved from `git:` or remote tarballs |
| `verifyDepsBeforeRun` | `error` | Refuses to run scripts when the lockfile has drifted from `package.json` |

The existing `allowBuilds` allowlist is untouched. pnpm 11 defaults (`strictDepBuilds`, `minimumReleaseAge=1440`) remain in force; this PR strengthens them.

## Rationale

Recent npm incidents (Sep 2025 chalk/debug, Shai-Hulud) were detected within hours. A 7-day strict window would have blocked every malicious release with margin. See https://pnpm.io/supply-chain-security.

## Test plan

- [x] `pnpm install --frozen-lockfile --prefer-offline` succeeds locally on pnpm 11.1.2
- [x] CI lint + build pass