### PR TITLE
Fix tigh margins that prevent us from seeing the axes labels

### DIFF
--- a/src/features/entities/neuron-simulation/experiment/visualization/layout-config.ts
+++ b/src/features/entities/neuron-simulation/experiment/visualization/layout-config.ts
@@ -1,4 +1,4 @@
-import Plotly from 'plotly.js-dist-min';
+import type Plotly from 'plotly.js-dist-min';
 
 export const PLOT_LAYOUT: Partial<Plotly.Layout> = {
   plot_bgcolor: '#fff',
@@ -22,7 +22,7 @@ export const PLOT_LAYOUT: Partial<Plotly.Layout> = {
   },
   showlegend: false,
   height: 320,
-  margin: { t: 20, r: 20, b: 20, l: 20 },
+  margin: { t: 20, r: 20, b: 50, l: 60 },
   legend: {
     orientation: 'h',
     yanchor: 'top',

--- a/src/features/entities/neuron-simulation/experiment/visualization/multi-plots-view/hooks.ts
+++ b/src/features/entities/neuron-simulation/experiment/visualization/multi-plots-view/hooks.ts
@@ -1,8 +1,9 @@
-import React from 'react';
 import Plotly from 'plotly.js-dist-min';
+import React from 'react';
 
-import { PlotInstance } from '../plots-parser';
 import { PLOT_CONFIG, PLOT_LAYOUT } from '../layout-config';
+
+import type { PlotInstance } from '../plots-parser';
 
 export function usePlotly(
   refPlot: React.RefObject<HTMLDivElement | null>,
@@ -26,10 +27,12 @@ export function usePlotly(
       return item;
     });
     const layout = structuredClone(PLOT_LAYOUT);
-    if (!layout.xaxis) layout.xaxis = { title: instance.xaxis };
-    else layout.xaxis.title = instance.xaxis;
-    if (!layout.yaxis) layout.yaxis = { title: instance.yaxis };
-    else layout.yaxis.title = instance.yaxis;
+    if (!layout.xaxis)
+      layout.xaxis = { title: { text: instance.xaxis, font: { size: 12 }, standoff: 6 } };
+    else layout.xaxis.title = { text: instance.xaxis, font: { size: 12 }, standoff: 6 };
+    if (!layout.yaxis)
+      layout.yaxis = { title: { text: instance.yaxis, font: { size: 12 }, standoff: 6 } };
+    else layout.yaxis.title = { text: instance.yaxis, font: { size: 12 }, standoff: 6 };
     layout.showlegend = false;
     layout.datarevision = performance.now();
     delete layout.height;

--- a/src/ui/segments/workflows/simulate/single-neuron/shared/elements/panel-selector.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/shared/elements/panel-selector.tsx
@@ -1,17 +1,17 @@
 'use client';
 
-import { parseAsString, SingleParserBuilder, useQueryState } from 'nuqs';
+import { parseAsString, type SingleParserBuilder, useQueryState } from 'nuqs';
 import { match } from 'ts-pattern';
 
-import { Content as SynaptomeContent } from '@/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome';
 import { Content as MEModelContent } from '@/ui/segments/workflows/simulate/single-neuron/memodel';
-import { Results } from '@/ui/segments/workflows/simulate/single-neuron/shared/steps/result';
-import { SimulationType } from '@/ui/segments/workflows/simulate/single-neuron/shared/types';
 import {
   PanelQueryParam,
-  WorkflowSimulatePanelKeys,
+  type WorkflowSimulatePanelKeys,
   WorkflowSimulatePanels,
 } from '@/ui/segments/workflows/simulate/single-neuron/shared/constant';
+import { Results } from '@/ui/segments/workflows/simulate/single-neuron/shared/steps/result';
+import { SimulationType } from '@/ui/segments/workflows/simulate/single-neuron/shared/types';
+import { Content as SynaptomeContent } from '@/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome';
 
 import type { IMEModel, ISingleNeuronSynaptome } from '@/api/entitycore/types';
 

--- a/src/ui/segments/workflows/simulate/single-neuron/shared/steps/result.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/shared/steps/result.tsx
@@ -1,21 +1,20 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
+import get from 'es-toolkit/compat/get';
 import { useAtomValue } from 'jotai';
+import dynamic from 'next/dynamic';
+import { useSearchParams } from 'next/navigation';
 import { match } from 'ts-pattern';
 
-import get from 'es-toolkit/compat/get';
-import dynamic from 'next/dynamic';
-
 import { SimulationColors } from '@/ui/segments/workflows/build/single-neuron-synaptome/helpers';
-import {
-  useCurrentSimulationConfig,
-  useRecordingPlotData,
-} from '@/ui/segments/workflows/simulate/single-neuron/shared/steps/hooks';
 import {
   SimulationStatus,
   simulationStatusAtomFamily,
 } from '@/ui/segments/workflows/simulate/single-neuron/shared/context';
+import {
+  useCurrentSimulationConfig,
+  useRecordingPlotData,
+} from '@/ui/segments/workflows/simulate/single-neuron/shared/steps/hooks';
 import { cn } from '@/utils/css-class';
 
 import type { PlotData } from '@/ui/segments/workflows/simulate/single-neuron/shared/types';


### PR DESCRIPTION
I fixed two things:

1. Tight margins in layout-config.ts — b: 20 and l: 20 didn't leave enough space for the axis title text to render visibly. Fixed to b: 50 and l: 60.
2. Title format — The axis titles were being set as plain strings, overwriting the structured { text, font, standoff } objects. Now they're set consistently as objects with proper font size and standoff spacing.

<img width="750" height="400" alt="image" src="https://github.com/user-attachments/assets/117a5960-ef72-4964-aa64-801f3c2ee039" />
