### PR TITLE
fix(scan-config): preserve dictionary entry order on rename

### DIFF
--- a/src/features/scan-config/components/block-dictionary-entries.tsx
+++ b/src/features/scan-config/components/block-dictionary-entries.tsx
@@ -8,6 +8,7 @@ import {
   WarningFilled,
 } from '@ant-design/icons';
 import { Input } from 'antd';
+import { kebabCase } from 'es-toolkit/compat';
 import { atom, useAtom } from 'jotai';
 import { AnimatePresence, motion } from 'motion/react';
 import { Fragment, memo, useMemo } from 'react';
@@ -51,6 +52,7 @@ function EntryTab({
     /* biome-ignore lint/a11y/useSemanticElements: input cannot be nested inside button */
     <div
       role="button"
+      id={`${kebabCase(entryKey)}-menu-block-dictionary-sub-entry__item`}
       key={entryKey}
       className={cn(
         'text-primary-8 flex h-12.5 min-h-12.5 min-w-37.5 items-center justify-between ',
@@ -158,8 +160,11 @@ export default function BlockDictionaryEntries({
     allEntries.delete(selectedEntry);
     allEntries.add(newKey);
 
-    selectedTabAtoms[newKey] = selectedTabAtoms[selectedEntry];
-    delete selectedTabAtoms[selectedEntry];
+    const renamedTabAtoms = Object.fromEntries(
+      Object.entries(selectedTabAtoms).map(([key, value]) =>
+        key === selectedEntry ? [newKey, value] : [key, value]
+      )
+    );
 
     // Rename references
 
@@ -204,7 +209,10 @@ export default function BlockDictionaryEntries({
         });
       });
 
-    setAtomsMap({ ...atomsMap });
+    setAtomsMap({
+      ...atomsMap,
+      [selectedRootElement]: renamedTabAtoms,
+    });
 
     setIsEditingKey(false);
     setSelectedEntry(newKey);
@@ -238,7 +246,7 @@ export default function BlockDictionaryEntries({
     <AnimatePresence>
       {visible && (
         <motion.div
-          data-scan-config-menu="menu-block-dictionary-sub-entry"
+          data-scan-config-menu={`${rootElement}-menu-block-dictionary-sub-entry`}
           data-active={visible}
           key={rootElement}
           initial={{ y: -10, opacity: 0, height: 0, marginBottom: -12 }}
@@ -252,7 +260,10 @@ export default function BlockDictionaryEntries({
           transition={{ duration: 0.3, ease: 'linear' }}
           className={cn('flex flex-col w-full items-center z-0 mb-4!')}
         >
-          <div className="flex flex-col w-full gap-1.5 px-4">
+          <div
+            id={`${rootElement}-menu-block-dictionary-sub-entry__container`}
+            className="flex flex-col w-full gap-1.5 px-4"
+          >
             {/* Render deleted entries first with red border */}
             {deletedEntriesFromHighlights.map((entry) => renderBlockTab(entry, true))}
 


### PR DESCRIPTION
rebuild the atoms map in place when renaming `BlockDictionary` keys so items stay in their original position instead of moving to the end of the list