### PR TITLE
Enable SWR caching for heavy reused payloads

### DIFF
--- a/src/api/api-client.ts
+++ b/src/api/api-client.ts
@@ -1,10 +1,19 @@
 import isNil from 'es-toolkit/compat/isNil';
 import omitBy from 'es-toolkit/compat/omitBy';
 
+import {
+  checkCache,
+  clearCache,
+  scheduleRevalidation,
+  shouldUseCache,
+  storeInCache,
+} from '@/api/cache-storage';
 import { parseApiError } from '@/api/utils';
 import { getSession } from '@/auth-fetch';
 import { compactRecord } from '@/utils/dictionary';
 import { log } from '@/utils/logger';
+
+import type { CacheConfiguration } from '@/api/cache-storage';
 
 type BackoffStrategy = {
   type: 'exponential' | 'custom';
@@ -32,20 +41,12 @@ type RequestOptions = {
   next?: NextFetchRequestConfig;
 };
 
-// New cache configuration type
-type CacheConfiguration = {
-  enabled: boolean;
-  ttlInSeconds: number;
-  cacheName: string;
-  excludeUrls?: RegExp[];
-};
-
 type ApiClientOptions = {
   rootUri: string;
   token?: string;
   headers?: Record<string, string>;
   config?: RequestConfiguration;
-  cache?: CacheConfiguration; // Add cache configuration to options
+  cache?: CacheConfiguration;
 };
 
 export type ErrorCause<T extends Record<string, any>> = {
@@ -69,7 +70,7 @@ class ApiClient {
 
   private _retryOnException?: boolean;
 
-  private _cacheConfig?: CacheConfiguration; // Cache configuration
+  private _cacheConfig?: CacheConfiguration;
 
   private requestInterceptors: ((request: Request) => Promise<Request>)[] = [];
 
@@ -86,111 +87,63 @@ class ApiClient {
     this._backoff = config.backoff;
     this._retryOnError = config.retryOnError;
     this._retryOnException = config.retryOnException;
-    this._cacheConfig = cache; // Store cache configuration
+    this._cacheConfig = cache;
   }
 
-  /**
-   * checks if caching should be used for a specific URL
-   *
-   * @param {string} url - url to check
-   * @param {CacheConfiguration} cacheConfig - cache configuration
-   * @returns {boolean} whether caching should be used
-   */
-  private shouldUseCache(url: string, cacheConfig?: CacheConfiguration): boolean {
-    if (!cacheConfig?.enabled) return false;
-
-    // check if url is in the exclude list
-    if (cacheConfig.excludeUrls) {
-      for (const pattern of cacheConfig.excludeUrls) {
-        if (pattern.test(url)) return false;
-      }
+  private async decodeResponse<T>(response: Response, asRawResponse?: boolean): Promise<T> {
+    if (asRawResponse) {
+      return response as unknown as T;
     }
-
-    return true;
+    const contentType = response.headers.get('Content-Type') || '';
+    if (contentType.includes('application/json')) {
+      return response.json();
+    }
+    if (contentType.includes('text')) {
+      return (await response.text()) as unknown as T;
+    }
+    if (contentType.includes('application/octet-stream')) {
+      return (await response.blob()) as unknown as T;
+    }
+    return (await response.arrayBuffer()) as unknown as T;
   }
 
-  /**
-   * checks if a cached response exists and is still valid
-   *
-   * @param {string} url - url to fetch from cache
-   * @param {CacheConfiguration} cacheConfig -  cache configuration
-   * @returns {Promise<{ valid: boolean, response: Response | null }>} cache status and response
-   */
-  private async checkCache(
-    url: string,
-    cacheConfig: CacheConfiguration
-  ): Promise<{
-    valid: boolean;
-    response: Response | null;
-  }> {
-    if (typeof caches === 'undefined') {
-      return { valid: false, response: null };
+  private async executeNetworkRequest(
+    method: string,
+    urlString: string,
+    options: RequestOptions
+  ): Promise<Response> {
+    let request = new Request(urlString, {
+      method,
+      headers: compactRecord({
+        ...this._headers,
+        ...(this._token ? { Authorization: `Bearer ${this._token}` } : {}),
+        ...options.headers,
+      }),
+      body: (() => {
+        if (!options.body) {
+          return undefined;
+        }
+        if (options.body instanceof FormData) {
+          return options.body;
+        }
+        return JSON.stringify(options.body);
+      })(),
+      signal: options.signal,
+      cache: options.cache,
+      next: options.next,
+    });
+
+    for (const interceptor of this.requestInterceptors) {
+      request = await interceptor(request);
     }
 
-    try {
-      const cache = await caches.open(cacheConfig.cacheName);
-      const cachedResponse = await cache.match(url);
+    let response = await fetch(request);
 
-      if (!cachedResponse) {
-        return { valid: false, response: null };
-      }
-
-      // check if the cache has expired
-      const cacheDate = cachedResponse.headers.get('x-cache-timestamp');
-
-      if (!cacheDate) {
-        return { valid: false, response: cachedResponse };
-      }
-
-      const cacheTimestamp = parseInt(cacheDate, 10);
-      const now = Date.now();
-      const ageInSeconds = (now - cacheTimestamp) / 1000;
-
-      return {
-        valid: ageInSeconds < cacheConfig.ttlInSeconds,
-        response: cachedResponse,
-      };
-    } catch (e) {
-      log('warn', 'Cache API access failed:', e);
-      return { valid: false, response: null };
+    for (const interceptor of this.responseInterceptors) {
+      response = await interceptor(response);
     }
-  }
 
-  /**
-   * stores a response in the cache
-   *
-   * @param {string} url - url to use as the cache key
-   * @param {Response} response - response to cache
-   * @param {CacheConfiguration} cacheConfig - cache configuration
-   * @returns {Promise<void>}
-   */
-  private async storeInCache(
-    url: string,
-    response: Response,
-    cacheConfig: CacheConfiguration
-  ): Promise<void> {
-    if (typeof caches === 'undefined') return;
-
-    try {
-      const cache = await caches.open(cacheConfig.cacheName);
-
-      // Clone the response before using it
-      const responseToCache = response.clone();
-
-      // Create a new response with our custom timestamp header
-      const headers = new Headers(responseToCache.headers);
-      headers.set('x-cache-timestamp', Date.now().toString());
-
-      const cachedResponseToStore = new Response(await responseToCache.blob(), {
-        status: responseToCache.status,
-        statusText: responseToCache.statusText,
-        headers,
-      });
-
-      await cache.put(url, cachedResponseToStore);
-    } catch (e) {
-      log('warn', 'Failed to store in cache:', e);
-    }
+    return response;
   }
 
   /**
@@ -226,39 +179,25 @@ class ApiClient {
 
     const urlString = url.toString();
 
-    // determine if caching should be used for this request
     const requestCacheConfig = config.cache ?? this._cacheConfig;
     const useCache =
       method.toLowerCase() === 'get' &&
-      this.shouldUseCache(urlString, requestCacheConfig) &&
+      shouldUseCache(urlString, requestCacheConfig) &&
       !config.asRawResponse;
 
-    // get from cache first for "get" requests
     if (useCache && requestCacheConfig) {
-      const { valid, response: cachedResponse } = await this.checkCache(
-        urlString,
-        requestCacheConfig
-      );
+      const { state, response: cachedResponse } = await checkCache(urlString, requestCacheConfig);
 
-      if (valid && cachedResponse) {
-        log('debug', `[cached] ${urlString}`);
-        const contentType = cachedResponse.headers.get('Content-Type') || '';
-        if (config.asRawResponse) {
-          return cachedResponse as unknown as T;
+      if (cachedResponse && (state === 'fresh' || state === 'stale')) {
+        log('debug', `[cached:${state}] ${urlString}`);
+        if (state === 'stale') {
+          scheduleRevalidation(urlString, requestCacheConfig, () =>
+            this.executeNetworkRequest(method, urlString, options)
+          );
         }
-        if (contentType.includes('application/json')) {
-          return cachedResponse.json();
-        }
-        if (contentType.includes('text')) {
-          return (await cachedResponse.text()) as unknown as T;
-        }
-        if (contentType.includes('application/octet-stream')) {
-          return (await cachedResponse.blob()) as unknown as T;
-        }
-        return (await cachedResponse.arrayBuffer()) as unknown as T;
+        return this.decodeResponse<T>(cachedResponse, config.asRawResponse);
       }
 
-      // if cache is invalid or expired, continue with the request
       if (cachedResponse) {
         log('log', `Cache expired for ${urlString}, fetching fresh data`);
       }
@@ -266,36 +205,7 @@ class ApiClient {
 
     const runRequest = async (): Promise<T> => {
       attempt++;
-      let request = new Request(urlString, {
-        method,
-        headers: compactRecord({
-          ...this._headers,
-          ...(this._token ? { Authorization: `Bearer ${this._token}` } : {}),
-          ...options.headers,
-        }),
-        body: (() => {
-          if (!options.body) {
-            return undefined;
-          }
-          if (options.body instanceof FormData) {
-            return options.body;
-          }
-          return JSON.stringify(options.body);
-        })(),
-        signal: options.signal,
-        cache: options.cache,
-        next: options.next,
-      });
-
-      for (const interceptor of this.requestInterceptors) {
-        request = await interceptor(request);
-      }
-
-      let response = await fetch(request);
-
-      for (const interceptor of this.responseInterceptors) {
-        response = await interceptor(response);
-      }
+      const response = await this.executeNetworkRequest(method, urlString, options);
 
       if (!response.ok && (config.retryOnError ?? this._retryOnError) && attempt < maxAttempts) {
         const delay = this.calculateBackoff(attempt, config.backoff ?? this._backoff);
@@ -306,24 +216,11 @@ class ApiClient {
         return runRequest();
       }
 
-      // store successful GET responses in cache if caching is enabled
       if (useCache && response.ok && requestCacheConfig) {
-        await this.storeInCache(urlString, response, requestCacheConfig);
+        await storeInCache(urlString, response, requestCacheConfig);
       }
 
-      const contentType = response.headers.get('Content-Type') || '';
-      let responseData: T;
-      if (config.asRawResponse) {
-        responseData = response as unknown as T;
-      } else if (contentType.includes('application/json')) {
-        responseData = await response.json();
-      } else if (contentType.includes('text')) {
-        responseData = (await response.text()) as unknown as T;
-      } else if (contentType.includes('application/octet-stream')) {
-        responseData = (await response.blob()) as unknown as T;
-      } else {
-        responseData = (await response.arrayBuffer()) as unknown as T;
-      }
+      const responseData = await this.decodeResponse<T>(response, config.asRawResponse);
 
       if (!response.ok) {
         if ((config.retryOnError ?? this._retryOnError) && attempt < maxAttempts) {
@@ -335,12 +232,12 @@ class ApiClient {
           return runRequest();
         }
         log('error', 'Request failed', {
-          url: url.toString(),
+          url: urlString,
           status: response.status,
           message: (responseData as any).message || `Request failed with status ${response.status}`,
           data: responseData,
         });
-        throw await parseApiError(request.url, response.status, responseData);
+        throw await parseApiError(urlString, response.status, responseData);
       }
 
       return responseData;
@@ -379,34 +276,10 @@ class ApiClient {
     return backoff.type === 'exponential' ? backoff.delay * 2 ** (attempt - 1) : backoff.delay;
   }
 
-  /**
-   * clears all cached responses or specific URL
-   *
-   * @param {string} [url] - optional specific url to clear from cache
-   * @returns {Promise<boolean>} Whether the operation succeeded
-   */
   async clearCache(url?: string): Promise<boolean> {
-    if (!this._cacheConfig?.enabled || typeof caches === 'undefined') {
-      return false;
-    }
-
-    try {
-      const cache = await caches.open(this._cacheConfig.cacheName);
-
-      if (url) {
-        // Clear specific URL
-        const fullUrl = new URL(url, this._rootUrl).toString();
-        await cache.delete(fullUrl);
-      } else {
-        // Clear all cache
-        await caches.delete(this._cacheConfig.cacheName);
-      }
-
-      return true;
-    } catch (e) {
-      log('error', 'Failed to clear cache:', e);
-      return false;
-    }
+    if (!this._cacheConfig) return false;
+    const fullUrl = url ? new URL(url, this._rootUrl).toString() : undefined;
+    return clearCache(this._cacheConfig, fullUrl);
   }
 
   get<T>(

--- a/src/api/cache-storage.ts
+++ b/src/api/cache-storage.ts
@@ -55,9 +55,7 @@ export async function checkCache(
 
   try {
     const cache = await caches.open(cacheConfig.cacheName);
-    // ignoreVary: defensive against entries stored by older versions of this
-    // wrapper that carried over a `Vary` header from a redirected origin.
-    const cachedResponse = await cache.match(url, { ignoreVary: true });
+    const cachedResponse = await cache.match(url);
 
     if (!cachedResponse) {
       return { state: 'miss', response: null };

--- a/src/api/cache-storage.ts
+++ b/src/api/cache-storage.ts
@@ -1,0 +1,171 @@
+import { log } from '@/utils/logger';
+
+export type CacheConfiguration = {
+  enabled: boolean;
+  ttlInSeconds: number;
+  cacheName: string;
+  excludeUrls?: RegExp[];
+  // When set, a cached entry whose age is between ttlInSeconds and
+  // (ttlInSeconds + staleWhileRevalidateSeconds) is returned immediately while a
+  // background fetch refreshes the cache. Past that window, treat as a miss.
+  staleWhileRevalidateSeconds?: number;
+};
+
+export type CacheState = 'fresh' | 'stale' | 'expired' | 'miss';
+
+// Defaults: 1 day fresh, 6 days stale-while-revalidate. Tuned for slow-changing
+// reference data (atlas regions, meshes, point clouds, composition summary).
+// Override per call site when a different cadence makes sense.
+export function swrCacheConfig(
+  cacheName: string,
+  ttlInSeconds: number = 24 * 60 * 60,
+  staleWhileRevalidateSeconds: number = 6 * 24 * 60 * 60
+): CacheConfiguration {
+  return {
+    enabled: true,
+    cacheName,
+    ttlInSeconds,
+    staleWhileRevalidateSeconds,
+  };
+}
+
+// Module-level dedupe map so concurrent stale reads coalesce into a single
+// background fetch per URL across all callers.
+const inflightRevalidations = new Map<string, Promise<void>>();
+
+export function shouldUseCache(url: string, cacheConfig?: CacheConfiguration): boolean {
+  if (!cacheConfig?.enabled) return false;
+
+  if (cacheConfig.excludeUrls) {
+    for (const pattern of cacheConfig.excludeUrls) {
+      if (pattern.test(url)) return false;
+    }
+  }
+
+  return true;
+}
+
+export async function checkCache(
+  url: string,
+  cacheConfig: CacheConfiguration
+): Promise<{ state: CacheState; response: Response | null }> {
+  if (typeof caches === 'undefined') {
+    return { state: 'miss', response: null };
+  }
+
+  try {
+    const cache = await caches.open(cacheConfig.cacheName);
+    // ignoreVary: defensive against entries stored by older versions of this
+    // wrapper that carried over a `Vary` header from a redirected origin.
+    const cachedResponse = await cache.match(url, { ignoreVary: true });
+
+    if (!cachedResponse) {
+      return { state: 'miss', response: null };
+    }
+
+    const cacheDate = cachedResponse.headers.get('x-cache-timestamp');
+
+    if (!cacheDate) {
+      return { state: 'expired', response: cachedResponse };
+    }
+
+    const cacheTimestamp = parseInt(cacheDate, 10);
+    const ageInSeconds = (Date.now() - cacheTimestamp) / 1000;
+
+    if (ageInSeconds < cacheConfig.ttlInSeconds) {
+      return { state: 'fresh', response: cachedResponse };
+    }
+
+    const swrWindow = cacheConfig.staleWhileRevalidateSeconds ?? 0;
+    if (ageInSeconds < cacheConfig.ttlInSeconds + swrWindow) {
+      return { state: 'stale', response: cachedResponse };
+    }
+
+    return { state: 'expired', response: cachedResponse };
+  } catch (e) {
+    log('warn', 'Cache API access failed:', e);
+    return { state: 'miss', response: null };
+  }
+}
+
+export async function storeInCache(
+  url: string,
+  response: Response,
+  cacheConfig: CacheConfiguration
+): Promise<void> {
+  if (typeof caches === 'undefined') return;
+
+  try {
+    const cache = await caches.open(cacheConfig.cacheName);
+
+    const responseToCache = response.clone();
+
+    // Only keep the Content-Type (needed for decode) and our timestamp.
+    // Dropping the rest avoids inheriting headers from a redirected origin
+    // (e.g. S3's `Vary: Origin`) that would poison cache.match() lookups.
+    const headers = new Headers();
+    const sourceContentType = responseToCache.headers.get('Content-Type');
+    if (sourceContentType) headers.set('Content-Type', sourceContentType);
+    headers.set('x-cache-timestamp', Date.now().toString());
+
+    const body = await responseToCache.blob();
+    headers.set('Content-Length', body.size.toString());
+
+    const cachedResponseToStore = new Response(body, {
+      status: responseToCache.status,
+      statusText: responseToCache.statusText,
+      headers,
+    });
+
+    await cache.put(url, cachedResponseToStore);
+  } catch (e) {
+    log('warn', 'Failed to store in cache:', e);
+  }
+}
+
+// Fire-and-forget background revalidation. Coalesces concurrent calls for the
+// same URL via inflightRevalidations. A non-ok Response and a thrown error
+// both leave the stale entry untouched; throwing makes the failure visible in
+// logs, returning a non-ok Response is silent. Fetchers do not get retry
+// semantics here — transient failures wait until the next user read.
+export function scheduleRevalidation(
+  url: string,
+  cacheConfig: CacheConfiguration,
+  fetcher: () => Promise<Response>
+): void {
+  if (inflightRevalidations.has(url)) return;
+
+  const task = (async () => {
+    try {
+      const response = await fetcher();
+      if (response.ok) {
+        await storeInCache(url, response, cacheConfig);
+      }
+    } catch (e) {
+      log('warn', `Background revalidation failed for ${url}`, e);
+    } finally {
+      inflightRevalidations.delete(url);
+    }
+  })();
+
+  inflightRevalidations.set(url, task);
+}
+
+export async function clearCache(cacheConfig: CacheConfiguration, url?: string): Promise<boolean> {
+  if (!cacheConfig.enabled || typeof caches === 'undefined') {
+    return false;
+  }
+
+  try {
+    if (url) {
+      const cache = await caches.open(cacheConfig.cacheName);
+      await cache.delete(url);
+    } else {
+      await caches.delete(cacheConfig.cacheName);
+    }
+    return true;
+  } catch (e) {
+    log('error', 'Failed to clear cache:', e);
+    return false;
+  }
+}

--- a/src/api/cache-storage.ts
+++ b/src/api/cache-storage.ts
@@ -14,7 +14,7 @@ export type CacheConfiguration = {
 export type CacheState = 'fresh' | 'stale' | 'expired' | 'miss';
 
 // Defaults: 1 day fresh, 6 days stale-while-revalidate. Tuned for slow-changing
-// reference data (atlas regions, meshes, point clouds, composition summary).
+// reference data (meshes, point clouds, composition summary).
 // Override per call site when a different cadence makes sense.
 export function swrCacheConfig(
   cacheName: string,

--- a/src/api/entitycore/queries/assets/index.ts
+++ b/src/api/entitycore/queries/assets/index.ts
@@ -5,6 +5,7 @@ import { getEntityCoreContext } from '@/api/entitycore/utils';
 import { config } from '@/config';
 import { compactRecord } from '@/utils/dictionary';
 
+import type { CacheConfiguration } from '@/api/cache-storage';
 import type { TEntityTypeDict } from '@/api/entitycore/types/entity-type';
 import type {
   AssetLabel,
@@ -73,6 +74,7 @@ export async function downloadAsset(params: {
   asRawResponse: true;
   retryOnError?: boolean;
   signal?: AbortSignal;
+  cache?: CacheConfiguration;
 }): Promise<Response>;
 
 export async function downloadAsset<T>(params: {
@@ -84,6 +86,7 @@ export async function downloadAsset<T>(params: {
   asRawResponse?: false;
   retryOnError?: boolean;
   signal?: AbortSignal;
+  cache?: CacheConfiguration;
 }): Promise<T>;
 
 /**
@@ -104,6 +107,7 @@ export async function downloadAsset<T>({
   retryOnError = false,
   assetPath = '',
   signal,
+  cache,
 }: {
   ctx?: WorkspaceContext | null;
   entityType: TEntityTypeDict;
@@ -113,6 +117,7 @@ export async function downloadAsset<T>({
   asRawResponse?: boolean;
   retryOnError?: boolean;
   signal?: AbortSignal;
+  cache?: CacheConfiguration;
 }): Promise<T | Response> {
   const api = await authApiClient(config.ENTITY_CORE_URL);
   return await api.get<T>(
@@ -122,7 +127,7 @@ export async function downloadAsset<T>({
       queryParams: compactRecord({ asset_path: assetPath }),
       signal,
     },
-    { asRawResponse, retryOnError }
+    { asRawResponse, retryOnError, cache }
   );
 }
 

--- a/src/api/entitycore/queries/general/brain-atlas.ts
+++ b/src/api/entitycore/queries/general/brain-atlas.ts
@@ -1,3 +1,4 @@
+import { swrCacheConfig } from '@/api/cache-storage';
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 
 import type {
@@ -83,16 +84,22 @@ export async function getBrainAtlasRegions({
   context?: WorkspaceContext | null;
 }) {
   const api = await entityCoreApi();
-  return await api.get<EntityCoreResponse<IBrainAtlasRegion>>(`${baseUri}/${atlasId}/regions`, {
-    queryParams: {
-      ...filters,
+  return await api.get<EntityCoreResponse<IBrainAtlasRegion>>(
+    `${baseUri}/${atlasId}/regions`,
+    {
+      queryParams: {
+        ...filters,
+      },
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+        ...getEntityCoreContext(context).headers,
+      },
     },
-    headers: {
-      accept: 'application/json',
-      'content-type': 'application/json',
-      ...getEntityCoreContext(context).headers,
-    },
-  });
+    // Cache only when no workspace context is set: Cache Storage keys by URL,
+    // so context-bearing requests would risk cross-org leakage.
+    context ? undefined : { cache: swrCacheConfig('brain-atlas-metadata') }
+  );
 }
 
 /**

--- a/src/api/entitycore/queries/general/brain-atlas.ts
+++ b/src/api/entitycore/queries/general/brain-atlas.ts
@@ -1,4 +1,3 @@
-import { swrCacheConfig } from '@/api/cache-storage';
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 
 import type {
@@ -84,22 +83,16 @@ export async function getBrainAtlasRegions({
   context?: WorkspaceContext | null;
 }) {
   const api = await entityCoreApi();
-  return await api.get<EntityCoreResponse<IBrainAtlasRegion>>(
-    `${baseUri}/${atlasId}/regions`,
-    {
-      queryParams: {
-        ...filters,
-      },
-      headers: {
-        accept: 'application/json',
-        'content-type': 'application/json',
-        ...getEntityCoreContext(context).headers,
-      },
+  return await api.get<EntityCoreResponse<IBrainAtlasRegion>>(`${baseUri}/${atlasId}/regions`, {
+    queryParams: {
+      ...filters,
     },
-    // Cache only when no workspace context is set: Cache Storage keys by URL,
-    // so context-bearing requests would risk cross-org leakage.
-    context ? undefined : { cache: swrCacheConfig('brain-atlas-metadata') }
-  );
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      ...getEntityCoreContext(context).headers,
+    },
+  });
 }
 
 /**

--- a/src/features/brain-atlas-viewer/api.ts
+++ b/src/features/brain-atlas-viewer/api.ts
@@ -1,25 +1,57 @@
+import {
+  checkCache,
+  scheduleRevalidation,
+  shouldUseCache,
+  storeInCache,
+  swrCacheConfig,
+} from '@/api/cache-storage';
+import { config } from '@/config';
 import { BRAIN_REGION_DOES_NOT_EXIST } from '@/constants/errors';
 
+const pointCloudCacheConfig = swrCacheConfig('brain-atlas-point-clouds');
+
 /**
- * Fetches the point cloud data from the Cells API
- *
- * @param url
+ * Fetches the point cloud data (Apache Arrow ArrayBuffer) from the Cells API
+ * with Cache Storage SWR persistence across page reloads.
  */
-export const fetchPointCloud = (url: string, token: string) =>
-  fetch(url, {
-    method: 'get',
-    headers: new Headers({
-      Accept: '*/*',
-      'nexus-token': token,
-    }),
-  }).then((response) => {
-    if (!response.ok) {
-      return response.json().then((errorData) => {
-        if (errorData.message.includes('No region ids found with region')) {
-          throw new Error(BRAIN_REGION_DOES_NOT_EXIST);
-        }
-        throw new Error(errorData.message);
-      });
+export async function fetchPointCloud(
+  params: { circuitId: string; annotationValue: number },
+  token: string
+): Promise<ArrayBuffer> {
+  const url = new URL(`${config.CELL_API_URL ?? ''}/circuit`);
+  url.searchParams.set('circuit_id', params.circuitId);
+  url.searchParams.set('region', String(params.annotationValue));
+  url.searchParams.set('how', 'arrow');
+  const urlString = url.toString();
+
+  const fetcher = () =>
+    fetch(urlString, {
+      method: 'get',
+      headers: new Headers({ Accept: '*/*', 'nexus-token': token }),
+    });
+
+  if (shouldUseCache(urlString, pointCloudCacheConfig)) {
+    const { state, response: cachedResponse } = await checkCache(urlString, pointCloudCacheConfig);
+    if (cachedResponse && (state === 'fresh' || state === 'stale')) {
+      if (state === 'stale') {
+        scheduleRevalidation(urlString, pointCloudCacheConfig, async () => {
+          const r = await fetcher();
+          if (!r.ok) throw new Error(`Point cloud revalidation failed: ${r.status}`);
+          return r;
+        });
+      }
+      return cachedResponse.arrayBuffer();
     }
-    return response.arrayBuffer();
-  });
+  }
+
+  const response = await fetcher();
+  if (!response.ok) {
+    const errorData = await response.json();
+    if (errorData.message?.includes('No region ids found with region')) {
+      throw new Error(BRAIN_REGION_DOES_NOT_EXIST);
+    }
+    throw new Error(errorData.message);
+  }
+  await storeInCache(urlString, response, pointCloudCacheConfig);
+  return response.arrayBuffer();
+}

--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/services/services.ts
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/services/services.ts
@@ -1,5 +1,6 @@
 import { tableFromIPC } from '@apache-arrow/es2015-esm';
 
+import { swrCacheConfig } from '@/api/cache-storage';
 import { AssetContentType } from '@/api/entitycore/types/shared/global';
 import { entityCoreApi } from '@/api/entitycore/utils';
 import { config } from '@/config';
@@ -26,6 +27,11 @@ export async function getCachedBrainRegionMeshArrayBuffer({
 
   const promise = getBrainRegionMeshArrayBufferQuery({ atlasId, regionId, queryClient });
   cacheMeshes.set(cacheKey, promise);
+
+  promise.catch(() => {
+    cacheMeshes.delete(cacheKey);
+  });
+
   return promise;
 }
 
@@ -61,7 +67,11 @@ async function getBrainRegionMeshArrayBufferQuery({
 
   const time = performance.now();
   const api = await entityCoreApi();
-  const data = await api.get(`/brain-atlas-region/${entity.id}/assets/${asset.id}/download`);
+  const data = await api.get(
+    `/brain-atlas-region/${entity.id}/assets/${asset.id}/download`,
+    undefined,
+    { cache: swrCacheConfig('brain-atlas-meshes') }
+  );
 
   log('debug', 'GLTF', `${performance.now() - time} msec`, data);
   const mesh = data instanceof ArrayBuffer ? data : null;
@@ -93,10 +103,10 @@ export async function getPointCouldData(annotationValue: number, accessToken: st
 }
 
 async function actualGetPointCouldData(annotationValue: number, accessToken: string) {
-  const url = `${config.CELL_API_URL}/circuit?circuit_id=${encodeURIComponent(
-    config.LEGACY_DEFAULT_CIRCUIT_ID || ''
-  )}&region=${annotationValue}&how=arrow`;
-  const rawData = await fetchPointCloud(url, accessToken);
+  const rawData = await fetchPointCloud(
+    { circuitId: config.LEGACY_DEFAULT_CIRCUIT_ID || '', annotationValue },
+    accessToken
+  );
   const table = tableFromIPC(rawData);
   const array = table.toArray();
   const dataPoint = new Float32Array(array.length * 4);

--- a/src/features/cell-composition/context.ts
+++ b/src/features/cell-composition/context.ts
@@ -1,6 +1,7 @@
 import { useQueries, useQuery } from '@tanstack/react-query';
 import { arrayToTree } from 'performant-array-to-tree';
 
+import { swrCacheConfig } from '@/api/cache-storage';
 import { getEtypes } from '@/api/entitycore/queries/annotations/etype';
 import { getMtypes } from '@/api/entitycore/queries/annotations/mtype';
 import { downloadAsset } from '@/api/entitycore/queries/assets';
@@ -57,6 +58,7 @@ const useCellCompositionSummaryQuery = () => {
         entityType: EntityTypeDict.CellComposition,
         entityId: cellComposition?.at(0)?.id!,
         id: summaryAsset?.id!,
+        cache: swrCacheConfig('cell-composition-summary-asset'),
       }),
     enabled: !!cellComposition?.at(0)?.id! && !!summaryAsset?.id,
     refetchOnWindowFocus: false,


### PR DESCRIPTION
## Why

A number of payloads were being re-fetched on every page load:

- **Point cloud** - Apache Arrow `ArrayBuffer` per circuit/region; large, recomputable backend response
- **Brain meshes** - GLB files sometimes having the size of up to 20 MBs.
- **Cell composition summary asset** - bulky JSON describing the full mouse atlas composition tree

Both are stable enough that aggressive client-side caching is safe, and large enough that re-downloading on every reload is a real cost (bandwidth + time-to-render). Persisting them in Cache Storage with a stale-while-revalidate window lets the next reload render instantly while a background fetch refreshes silently.

The SWR machinery already existed inside `ApiClient` (used for mesh GLBs), but `fetchPointCloud` bypasses `ApiClient` entirely because the cell-api needs a `nexus-token` header instead of `Authorization: Bearer`. Extracting the cache logic into its own module lets both `ApiClient`-driven and raw-`fetch` call sites share the same SWR implementation.

## Summary

- Extract Cache Storage SWR from `ApiClient` into a standalone `src/api/cache-storage.ts` module
- Add `swrCacheConfig(name, ttl?, swr?)` factory — 1d fresh / 6d stale-while-revalidate defaults match the existing mesh cache windows; per-call overrides for future tuning
- Cache point cloud responses (`fetchPointCloud`) and the cell composition summary asset (`downloadAsset` opt-in `cache` param)

## Behavior preserved

- `ApiClient` delegates to the extracted functions — tri-state (fresh/stale/expired), inflight-revalidation dedupe, header sanitisation, and `ignoreVary` on lookup are unchanged
- `downloadAsset`'s three overloads gain optional `cache?: CacheConfiguration`; the ~15 existing callers are untouched
- Mesh GLB caching continues to work identically

## Test plan

- [x] Hard-refresh a brain-atlas-viewer page → `brain-atlas-meshes`, `brain-atlas-point-clouds` populate in DevTools → Application → Cache Storage; second load shows `[cached:fresh]` logs with no network calls
- [x] Visit a page triggering `useCellCompositionQuery` → new `cell-composition-summary-asset` bucket populates; reload shows `[cached:fresh]`
- [x] Temporarily lower `ttlInSeconds` to force a stale read → verify exactly one background `/circuit` revalidation per URL
- [x] Point cloud error mapping (`BRAIN_REGION_DOES_NOT_EXIST`) surfaces unchanged
- [x] Other `downloadAsset` callers (NWB traces, ion-channel recording, thumbnails) still hit the network and don't appear in any Cache Storage bucket