### PR TITLE
feat-110: multi selection UI (part-1)

### DIFF
--- a/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/build/configure/em-synapse-mapping-campaign/[id]/page.tsx
+++ b/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/build/configure/em-synapse-mapping-campaign/[id]/page.tsx
@@ -1,79 +1,11 @@
-import { notFound } from 'next/navigation';
+'use client';
 
-import { getCellMorphology } from '@/api/entitycore/queries';
-import { tryCatch } from '@/api/utils';
-import { EmSynapseMappingCampaign } from '@/entity-configuration/domain/model/em-synapse-mapping-campaign';
-import { ScanConfiguration } from '@/features/scan-config';
-import { ScanConfigCampaignOriginActionDict } from '@/features/scan-config/helpers';
-import { BuildScanConfigTabs, ScanConfigActivity } from '@/features/scan-config/types';
+import {
+  buildEmSynapseMappingWorkflow,
+  createScanConfigWorkflowPage,
+} from '@/features/scan-config/workflow';
 import { DownloadPanel } from '@/ui/segments/explore/circuit/elements/download-panel';
 
-import type { ServerSideComponentProp, WorkspaceContext } from '@/types/common';
-import type { WorkflowSimulatePanelKeys } from '@/ui/segments/workflows/simulate/single-neuron/shared/constant';
-import type { ExperimentStepKeys } from '@/ui/segments/workflows/simulate/single-neuron/shared/elements/menu';
-
-export default async function Page({
-  searchParams,
-  params: pathParams,
-}: ServerSideComponentProp<
-  WorkspaceContext & { id: string },
-  {
-    step: ExperimentStepKeys;
-    sessionId: string;
-    panel: WorkflowSimulatePanelKeys;
-    initialCampaignId: string;
-  }
->) {
-  const queryParams = await searchParams;
-  const { initialCampaignId } = queryParams;
-  const { virtualLabId, projectId, id: modelId } = await pathParams;
-
-  const { data: entity, error } = await tryCatch(
-    getCellMorphology({ id: modelId, context: { virtualLabId, projectId } })
-  );
-  if (!entity || error) {
-    return notFound();
-  }
-
-  let campaignData = null;
-  let campaignError = null;
-
-  if (initialCampaignId) {
-    const { data, error } = await tryCatch(
-      // biome-ignore lint/style/noNonNullAssertion: function is guaranteed to be defined
-      EmSynapseMappingCampaign.api.query.resolve!({
-        id: initialCampaignId,
-        context: { virtualLabId, projectId },
-      })
-    );
-
-    campaignData = data;
-    campaignError = error;
-
-    if (campaignError || !campaignData) {
-      return notFound();
-    }
-  }
-
-  if (!initialCampaignId || (initialCampaignId && campaignData?.config.form)) {
-    return (
-      <div className="border-neutral-2 ml-2 h-full rounded-2xl border">
-        <ScanConfiguration
-          entityId={entity.id}
-          entityType={entity.type}
-          virtualLabId={virtualLabId}
-          projectId={projectId}
-          initialConfig={campaignData?.config.form}
-          className="px-4"
-          activity={ScanConfigActivity.Build}
-          defaultTab={{
-            __activity: ScanConfigActivity.Build,
-            id: BuildScanConfigTabs.configuration,
-          }}
-          campaignOriginAction={ScanConfigCampaignOriginActionDict.Task}
-        />
-        <DownloadPanel />
-      </div>
-    );
-  }
-}
+export default createScanConfigWorkflowPage(buildEmSynapseMappingWorkflow, {
+  aside: <DownloadPanel />,
+});

--- a/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/extract/configure/circuit/[id]/page.tsx
+++ b/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/extract/configure/circuit/[id]/page.tsx
@@ -1,82 +1,11 @@
 'use client';
 
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { notFound } from 'next/navigation';
-import { use } from 'react';
-
-import { getCircuit } from '@/api/entitycore/queries/model/circuit';
-import { CircuitExtractionCampaign } from '@/entity-configuration/domain/extraction/extraction-campaign';
-import { ScanConfiguration } from '@/features/scan-config';
-import { ScanConfigCampaignOriginActionDict } from '@/features/scan-config/helpers';
-import { ExtractScanConfigTabs, ScanConfigActivity } from '@/features/scan-config/types';
+import {
+  createScanConfigWorkflowPage,
+  extractCircuitWorkflow,
+} from '@/features/scan-config/workflow';
 import { DownloadPanel } from '@/ui/segments/explore/circuit/elements/download-panel';
-import { keyBuilder } from '@/ui/use-query-keys/data';
 
-import type { ServerSideComponentProp, WorkspaceContext } from '@/types/common';
-import type { WorkflowSimulatePanelKeys } from '@/ui/segments/workflows/simulate/single-neuron/shared/constant';
-import type { ExperimentStepKeys } from '@/ui/segments/workflows/simulate/single-neuron/shared/elements/menu';
-
-export default function Page({
-  searchParams,
-  params: pathParams,
-}: ServerSideComponentProp<
-  WorkspaceContext & { id: string },
-  {
-    step: ExperimentStepKeys;
-    sessionId: string;
-    panel: WorkflowSimulatePanelKeys;
-    initialCampaignId: string;
-  }
->) {
-  const queryParams = use(searchParams);
-  const { initialCampaignId } = queryParams;
-  const { virtualLabId, projectId, id: modelId } = use(pathParams);
-
-  const { data: entity } = useSuspenseQuery({
-    queryKey: keyBuilder.oneCircuit({ virtualLabId, projectId, entityId: modelId }),
-    queryFn: () => getCircuit({ id: modelId, context: { virtualLabId, projectId } }),
-  });
-
-  const {
-    data: campaignData,
-    error,
-    isLoading,
-  } = useQuery({
-    queryKey: keyBuilder.simCampaign({ entityId: initialCampaignId }),
-    queryFn: async () => {
-      if (!initialCampaignId) return null;
-      const resolveExtractionCampaign = CircuitExtractionCampaign.api.query.resolve;
-      if (!resolveExtractionCampaign) return null;
-      return await resolveExtractionCampaign({
-        id: initialCampaignId,
-        context: { virtualLabId, projectId },
-      });
-    },
-  });
-
-  if (error || !entity) {
-    return notFound();
-  }
-
-  if (!initialCampaignId || (initialCampaignId && !isLoading && campaignData?.config.form)) {
-    return (
-      <div className="border-neutral-2 ml-2 h-full rounded-2xl border">
-        <ScanConfiguration
-          entityId={entity.id}
-          entityType={entity.type}
-          virtualLabId={virtualLabId}
-          projectId={projectId}
-          initialConfig={campaignData?.config.form}
-          className="px-4"
-          activity={ScanConfigActivity.Extract}
-          defaultTab={{
-            __activity: ScanConfigActivity.Extract,
-            id: ExtractScanConfigTabs.configuration,
-          }}
-          campaignOriginAction={ScanConfigCampaignOriginActionDict.Task}
-        />
-        <DownloadPanel />
-      </div>
-    );
-  }
-}
+export default createScanConfigWorkflowPage(extractCircuitWorkflow, {
+  aside: <DownloadPanel />,
+});

--- a/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/process/configure/em-cell-mesh/[id]/page.tsx
+++ b/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/process/configure/em-cell-mesh/[id]/page.tsx
@@ -1,79 +1,8 @@
 'use client';
 
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { notFound } from 'next/navigation';
-import { use } from 'react';
+import {
+  createScanConfigWorkflowPage,
+  processEmCellMeshWorkflow,
+} from '@/features/scan-config/workflow';
 
-import { getEmCellMesh } from '@/api/entitycore/queries';
-import { EntityTypeDict } from '@/api/entitycore/types';
-import { SkeletonizationCampaign } from '@/entity-configuration/domain/processing/skeletonization-campaign';
-import { ScanConfiguration } from '@/features/scan-config';
-import { ScanConfigActivity } from '@/features/scan-config/types';
-import { keyBuilder } from '@/ui/use-query-keys/data';
-
-import type { ServerSideComponentProp, WorkspaceContext } from '@/types/common';
-import type { WorkflowSimulatePanelKeys } from '@/ui/segments/workflows/simulate/single-neuron/shared/constant';
-import type { ExperimentStepKeys } from '@/ui/segments/workflows/simulate/single-neuron/shared/elements/menu';
-
-export default function Page({
-  searchParams,
-  params: pathParams,
-}: ServerSideComponentProp<
-  WorkspaceContext & { id: string },
-  {
-    step: ExperimentStepKeys;
-    sessionId: string;
-    panel: WorkflowSimulatePanelKeys;
-    initialCampaignId: string;
-  }
->) {
-  const queryParams = use(searchParams);
-  const { initialCampaignId } = queryParams;
-  const { virtualLabId, projectId, id: modelId } = use(pathParams);
-
-  const { data: entity } = useSuspenseQuery({
-    queryKey: keyBuilder.entity({
-      context: { virtualLabId, projectId },
-      id: modelId,
-      type: EntityTypeDict.EMCellMesh,
-    }),
-    queryFn: () => getEmCellMesh({ id: modelId, context: { virtualLabId, projectId } }),
-  });
-
-  const {
-    data: campaignData,
-    error,
-    isLoading,
-  } = useQuery({
-    queryKey: keyBuilder.simCampaign({ entityId: initialCampaignId }),
-    queryFn: async () => {
-      if (!initialCampaignId) return null;
-      // biome-ignore lint/style/noNonNullAssertion: function is guaranteed to be defined
-      const resolveSkeletonizationCampaign = SkeletonizationCampaign.api.query.resolve!;
-      return await resolveSkeletonizationCampaign({
-        id: initialCampaignId,
-        context: { virtualLabId, projectId },
-      });
-    },
-  });
-
-  if (error || !entity) {
-    return notFound();
-  }
-
-  if (!initialCampaignId || (initialCampaignId && !isLoading && campaignData?.config.form)) {
-    return (
-      <div className="border-neutral-2 ml-2 h-full rounded-2xl border">
-        <ScanConfiguration
-          entityId={entity.id}
-          entityType={entity.type}
-          virtualLabId={virtualLabId}
-          projectId={projectId}
-          initialConfig={campaignData?.config.form}
-          className="px-4"
-          activity={ScanConfigActivity.Process}
-        />
-      </div>
-    );
-  }
-}
+export default createScanConfigWorkflowPage(processEmCellMeshWorkflow);

--- a/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/simulate/configure/circuit/[id]/page.tsx
+++ b/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/simulate/configure/circuit/[id]/page.tsx
@@ -1,8 +1,5 @@
 'use client';
 
-import {
-  createScanConfigWorkflowPage,
-  simulateCircuitWorkflow,
-} from '@/features/scan-config/workflow';
+import { createSimulateCircuitScanConfigPage } from '@/features/scan-config/workflow';
 
-export default createScanConfigWorkflowPage(simulateCircuitWorkflow);
+export default createSimulateCircuitScanConfigPage();

--- a/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/simulate/configure/circuit/[id]/page.tsx
+++ b/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/simulate/configure/circuit/[id]/page.tsx
@@ -1,75 +1,8 @@
 'use client';
 
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { notFound } from 'next/navigation';
-import { use } from 'react';
+import {
+  createScanConfigWorkflowPage,
+  simulateCircuitWorkflow,
+} from '@/features/scan-config/workflow';
 
-import { getCircuit } from '@/api/entitycore/queries/model/circuit';
-import { resolveSimulationByCampaignId } from '@/entity-configuration/domain/simulation/small-microcircuit-simulation';
-import { ScanConfiguration } from '@/features/scan-config';
-import { ScanConfigCampaignOriginActionDict } from '@/features/scan-config/helpers';
-import { ScanConfigActivity, SchemaMappingKeyDict } from '@/features/scan-config/types';
-import { keyBuilder } from '@/ui/use-query-keys/data';
-
-import type { ServerSideComponentProp, WorkspaceContext } from '@/types/common';
-import type { WorkflowSimulatePanelKeys } from '@/ui/segments/workflows/simulate/single-neuron/shared/constant';
-import type { ExperimentStepKeys } from '@/ui/segments/workflows/simulate/single-neuron/shared/elements/menu';
-
-export default function Page({
-  searchParams,
-  params: pathParams,
-}: ServerSideComponentProp<
-  WorkspaceContext & { id: string },
-  {
-    step: ExperimentStepKeys;
-    sessionId: string;
-    panel: WorkflowSimulatePanelKeys;
-    initialCampaignId: string;
-  }
->) {
-  const queryParams = use(searchParams);
-  const { initialCampaignId } = queryParams;
-  const { virtualLabId, projectId, id: modelId } = use(pathParams);
-
-  const { data: entity } = useSuspenseQuery({
-    queryKey: keyBuilder.oneCircuit({ virtualLabId, projectId, entityId: modelId }),
-    queryFn: () => getCircuit({ id: modelId, context: { virtualLabId, projectId } }),
-  });
-
-  const {
-    data: campaignData,
-    error,
-    isLoading,
-  } = useQuery({
-    queryKey: keyBuilder.simCampaign({ entityId: initialCampaignId }),
-    queryFn: async () => {
-      if (!initialCampaignId) return null;
-      return await resolveSimulationByCampaignId({
-        id: initialCampaignId,
-        context: { virtualLabId, projectId },
-      });
-    },
-  });
-
-  if (error || !entity) {
-    return notFound();
-  }
-
-  if (!initialCampaignId || (initialCampaignId && !isLoading && campaignData?.config.form)) {
-    return (
-      <div className="border-neutral-2 ml-2 h-full rounded-2xl border">
-        <ScanConfiguration
-          entityType={entity.type}
-          entityId={entity.id}
-          virtualLabId={virtualLabId}
-          projectId={projectId}
-          initialConfig={campaignData?.config.form}
-          className="px-4"
-          activity={ScanConfigActivity.Simulate}
-          schemaMappingKey={SchemaMappingKeyDict.Circuit}
-          campaignOriginAction={ScanConfigCampaignOriginActionDict.Task}
-        />
-      </div>
-    );
-  }
-}
+export default createScanConfigWorkflowPage(simulateCircuitWorkflow);

--- a/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/simulate/configure/ion-channel-model-simulation/page.tsx
+++ b/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/simulate/configure/ion-channel-model-simulation/page.tsx
@@ -1,69 +1,8 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
-import { notFound } from 'next/navigation';
-import { use } from 'react';
+import {
+  createScanConfigWorkflowPage,
+  simulateIonChannelWorkflow,
+} from '@/features/scan-config/workflow';
 
-import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
-import { resolveSimulationByCampaignId } from '@/entity-configuration/domain/simulation/ion-channel-model-simulation';
-import { ScanConfiguration } from '@/features/scan-config';
-import { ScanConfigCampaignOriginActionDict } from '@/features/scan-config/helpers';
-import { ScanConfigActivity, SchemaMappingKeyDict } from '@/features/scan-config/types';
-import { keyBuilder } from '@/ui/use-query-keys/data';
-
-import type { ServerSideComponentProp, WorkspaceContext } from '@/types/common';
-import type { WorkflowSimulatePanelKeys } from '@/ui/segments/workflows/simulate/single-neuron/shared/constant';
-import type { ExperimentStepKeys } from '@/ui/segments/workflows/simulate/single-neuron/shared/elements/menu';
-
-export default function Page({
-  searchParams,
-  params: pathParams,
-}: ServerSideComponentProp<
-  WorkspaceContext & { id: string },
-  {
-    step: ExperimentStepKeys;
-    sessionId: string;
-    panel: WorkflowSimulatePanelKeys;
-    initialCampaignId: string;
-  }
->) {
-  const queryParams = use(searchParams);
-  const { initialCampaignId } = queryParams;
-  const { virtualLabId, projectId } = use(pathParams);
-
-  const {
-    data: campaignData,
-    error,
-    isLoading,
-  } = useQuery({
-    queryKey: keyBuilder.simCampaign({ entityId: initialCampaignId }),
-    queryFn: async () => {
-      if (!initialCampaignId) return null;
-      return await resolveSimulationByCampaignId({
-        id: initialCampaignId,
-        context: { virtualLabId, projectId },
-      });
-    },
-  });
-
-  if (error) {
-    return notFound();
-  }
-
-  if (!initialCampaignId || (initialCampaignId && !isLoading && campaignData?.config.form)) {
-    return (
-      <div className="border-neutral-2 ml-2 h-full rounded-2xl border">
-        <ScanConfiguration
-          entityType={ExtendedEntitiesTypeDict.IonChannelModel}
-          virtualLabId={virtualLabId}
-          projectId={projectId}
-          initialConfig={campaignData?.config.form}
-          className="px-4"
-          activity={ScanConfigActivity.Simulate}
-          schemaMappingKey={SchemaMappingKeyDict.IonChannelModel}
-          campaignOriginAction={ScanConfigCampaignOriginActionDict.Task}
-        />
-      </div>
-    );
-  }
-}
+export default createScanConfigWorkflowPage(simulateIonChannelWorkflow);

--- a/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/simulate/configure/me-model-circuit/[id]/page.tsx
+++ b/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/simulate/configure/me-model-circuit/[id]/page.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import {
+  createScanConfigWorkflowPage,
+  simulateMemodelCircuitWorkflow,
+} from '@/features/scan-config/workflow';
+
+export default createScanConfigWorkflowPage(simulateMemodelCircuitWorkflow);

--- a/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/simulate/configure/memodel/[id]/page.tsx
+++ b/src/app/app/virtual-lab/[virtualLabId]/[projectId]/workflows/simulate/configure/memodel/[id]/page.tsx
@@ -1,16 +1,10 @@
 'use client';
 
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { use } from 'react';
 
 import { getMEModel } from '@/api/entitycore/queries';
-import {
-  ExtendedEntitiesTypeDict,
-  type TExtendedEntitiesTypeDict,
-} from '@/api/entitycore/types/extended-entity-type';
 import { ResponsiveSideViewer } from '@/components/responsive-side-viewer';
-import { resolveSimulationByCampaignId } from '@/entity-configuration/domain/simulation/memodel-circuit-simulation';
-import { ScanConfiguration } from '@/features/scan-config';
 import { WorkflowSimulateLayout } from '@/ui/layouts/workflow-simulate-layout';
 import { Header } from '@/ui/segments/workflows/simulate/single-neuron/shared/elements/header';
 import { MenuSelector } from '@/ui/segments/workflows/simulate/single-neuron/shared/elements/menu-selector';
@@ -36,55 +30,17 @@ export default function Page({
     step: ExperimentStepKeys;
     sessionId: string;
     panel: WorkflowSimulatePanelKeys;
-    dataType: TExtendedEntitiesTypeDict;
     '3d': ThreeDVisualizerQueryParamKeys;
-    initialCampaignId: string;
   }
 >) {
   const queryParams = use(searchParams);
-  const { initialCampaignId } = queryParams;
   const { virtualLabId, projectId, id: modelId } = use(pathParams);
-  let sessionId = queryParams?.sessionId;
-  if (!sessionId) sessionId = crypto.randomUUID();
+  const sessionId = queryParams?.sessionId ?? crypto.randomUUID();
 
   const { data: entity } = useSuspenseQuery({
     queryKey: keyBuilder.meModel({ virtualLabId, projectId, entityId: modelId }),
     queryFn: () => getMEModel({ id: modelId, context: { virtualLabId, projectId } }),
   });
-
-  const { data: campaignData, isLoading: isCampaignLoading } = useQuery({
-    queryKey: keyBuilder.simCampaign({ entityId: initialCampaignId }),
-    queryFn: async () => {
-      if (!initialCampaignId) return null;
-      return await resolveSimulationByCampaignId({
-        id: initialCampaignId,
-        context: { virtualLabId, projectId },
-        populate: ['config'],
-      });
-    },
-    enabled: !!initialCampaignId,
-  });
-
-  if (
-    queryParams.dataType === ExtendedEntitiesTypeDict.MemodelCircuit &&
-    (!initialCampaignId || (!isCampaignLoading && campaignData?.config.form))
-  ) {
-    return (
-      <div className="border-neutral-2 ml-2 h-full rounded-2xl border">
-        <ScanConfiguration
-          entityId={entity.id}
-          entityType={ExtendedEntitiesTypeDict.MemodelCircuit}
-          virtualLabId={virtualLabId}
-          projectId={projectId}
-          initialConfig={campaignData?.config.form}
-          className="px-4"
-        />
-      </div>
-    );
-  }
-  if (queryParams.dataType === ExtendedEntitiesTypeDict.MemodelCircuit) {
-    return null;
-  }
 
   return (
     <WorkflowSimulateLayout>

--- a/src/entity-configuration/domain/extraction/extraction-campaign.ts
+++ b/src/entity-configuration/domain/extraction/extraction-campaign.ts
@@ -136,6 +136,7 @@ export const CircuitExtractionCampaign: EntityCoreTypeConfig<
     query: {
       list,
       status,
+      // NOTE: this is guaranteed to be defined because it is used in the workflow definitions
       resolve,
       count: (params) => Task.count({ ...params, ...TaskFlow }),
       one: (params) => getTaskConfig({ id: params.id, context: params.context }),

--- a/src/entity-configuration/domain/model/em-synapse-mapping-campaign.ts
+++ b/src/entity-configuration/domain/model/em-synapse-mapping-campaign.ts
@@ -135,6 +135,7 @@ export const EmSynapseMappingCampaign: EntityCoreTypeConfig<
     query: {
       list,
       status,
+      // NOTE: this is guaranteed to be defined because it is used in the workflow definitions
       resolve,
       count: (params) => Task.count({ ...params, ...TaskFlow }),
       one: (params) => getTaskConfig({ id: params.id, context: params.context }),

--- a/src/entity-configuration/domain/processing/skeletonization-campaign.ts
+++ b/src/entity-configuration/domain/processing/skeletonization-campaign.ts
@@ -139,6 +139,7 @@ export const SkeletonizationCampaign: EntityCoreTypeConfig<
     query: {
       list,
       status,
+      // NOTE: this is guaranteed to be defined because it is used in the workflow definitions
       resolve,
       count: (params) => Task.count({ ...params, ...TaskFlow }),
       one: (params) => getTaskConfig({ id: params.id, context: params.context }),

--- a/src/features/scan-config/components/hooks/use-scan-configuration.ts
+++ b/src/features/scan-config/components/hooks/use-scan-configuration.ts
@@ -10,6 +10,7 @@
 import { get } from 'es-toolkit/compat';
 import { useMemo } from 'react';
 
+import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { getEntityByExtendedType } from '@/entity-configuration/domain/helpers';
 import { useModelQuery } from '@/features/scan-config/components/atoms';
 import {
@@ -98,7 +99,7 @@ export function useScanConfiguration({
   defaultTab = ScanConfigDefaultTab,
   readOnly,
   activity = ScanConfigActivity.Simulate,
-  schemaMappingKey = SchemaMappingKeyDict.Circuit,
+  schemaMappingKey,
   campaignOriginAction = ScanConfigCampaignOriginActionDict.Task,
 }: TUseScanConfigurationParams): TUseScanConfigurationResult {
   const shouldFetchEntity = !entityFromProps && !!entityId;
@@ -145,8 +146,23 @@ export function useScanConfiguration({
     schemaName: resolved?.schemaName,
   });
 
-  const property_endpoints = schemaMappingKey
-    ? get(schema?.property_endpoints, schemaMappingKey, '')
+  const effectiveSchemaMappingKey = useMemo((): TSchemaMappingKey | undefined => {
+    if (schemaMappingKey) {
+      return schemaMappingKey;
+    }
+
+    if (
+      resolved?.usedType === ExtendedEntitiesTypeDict.Circuit ||
+      resolved?.usedType === ExtendedEntitiesTypeDict.MEModelWithSynapses
+    ) {
+      return SchemaMappingKeyDict.Circuit;
+    }
+
+    return undefined;
+  }, [resolved?.usedType, schemaMappingKey]);
+
+  const property_endpoints = effectiveSchemaMappingKey
+    ? get(schema?.property_endpoints, effectiveSchemaMappingKey, '')
     : '';
 
   const { data: schemaMappingConfig, isLoading: loadingConfiguration } =
@@ -154,7 +170,8 @@ export function useScanConfiguration({
       entityId: entity?.id,
       workspace: { virtualLabId, projectId },
       endpoint: property_endpoints,
-      isSchemaLoaded: !loadingSchema && !!schema && schemaMappingKey === 'Circuit',
+      isSchemaLoaded:
+        !loadingSchema && !!schema && effectiveSchemaMappingKey === SchemaMappingKeyDict.Circuit,
     });
 
   const isLoading = loadingConfiguration || isEntityLoading || loadingSchema;

--- a/src/features/scan-config/components/hooks/use-scan-configuration.ts
+++ b/src/features/scan-config/components/hooks/use-scan-configuration.ts
@@ -1,0 +1,247 @@
+'use client';
+
+/**
+ * loads everything the scan-config editor needs: entity, ObiOne schema, grid endpoint, optional circuit mapping
+ *
+ * assumes `entity` if you already fetched it (workflow pages), otherwise pass `entityId` and will fetch it next
+ * when stuff's ready, `ready` has the props for `ScanConfigTemplate`. until then check `isLoading`, `error`, or `unresolvedMessage`
+ */
+
+import { get } from 'es-toolkit/compat';
+import { useMemo } from 'react';
+
+import { getEntityByExtendedType } from '@/entity-configuration/domain/helpers';
+import { useModelQuery } from '@/features/scan-config/components/atoms';
+import {
+  getGeneratedApiUrl,
+  getScanConfigSchemaName,
+} from '@/features/scan-config/components/hooks';
+import {
+  type TSchemaMappingConfiguration,
+  useObioneJsonSchema,
+  useSchemaMappingConfiguration,
+} from '@/features/scan-config/components/hooks/schema';
+import {
+  ScanConfigCampaignOriginActionDict,
+  type TScanConfigCampaignOriginActionDict,
+} from '@/features/scan-config/helpers';
+import {
+  type Config,
+  type ConfigSchema,
+  getSupportedEntityTypesForScanConfiguration,
+  ScanConfigActivity,
+  ScanConfigDefaultTab,
+  SchemaMappingKeyDict,
+  type SchemaName,
+  type TScanConfigActivity,
+  type TScanConfigTabs,
+  type TSchemaMappingKey,
+  type TSupportedEntitiesForScanConfiguration,
+  type TSupportedEntityTypesForScanConfiguration,
+} from '@/features/scan-config/types';
+
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import type { Nullish } from '@/utils/type';
+
+export type TUseScanConfigurationParams = {
+  entityId?: string | Nullish;
+  entityType: TExtendedEntitiesTypeDict;
+  entity?: TSupportedEntitiesForScanConfiguration | Nullish;
+  virtualLabId: string;
+  projectId: string;
+  initialCampaignId?: string;
+  initialConfig?: Config;
+  defaultTab?: TScanConfigTabs;
+  readOnly?: boolean;
+  activity?: TScanConfigActivity;
+  schemaMappingKey?: TSchemaMappingKey;
+  campaignOriginAction?: TScanConfigCampaignOriginActionDict;
+};
+
+export type TScanConfigurationReadyState = {
+  entity: TSupportedEntitiesForScanConfiguration | Nullish;
+  entityType: TSupportedEntityTypesForScanConfiguration;
+  virtualLabId: string;
+  projectId: string;
+  initialCampaignId?: string;
+  initialConfig?: Config;
+  defaultTab: TScanConfigTabs;
+  readOnly?: boolean;
+  activity: TScanConfigActivity;
+  campaignOriginAction: TScanConfigCampaignOriginActionDict;
+  schema: ConfigSchema;
+  schemaName: SchemaName;
+  schemaMappingConfig: TSchemaMappingConfiguration | undefined;
+  generatedEndpoint: string;
+  aiEnabled: boolean;
+};
+
+/**
+ * - `ready` hands this to the template
+ * - `unresolvedMessage` soft fail (bad entity type, missing schema, ...), not a thrown error
+ */
+export type TUseScanConfigurationResult = {
+  isLoading: boolean;
+  error: Error | null;
+  unresolvedMessage: string | null;
+  ready: TScanConfigurationReadyState | null;
+};
+
+export function useScanConfiguration({
+  entityId,
+  entityType,
+  entity: entityFromProps,
+  virtualLabId,
+  projectId,
+  initialCampaignId,
+  initialConfig,
+  defaultTab = ScanConfigDefaultTab,
+  readOnly,
+  activity = ScanConfigActivity.Simulate,
+  schemaMappingKey = SchemaMappingKeyDict.Circuit,
+  campaignOriginAction = ScanConfigCampaignOriginActionDict.Task,
+}: TUseScanConfigurationParams): TUseScanConfigurationResult {
+  const shouldFetchEntity = !entityFromProps && !!entityId;
+
+  const {
+    entity: fetchedEntity,
+    isLoading: loadingEntity,
+    error,
+  } = useModelQuery({
+    id: shouldFetchEntity ? entityId : undefined,
+    context: { virtualLabId, projectId },
+  });
+
+  const entity = entityFromProps ?? fetchedEntity;
+  const isEntityLoading = shouldFetchEntity && loadingEntity;
+
+  const resolved = useMemo(() => {
+    if (isEntityLoading && !entity) {
+      return null;
+    }
+
+    if (!entity && !entityType) {
+      return null;
+    }
+
+    const usedType = getSupportedEntityTypesForScanConfiguration({
+      entity: entity ?? { type: entityType },
+    });
+
+    const entityConfig = getEntityByExtendedType({ type: usedType });
+    const endpoint = getGeneratedApiUrl({
+      activity,
+      entityType: usedType,
+    });
+    const schemaName = getScanConfigSchemaName({
+      activity,
+      entityType: usedType,
+    });
+
+    return { usedType, entityConfig, endpoint, schemaName };
+  }, [activity, entity, entityType, isEntityLoading]);
+
+  const { schema, isLoading: loadingSchema } = useObioneJsonSchema({
+    schemaName: resolved?.schemaName,
+  });
+
+  const property_endpoints = schemaMappingKey
+    ? get(schema?.property_endpoints, schemaMappingKey, '')
+    : '';
+
+  const { data: schemaMappingConfig, isLoading: loadingConfiguration } =
+    useSchemaMappingConfiguration({
+      entityId: entity?.id,
+      workspace: { virtualLabId, projectId },
+      endpoint: property_endpoints,
+      isSchemaLoaded: !loadingSchema && !!schema && schemaMappingKey === 'Circuit',
+    });
+
+  const isLoading = loadingConfiguration || isEntityLoading || loadingSchema;
+
+  return useMemo(() => {
+    if (isLoading) {
+      return { isLoading: true, error: null, unresolvedMessage: null, ready: null };
+    }
+
+    if (error) {
+      return {
+        isLoading: false,
+        error,
+        unresolvedMessage: null,
+        ready: null,
+      };
+    }
+
+    if (!resolved?.usedType || !resolved.entityConfig) {
+      return {
+        isLoading: false,
+        error: null,
+        unresolvedMessage: 'Could not resolve the entity or the entity configuration',
+        ready: null,
+      };
+    }
+
+    if (!resolved.endpoint) {
+      return {
+        isLoading: false,
+        error: null,
+        unresolvedMessage: `No grid generation found for ${resolved.entityConfig.title}`,
+        ready: null,
+      };
+    }
+
+    if (!resolved.schemaName || !schema) {
+      return {
+        isLoading: false,
+        error: null,
+        unresolvedMessage: `No configuration schema found for ${resolved.entityConfig.title}`,
+        ready: null,
+      };
+    }
+
+    const aiEnabled = entity ? 'scale' in entity && entity.scale !== 'single' : false;
+
+    if (!entity && !resolved.usedType) {
+      return { isLoading: false, error: null, unresolvedMessage: null, ready: null };
+    }
+
+    return {
+      isLoading: false,
+      error: null,
+      unresolvedMessage: null,
+      ready: {
+        entity,
+        entityType: resolved.usedType,
+        virtualLabId,
+        projectId,
+        initialCampaignId,
+        initialConfig,
+        defaultTab,
+        readOnly,
+        activity,
+        campaignOriginAction,
+        schema,
+        schemaName: resolved.schemaName,
+        schemaMappingConfig,
+        generatedEndpoint: resolved.endpoint,
+        aiEnabled,
+      },
+    };
+  }, [
+    activity,
+    campaignOriginAction,
+    defaultTab,
+    entity,
+    error,
+    initialCampaignId,
+    initialConfig,
+    isLoading,
+    projectId,
+    readOnly,
+    resolved,
+    schema,
+    schemaMappingConfig,
+    virtualLabId,
+  ]);
+}

--- a/src/features/scan-config/components/hooks/use-scan-origin-campaign.ts
+++ b/src/features/scan-config/components/hooks/use-scan-origin-campaign.ts
@@ -1,0 +1,70 @@
+'use client';
+
+/**
+ * loads an existing campaign when `initialCampaignId` is on the URL (or passed in)
+ *
+ * plug in a `resolve` function per workflow (simulate, extract, build, ...)
+ * `shouldRenderScanConfig` tells when it's OK to show the editor
+ * - no campaign id → show it (fresh config)
+ * - campaign id → wait until we've got `config.form`
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { keyBuilder } from '@/ui/use-query-keys/data';
+
+import type { Config } from '@/features/scan-config/types';
+import type { WorkspaceContext } from '@/types/common';
+
+/** campaign payload shape, just need the form blob */
+type CampaignWithFormConfig = {
+  config?: {
+    form?: Config;
+  };
+};
+
+export type UseScanConfigOriginCampaignParams<T extends CampaignWithFormConfig> = {
+  /** from `?initialCampaignId=`, skip the query when this is missing */
+  initialCampaignId?: string;
+  context: WorkspaceContext;
+  /** workflow-specific fetcher, e.g. `resolveSimulationByCampaignId` */
+  resolve: (args: { id: string; context: WorkspaceContext }) => Promise<T | null>;
+  /** set false to pause the query without unmounting, default true */
+  enabled?: boolean;
+};
+
+/**
+ * fetches campaign config for resume/edit flows
+ *
+ * @returns
+ * - `initialConfig`, `config.form` from the campaign, pass into `useScanConfiguration`
+ * - `shouldRenderScanConfig`, false while loading an existing campaign that has no form yet
+ */
+export function useScanConfigOriginCampaign<T extends CampaignWithFormConfig>({
+  initialCampaignId,
+  context,
+  resolve,
+  enabled = true,
+}: UseScanConfigOriginCampaignParams<T>) {
+  const { data, error, isLoading } = useQuery({
+    queryKey: initialCampaignId
+      ? keyBuilder.simCampaign({ entityId: initialCampaignId })
+      : ['scan-config-campaign', 'idle', context],
+    queryFn: async () => {
+      if (!initialCampaignId) return null;
+      return await resolve({ id: initialCampaignId, context });
+    },
+    enabled: enabled && !!initialCampaignId,
+  });
+
+  const shouldRenderScanConfig =
+    !initialCampaignId || (Boolean(initialCampaignId) && !isLoading && Boolean(data?.config?.form));
+
+  return {
+    campaignData: data,
+    initialConfig: data?.config?.form,
+    error,
+    isLoading,
+    shouldRenderScanConfig,
+  };
+}

--- a/src/features/scan-config/container.tsx
+++ b/src/features/scan-config/container.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import {
+  type TUseScanConfigurationParams,
+  useScanConfiguration,
+} from '@/features/scan-config/components/hooks/use-scan-configuration';
+import ScanConfigSkeleton from '@/features/scan-config/components/skeletons/full-page';
+import { ScanConfigTemplate } from '@/features/scan-config/template';
+
+export type ScanConfigContainerProps = TUseScanConfigurationParams & {
+  className?: string;
+};
+
+export function ScanConfigContainer(props: ScanConfigContainerProps) {
+  const { className, ...configurationParams } = props;
+  const { isLoading, error, unresolvedMessage, ready } = useScanConfiguration(configurationParams);
+
+  if (isLoading) {
+    return <ScanConfigSkeleton />;
+  }
+
+  if (error) {
+    return <div className="flex h-full w-full items-center justify-center">{error.message}</div>;
+  }
+
+  if (unresolvedMessage) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">{unresolvedMessage}</div>
+    );
+  }
+
+  if (!ready) {
+    return null;
+  }
+
+  return <ScanConfigTemplate {...ready} className={className} />;
+}

--- a/src/features/scan-config/index.tsx
+++ b/src/features/scan-config/index.tsx
@@ -1,182 +1,32 @@
-'use client';
+export {
+  type TScanConfigurationReadyState as ScanConfigurationReadyState,
+  type TUseScanConfigurationParams as UseScanConfigurationParams,
+  type TUseScanConfigurationResult as UseScanConfigurationResult,
+  useScanConfiguration,
+} from '@/features/scan-config/components/hooks/use-scan-configuration';
+export {
+  type UseScanConfigOriginCampaignParams as UseScanConfigCampaignParams,
+  useScanConfigOriginCampaign as useScanConfigCampaign,
+} from '@/features/scan-config/components/hooks/use-scan-origin-campaign';
+export {
+  ScanConfigContainer,
+  ScanConfigContainer as ScanConfiguration,
+  ScanConfigContainer as default,
+  type ScanConfigContainerProps,
+} from '@/features/scan-config/container';
+export {
+  createScanConfigWorkflowPage,
+  defineScanConfigWorkflow,
+  ScanConfigWorkflow,
+  ScanConfigWorkflowConfigurePage,
+  ScanConfigWorkflowProvider,
+  scanConfigEntityQueries,
+  useScanConfigWorkflow,
+} from '@/features/scan-config/workflow';
 
-import { get } from 'es-toolkit/compat';
-
-import { getEntityByExtendedType } from '@/entity-configuration/domain/helpers';
-import { useModelQuery } from '@/features/scan-config/components/atoms';
-import {
-  getGeneratedApiUrl,
-  getScanConfigSchemaName,
-} from '@/features/scan-config/components/hooks';
-import {
-  useObioneJsonSchema,
-  useSchemaMappingConfiguration,
-} from '@/features/scan-config/components/hooks/schema';
-import {
-  ScanConfigCampaignOriginActionDict,
-  type TScanConfigCampaignOriginActionDict,
-} from '@/features/scan-config/helpers';
-import { ScanConfigTemplate } from '@/features/scan-config/template';
-import {
-  type Config,
-  getSupportedEntityTypesForScanConfiguration,
-  ScanConfigActivity,
-  ScanConfigDefaultTab,
-  SchemaMappingKeyDict,
-  type SchemaName,
-  type TScanConfigActivity,
-  type TScanConfigTabs,
-  type TSchemaMappingKey,
-  type TSupportedEntityTypesForScanConfiguration,
-} from '@/features/scan-config/types';
-
-import ScanConfigSkeleton from './components/skeletons/full-page';
-
-import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
-import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
-import type { Nullish } from '@/utils/type';
-
-type Props = {
-  entityId?: string | Nullish;
-  entityType: TExtendedEntitiesTypeDict;
-  schemaMappingKey?: TSchemaMappingKey;
-  virtualLabId: string;
-  projectId: string;
-  initialCampaignId?: string;
-  initialConfig?: Config;
-  defaultTab?: TScanConfigTabs;
-  readOnly?: boolean;
-  className?: string;
-  activity?: TScanConfigActivity;
-  campaignOriginAction?: TScanConfigCampaignOriginActionDict;
-};
-
-export function ScanConfiguration({
-  entityId,
-  entityType,
-  virtualLabId,
-  projectId,
-  initialCampaignId,
-  initialConfig,
-  defaultTab = ScanConfigDefaultTab,
-  readOnly,
-  className,
-  activity = ScanConfigActivity.Simulate,
-  schemaMappingKey = SchemaMappingKeyDict.Circuit,
-  campaignOriginAction = ScanConfigCampaignOriginActionDict.Task,
-}: Props) {
-  let endpoint: string | undefined;
-  let schemaName: SchemaName | undefined;
-  let usedType: TSupportedEntityTypesForScanConfiguration | undefined;
-
-  let entityConfig: EntityCoreTypeConfig<any, any, any> | undefined;
-
-  const {
-    entity,
-    isLoading: loadingEntity,
-    error,
-  } = useModelQuery({
-    id: entityId,
-    context: { virtualLabId, projectId },
-  });
-
-  if (!loadingEntity && (entity || entityType)) {
-    usedType = getSupportedEntityTypesForScanConfiguration({
-      entity: entity ?? { type: entityType },
-    });
-
-    entityConfig = getEntityByExtendedType({ type: usedType });
-    endpoint = getGeneratedApiUrl({
-      activity,
-      entityType: usedType,
-    });
-
-    schemaName = getScanConfigSchemaName({
-      activity,
-      entityType: usedType,
-    });
-  }
-
-  const { schema, isLoading: loadingSchema } = useObioneJsonSchema({
-    schemaName,
-  });
-
-  const property_endpoints = schemaMappingKey
-    ? get(schema?.property_endpoints, schemaMappingKey, '')
-    : '';
-
-  // TODO: discussed with @James to refactor this endpoint to purpose-based endpoints
-  // one for usage and one for property mapping
-  const { data: schemaMappingConfig, isLoading: loadingConfiguration } =
-    useSchemaMappingConfiguration({
-      entityId: entity?.id,
-      workspace: { virtualLabId, projectId },
-      endpoint: property_endpoints,
-      isSchemaLoaded: !loadingSchema && !!schema && schemaMappingKey === 'Circuit',
-    });
-
-  const loading = loadingConfiguration || loadingEntity || loadingSchema;
-
-  if (loading) {
-    return <ScanConfigSkeleton />;
-  }
-
-  if (error) {
-    return <div className="h-full w-full flex items-center justify-center">{error?.message}</div>;
-  }
-
-  if (!usedType || !entityConfig) {
-    return (
-      <div className="h-full w-full flex items-center justify-center">
-        Could not resolve the entity or the entity configuration
-      </div>
-    );
-  }
-
-  if (!endpoint) {
-    return (
-      <div className="h-full w-full flex items-center justify-center">
-        No grid generation found for {entityConfig?.title}
-      </div>
-    );
-  }
-
-  if (!schemaName || !schema) {
-    return (
-      <div className="h-full w-full flex items-center justify-center">
-        No configuration schema found for {entityConfig?.title}
-      </div>
-    );
-  }
-
-  const aiEnabled = entity ? 'scale' in entity && entity.scale !== 'single' : false;
-
-  if (entity || usedType) {
-    return (
-      <ScanConfigTemplate
-        {...{
-          entity,
-          entityType: usedType,
-          virtualLabId,
-          projectId,
-          initialCampaignId,
-          initialConfig,
-          defaultTab,
-          readOnly,
-          className,
-          activity,
-          campaignOriginAction,
-          schema,
-          schemaName,
-          schemaMappingConfig,
-          generatedEndpoint: endpoint,
-          aiEnabled,
-        }}
-      />
-    );
-  }
-
-  return null;
-}
-
-export default ScanConfiguration;
+export type {
+  ScanConfigCampaignSource,
+  ScanConfigEditorOptions,
+  ScanConfigEntitySource,
+  ScanConfigWorkflowDefinition,
+} from '@/features/scan-config/workflow';

--- a/src/features/scan-config/workflow/components.tsx
+++ b/src/features/scan-config/workflow/components.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { notFound } from 'next/navigation';
+
+import { ScanConfigContainer } from '@/features/scan-config/container';
+import { useScanConfigWorkflow } from '@/features/scan-config/workflow/context';
+import { cn } from '@/utils/css-class';
+
+import { ScanConfigWorkflowStatus } from './types';
+
+import type { ReactNode } from 'react';
+
+function ScanConfigWorkflowGate({ children }: { children: ReactNode }) {
+  const { status } = useScanConfigWorkflow();
+
+  if (status === ScanConfigWorkflowStatus.Blocked) {
+    return notFound();
+  }
+
+  if (status === ScanConfigWorkflowStatus.Pending) {
+    return null;
+  }
+
+  return children;
+}
+
+function ScanConfigWorkflowFrame({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn('border-neutral-2 ml-2 h-full rounded-2xl border', className)}>
+      {children}
+    </div>
+  );
+}
+
+function ScanConfigWorkflowEditor() {
+  const { definition, workspace, entity, campaign, editor } = useScanConfigWorkflow();
+
+  return (
+    <ScanConfigContainer
+      entity={entity.entity}
+      entityId={entity.entityId}
+      entityType={entity.entityType}
+      virtualLabId={workspace.virtualLabId}
+      projectId={workspace.projectId}
+      initialConfig={campaign.initialConfig}
+      activity={definition.activity}
+      schemaMappingKey={editor.schemaMappingKey}
+      defaultTab={editor.defaultTab}
+      readOnly={editor.readOnly}
+      campaignOriginAction={editor.campaignOriginAction}
+      className={editor.className}
+    />
+  );
+}
+
+function ScanConfigWorkflowAside({ children }: { children: ReactNode }) {
+  return children;
+}
+
+export const ScanConfigWorkflow = {
+  Gate: ScanConfigWorkflowGate,
+  Frame: ScanConfigWorkflowFrame,
+  Editor: ScanConfigWorkflowEditor,
+  Aside: ScanConfigWorkflowAside,
+};

--- a/src/features/scan-config/workflow/context.tsx
+++ b/src/features/scan-config/workflow/context.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { createContext, useContext, useMemo } from 'react';
+
+import { ScanConfigWorkflowEntityProvider } from '@/features/scan-config/workflow/entity-provider';
+import {
+  ScanConfigEntitySourceMode,
+  ScanConfigWorkflowStatus,
+  type TResolvedScanConfigEntity,
+  type TScanConfigWorkflowContextValue,
+  type TScanConfigWorkflowDefinition,
+  type TScanConfigWorkflowPageProps,
+  type TScanConfigWorkflowStatus,
+} from '@/features/scan-config/workflow/types';
+import { useWorkflowCampaign } from '@/features/scan-config/workflow/use-workflow-campaign';
+
+const ScanConfigWorkflowContext = createContext<TScanConfigWorkflowContextValue | null>(null);
+
+function entitySourceRequiresEntity(
+  entitySource: TScanConfigWorkflowDefinition['entity']
+): boolean {
+  return entitySource.mode === ScanConfigEntitySourceMode.RouteId;
+}
+
+function resolveWorkflowStatus({
+  entity,
+  campaign,
+  requiresEntity,
+}: {
+  entity: TResolvedScanConfigEntity;
+  campaign: TScanConfigWorkflowContextValue['campaign'];
+  requiresEntity: boolean;
+}): TScanConfigWorkflowStatus {
+  if (campaign.error) {
+    return ScanConfigWorkflowStatus.Blocked;
+  }
+
+  // Resume URL had a campaign id, but resolve returned nothing → 404 (not a blank pending screen).
+  if (campaign.initialCampaignId && !campaign.isLoading && !campaign.campaignData) {
+    return ScanConfigWorkflowStatus.Blocked;
+  }
+
+  if (requiresEntity && !entity.entity) {
+    return ScanConfigWorkflowStatus.Blocked;
+  }
+
+  if (!campaign.shouldRender) {
+    return ScanConfigWorkflowStatus.Pending;
+  }
+
+  return ScanConfigWorkflowStatus.Ready;
+}
+
+function ScanConfigWorkflowContextValueProvider({
+  definition,
+  workspace,
+  routeParams,
+  searchParams,
+  entity,
+  children,
+}: TScanConfigWorkflowPageProps & { entity: TResolvedScanConfigEntity }) {
+  const campaign = useWorkflowCampaign({
+    campaignSource: definition.campaign,
+    workspace,
+    searchParams,
+  });
+
+  const requiresEntity = entitySourceRequiresEntity(definition.entity);
+
+  const status = resolveWorkflowStatus({
+    entity,
+    campaign,
+    requiresEntity,
+  });
+
+  const value = useMemo<TScanConfigWorkflowContextValue>(
+    () => ({
+      definition,
+      workspace,
+      entity,
+      campaign,
+      status,
+      editor: definition.editor ?? {},
+    }),
+    [campaign, definition, entity, status, workspace]
+  );
+
+  return (
+    <ScanConfigWorkflowContext.Provider value={value}>
+      {children}
+    </ScanConfigWorkflowContext.Provider>
+  );
+}
+
+export function ScanConfigWorkflowProvider({
+  definition,
+  workspace,
+  routeParams,
+  searchParams,
+  children,
+}: TScanConfigWorkflowPageProps) {
+  return (
+    <ScanConfigWorkflowEntityProvider
+      entitySource={definition.entity}
+      workspace={workspace}
+      routeParams={routeParams}
+    >
+      {(entity) => (
+        <ScanConfigWorkflowContextValueProvider
+          definition={definition}
+          workspace={workspace}
+          routeParams={routeParams}
+          searchParams={searchParams}
+          entity={entity}
+        >
+          {children}
+        </ScanConfigWorkflowContextValueProvider>
+      )}
+    </ScanConfigWorkflowEntityProvider>
+  );
+}
+
+export function useScanConfigWorkflow(): TScanConfigWorkflowContextValue {
+  const context = useContext(ScanConfigWorkflowContext);
+  if (!context) {
+    throw new Error('useScanConfigWorkflow must be used within ScanConfigWorkflowProvider');
+  }
+  return context;
+}

--- a/src/features/scan-config/workflow/create-page.tsx
+++ b/src/features/scan-config/workflow/create-page.tsx
@@ -1,7 +1,13 @@
 'use client';
 
-import { ScanConfigWorkflowConfigurePage } from '@/features/scan-config/workflow/page-template';
+import { notFound } from 'next/navigation';
+import { use, useMemo } from 'react';
 
+import { ScanConfigWorkflowConfigurePage } from '@/features/scan-config/workflow/page-template';
+import { getSimulateCircuitWorkflow } from '@/features/scan-config/workflow/simulate-circuit-workflows';
+import { log } from '@/utils/logger';
+
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type {
   TCreateScanConfigWorkflowPageOptions,
   TScanConfigWorkflowDefinition,
@@ -10,16 +16,17 @@ import type { ServerSideComponentProp, WorkspaceContext } from '@/types/common';
 
 type ConfigurePageParams = WorkspaceContext & { id?: string };
 type ConfigurePageSearchParams = {
+  dataType?: string;
   initialCampaignId?: string;
   [key: string]: string | string[] | undefined;
 };
 
 /**
- * factory for workflow configure routes.
+ * factory for workflow configure routes
  * keeps page files to a single declarative export
  *
  * @example
- * export default createScanConfigWorkflowPage(simulateCircuitWorkflow);
+ * export default createScanConfigWorkflowPage(simulateSmallMicrocircuitWorkflow);
  *
  * @example
  * export default createScanConfigWorkflowPage(extractCircuitWorkflow, {
@@ -30,6 +37,7 @@ export function makeScanConfigWorkflowPage(
   definition: TScanConfigWorkflowDefinition,
   options?: TCreateScanConfigWorkflowPageOptions
 ) {
+  log('debug', '[MakeScanConfigWorkflowPage]', { definition, options });
   function Page(props: ServerSideComponentProp<ConfigurePageParams, ConfigurePageSearchParams>) {
     return (
       <ScanConfigWorkflowConfigurePage definition={definition} aside={options?.aside} {...props} />
@@ -37,5 +45,36 @@ export function makeScanConfigWorkflowPage(
   }
 
   Page.displayName = `ScanConfigWorkflowPage(${definition.id})`;
+  return Page;
+}
+
+/**
+ * shared `/simulate/configure/circuit/[id]` page
+ * resolves the workflow definition from `?dataType=`, then delegates to {@link makeScanConfigWorkflowPage}
+ */
+export function makeSimulateCircuitScanConfigPage(options?: TCreateScanConfigWorkflowPageOptions) {
+  function Page(props: ServerSideComponentProp<ConfigurePageParams, ConfigurePageSearchParams>) {
+    const searchParams = use(props.searchParams);
+    const rawDataType = searchParams.dataType;
+    const dataType = typeof rawDataType === 'string' ? rawDataType : undefined;
+
+    if (!dataType) {
+      notFound();
+    }
+
+    const definition = getSimulateCircuitWorkflow(dataType as TExtendedEntitiesTypeDict);
+    if (!definition) {
+      notFound();
+    }
+
+    const ConfiguredPage = useMemo(
+      () => makeScanConfigWorkflowPage(definition, options),
+      [definition]
+    );
+
+    return <ConfiguredPage {...props} />;
+  }
+
+  Page.displayName = 'SimulateCircuitScanConfigPage';
   return Page;
 }

--- a/src/features/scan-config/workflow/create-page.tsx
+++ b/src/features/scan-config/workflow/create-page.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { ScanConfigWorkflowConfigurePage } from '@/features/scan-config/workflow/page-template';
+
+import type {
+  TCreateScanConfigWorkflowPageOptions,
+  TScanConfigWorkflowDefinition,
+} from '@/features/scan-config/workflow/types';
+import type { ServerSideComponentProp, WorkspaceContext } from '@/types/common';
+
+type ConfigurePageParams = WorkspaceContext & { id?: string };
+type ConfigurePageSearchParams = {
+  initialCampaignId?: string;
+  [key: string]: string | string[] | undefined;
+};
+
+/**
+ * factory for workflow configure routes.
+ * keeps page files to a single declarative export
+ *
+ * @example
+ * export default createScanConfigWorkflowPage(simulateCircuitWorkflow);
+ *
+ * @example
+ * export default createScanConfigWorkflowPage(extractCircuitWorkflow, {
+ *   aside: <DownloadPanel />,
+ * });
+ */
+export function makeScanConfigWorkflowPage(
+  definition: TScanConfigWorkflowDefinition,
+  options?: TCreateScanConfigWorkflowPageOptions
+) {
+  function Page(props: ServerSideComponentProp<ConfigurePageParams, ConfigurePageSearchParams>) {
+    return (
+      <ScanConfigWorkflowConfigurePage definition={definition} aside={options?.aside} {...props} />
+    );
+  }
+
+  Page.displayName = `ScanConfigWorkflowPage(${definition.id})`;
+  return Page;
+}

--- a/src/features/scan-config/workflow/define.ts
+++ b/src/features/scan-config/workflow/define.ts
@@ -1,0 +1,7 @@
+import type { TScanConfigWorkflowDefinition } from '@/features/scan-config/workflow/types';
+
+export function defineScanConfigWorkflow<const T extends TScanConfigWorkflowDefinition>(
+  definition: T
+): T {
+  return definition;
+}

--- a/src/features/scan-config/workflow/definitions/build-em-synapse-mapping.ts
+++ b/src/features/scan-config/workflow/definitions/build-em-synapse-mapping.ts
@@ -1,0 +1,28 @@
+import { EmSynapseMappingCampaign } from '@/entity-configuration/domain/model/em-synapse-mapping-campaign';
+import { ScanConfigCampaignOriginActionDict } from '@/features/scan-config/helpers';
+import { BuildScanConfigTabs, ScanConfigActivity } from '@/features/scan-config/types';
+import { defineScanConfigWorkflow } from '@/features/scan-config/workflow/define';
+import { scanConfigEntityQueries } from '@/features/scan-config/workflow/entity-queries';
+
+export const buildEmSynapseMappingWorkflow = defineScanConfigWorkflow({
+  id: 'build-em-synapse-mapping',
+  activity: ScanConfigActivity.Build,
+  entity: {
+    mode: 'route-id',
+    query: scanConfigEntityQueries.cellMorphology,
+  },
+  campaign: {
+    resolve: async ({ id, context }) => {
+      // biome-ignore lint/style/noNonNullAssertion: function is guaranteed to be defined
+      return await EmSynapseMappingCampaign.api.query.resolve!({ id, context });
+    },
+  },
+  editor: {
+    className: 'px-4',
+    campaignOriginAction: ScanConfigCampaignOriginActionDict.Task,
+    defaultTab: {
+      __activity: ScanConfigActivity.Build,
+      id: BuildScanConfigTabs.configuration,
+    },
+  },
+});

--- a/src/features/scan-config/workflow/definitions/build-em-synapse-mapping.ts
+++ b/src/features/scan-config/workflow/definitions/build-em-synapse-mapping.ts
@@ -3,12 +3,13 @@ import { ScanConfigCampaignOriginActionDict } from '@/features/scan-config/helpe
 import { BuildScanConfigTabs, ScanConfigActivity } from '@/features/scan-config/types';
 import { defineScanConfigWorkflow } from '@/features/scan-config/workflow/define';
 import { scanConfigEntityQueries } from '@/features/scan-config/workflow/entity-queries';
+import { ScanConfigEntitySourceMode } from '@/features/scan-config/workflow/types';
 
 export const buildEmSynapseMappingWorkflow = defineScanConfigWorkflow({
   id: 'build-em-synapse-mapping',
   activity: ScanConfigActivity.Build,
   entity: {
-    mode: 'route-id',
+    mode: ScanConfigEntitySourceMode.RouteId,
     query: scanConfigEntityQueries.cellMorphology,
   },
   campaign: {

--- a/src/features/scan-config/workflow/definitions/extract-circuit.ts
+++ b/src/features/scan-config/workflow/definitions/extract-circuit.ts
@@ -1,0 +1,28 @@
+import { CircuitExtractionCampaign } from '@/entity-configuration/domain/extraction/extraction-campaign';
+import { ScanConfigCampaignOriginActionDict } from '@/features/scan-config/helpers';
+import { ExtractScanConfigTabs, ScanConfigActivity } from '@/features/scan-config/types';
+import { defineScanConfigWorkflow } from '@/features/scan-config/workflow/define';
+import { scanConfigEntityQueries } from '@/features/scan-config/workflow/entity-queries';
+
+export const extractCircuitWorkflow = defineScanConfigWorkflow({
+  id: 'extract-circuit',
+  activity: ScanConfigActivity.Extract,
+  entity: {
+    mode: 'route-id',
+    query: scanConfigEntityQueries.circuit,
+  },
+  campaign: {
+    resolve: async ({ id, context }) => {
+      // biome-ignore lint/style/noNonNullAssertion: function is guaranteed to be defined
+      return await CircuitExtractionCampaign.api.query.resolve!({ id, context });
+    },
+  },
+  editor: {
+    className: 'px-4',
+    campaignOriginAction: ScanConfigCampaignOriginActionDict.Task,
+    defaultTab: {
+      __activity: ScanConfigActivity.Extract,
+      id: ExtractScanConfigTabs.configuration,
+    },
+  },
+});

--- a/src/features/scan-config/workflow/definitions/extract-circuit.ts
+++ b/src/features/scan-config/workflow/definitions/extract-circuit.ts
@@ -3,12 +3,13 @@ import { ScanConfigCampaignOriginActionDict } from '@/features/scan-config/helpe
 import { ExtractScanConfigTabs, ScanConfigActivity } from '@/features/scan-config/types';
 import { defineScanConfigWorkflow } from '@/features/scan-config/workflow/define';
 import { scanConfigEntityQueries } from '@/features/scan-config/workflow/entity-queries';
+import { ScanConfigEntitySourceMode } from '@/features/scan-config/workflow/types';
 
 export const extractCircuitWorkflow = defineScanConfigWorkflow({
   id: 'extract-circuit',
   activity: ScanConfigActivity.Extract,
   entity: {
-    mode: 'route-id',
+    mode: ScanConfigEntitySourceMode.RouteId,
     query: scanConfigEntityQueries.circuit,
   },
   campaign: {

--- a/src/features/scan-config/workflow/definitions/index.ts
+++ b/src/features/scan-config/workflow/definitions/index.ts
@@ -1,0 +1,5 @@
+export { buildEmSynapseMappingWorkflow } from '@/features/scan-config/workflow/definitions/build-em-synapse-mapping';
+export { extractCircuitWorkflow } from '@/features/scan-config/workflow/definitions/extract-circuit';
+export { processEmCellMeshWorkflow } from '@/features/scan-config/workflow/definitions/process-em-cell-mesh';
+export { simulateCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-circuit';
+export { simulateIonChannelWorkflow } from '@/features/scan-config/workflow/definitions/simulate-ion-channel';

--- a/src/features/scan-config/workflow/definitions/index.ts
+++ b/src/features/scan-config/workflow/definitions/index.ts
@@ -1,5 +1,41 @@
+import { ScanConfigCampaignOriginActionDict } from '@/features/scan-config/helpers';
+import { ScanConfigActivity, SchemaMappingKeyDict } from '@/features/scan-config/types';
+import { defineScanConfigWorkflow } from '@/features/scan-config/workflow/define';
+import { scanConfigEntityQueries } from '@/features/scan-config/workflow/entity-queries';
+import { ScanConfigEntitySourceMode } from '@/features/scan-config/workflow/types';
+
+import type { TCampaignResolver } from '@/features/scan-config/workflow/types';
+
+export function defineSimulateCircuitScanConfigWorkflow({
+  id,
+  resolve,
+}: {
+  id: string;
+  resolve: TCampaignResolver;
+}) {
+  return defineScanConfigWorkflow({
+    id,
+    activity: ScanConfigActivity.Simulate,
+    entity: {
+      mode: ScanConfigEntitySourceMode.RouteId,
+      query: scanConfigEntityQueries.circuit,
+    },
+    campaign: { resolve },
+    editor: {
+      schemaMappingKey: SchemaMappingKeyDict.Circuit,
+      campaignOriginAction: ScanConfigCampaignOriginActionDict.Task,
+      className: 'px-4',
+    },
+  });
+}
+
 export { buildEmSynapseMappingWorkflow } from '@/features/scan-config/workflow/definitions/build-em-synapse-mapping';
 export { extractCircuitWorkflow } from '@/features/scan-config/workflow/definitions/extract-circuit';
 export { processEmCellMeshWorkflow } from '@/features/scan-config/workflow/definitions/process-em-cell-mesh';
-export { simulateCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-circuit';
 export { simulateIonChannelWorkflow } from '@/features/scan-config/workflow/definitions/simulate-ion-channel';
+export { simulateMemodelCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-memodel-circuit';
+export { simulateMicrocircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-microcircuit';
+export { simulatePairedNeuronCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-paired-neuron-circuit';
+export { simulateRegionCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-region-circuit';
+export { simulateSingleNeuronCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-single-neuron-circuit';
+export { simulateSmallMicrocircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-small-microcircuit';

--- a/src/features/scan-config/workflow/definitions/process-em-cell-mesh.ts
+++ b/src/features/scan-config/workflow/definitions/process-em-cell-mesh.ts
@@ -2,12 +2,13 @@ import { SkeletonizationCampaign } from '@/entity-configuration/domain/processin
 import { ScanConfigActivity } from '@/features/scan-config/types';
 import { defineScanConfigWorkflow } from '@/features/scan-config/workflow/define';
 import { scanConfigEntityQueries } from '@/features/scan-config/workflow/entity-queries';
+import { ScanConfigEntitySourceMode } from '@/features/scan-config/workflow/types';
 
 export const processEmCellMeshWorkflow = defineScanConfigWorkflow({
   id: 'process-em-cell-mesh',
   activity: ScanConfigActivity.Process,
   entity: {
-    mode: 'route-id',
+    mode: ScanConfigEntitySourceMode.RouteId,
     query: scanConfigEntityQueries.emCellMesh,
   },
   campaign: {

--- a/src/features/scan-config/workflow/definitions/process-em-cell-mesh.ts
+++ b/src/features/scan-config/workflow/definitions/process-em-cell-mesh.ts
@@ -1,0 +1,22 @@
+import { SkeletonizationCampaign } from '@/entity-configuration/domain/processing/skeletonization-campaign';
+import { ScanConfigActivity } from '@/features/scan-config/types';
+import { defineScanConfigWorkflow } from '@/features/scan-config/workflow/define';
+import { scanConfigEntityQueries } from '@/features/scan-config/workflow/entity-queries';
+
+export const processEmCellMeshWorkflow = defineScanConfigWorkflow({
+  id: 'process-em-cell-mesh',
+  activity: ScanConfigActivity.Process,
+  entity: {
+    mode: 'route-id',
+    query: scanConfigEntityQueries.emCellMesh,
+  },
+  campaign: {
+    resolve: async ({ id, context }) => {
+      // biome-ignore lint/style/noNonNullAssertion: function is guaranteed to be defined
+      return await SkeletonizationCampaign.api.query.resolve!({ id, context });
+    },
+  },
+  editor: {
+    className: 'px-4',
+  },
+});

--- a/src/features/scan-config/workflow/definitions/simulate-circuit.ts
+++ b/src/features/scan-config/workflow/definitions/simulate-circuit.ts
@@ -3,12 +3,13 @@ import { ScanConfigCampaignOriginActionDict } from '@/features/scan-config/helpe
 import { ScanConfigActivity, SchemaMappingKeyDict } from '@/features/scan-config/types';
 import { defineScanConfigWorkflow } from '@/features/scan-config/workflow/define';
 import { scanConfigEntityQueries } from '@/features/scan-config/workflow/entity-queries';
+import { ScanConfigEntitySourceMode } from '@/features/scan-config/workflow/types';
 
 export const simulateCircuitWorkflow = defineScanConfigWorkflow({
   id: 'simulate-circuit',
   activity: ScanConfigActivity.Simulate,
   entity: {
-    mode: 'route-id',
+    mode: ScanConfigEntitySourceMode.RouteId,
     query: scanConfigEntityQueries.circuit,
   },
   campaign: {

--- a/src/features/scan-config/workflow/definitions/simulate-circuit.ts
+++ b/src/features/scan-config/workflow/definitions/simulate-circuit.ts
@@ -1,0 +1,22 @@
+import { resolveSimulationByCampaignId } from '@/entity-configuration/domain/simulation/small-microcircuit-simulation';
+import { ScanConfigCampaignOriginActionDict } from '@/features/scan-config/helpers';
+import { ScanConfigActivity, SchemaMappingKeyDict } from '@/features/scan-config/types';
+import { defineScanConfigWorkflow } from '@/features/scan-config/workflow/define';
+import { scanConfigEntityQueries } from '@/features/scan-config/workflow/entity-queries';
+
+export const simulateCircuitWorkflow = defineScanConfigWorkflow({
+  id: 'simulate-circuit',
+  activity: ScanConfigActivity.Simulate,
+  entity: {
+    mode: 'route-id',
+    query: scanConfigEntityQueries.circuit,
+  },
+  campaign: {
+    resolve: resolveSimulationByCampaignId,
+  },
+  editor: {
+    schemaMappingKey: SchemaMappingKeyDict.Circuit,
+    campaignOriginAction: ScanConfigCampaignOriginActionDict.Task,
+    className: 'px-4',
+  },
+});

--- a/src/features/scan-config/workflow/definitions/simulate-ion-channel.ts
+++ b/src/features/scan-config/workflow/definitions/simulate-ion-channel.ts
@@ -3,12 +3,13 @@ import { resolveSimulationByCampaignId } from '@/entity-configuration/domain/sim
 import { ScanConfigCampaignOriginActionDict } from '@/features/scan-config/helpers';
 import { ScanConfigActivity, SchemaMappingKeyDict } from '@/features/scan-config/types';
 import { defineScanConfigWorkflow } from '@/features/scan-config/workflow/define';
+import { ScanConfigEntitySourceMode } from '@/features/scan-config/workflow/types';
 
 export const simulateIonChannelWorkflow = defineScanConfigWorkflow({
   id: 'simulate-ion-channel-model',
   activity: ScanConfigActivity.Simulate,
   entity: {
-    mode: 'static-type',
+    mode: ScanConfigEntitySourceMode.StaticType,
     entityType: ExtendedEntitiesTypeDict.IonChannelModel,
   },
   campaign: {

--- a/src/features/scan-config/workflow/definitions/simulate-ion-channel.ts
+++ b/src/features/scan-config/workflow/definitions/simulate-ion-channel.ts
@@ -1,0 +1,22 @@
+import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import { resolveSimulationByCampaignId } from '@/entity-configuration/domain/simulation/ion-channel-model-simulation';
+import { ScanConfigCampaignOriginActionDict } from '@/features/scan-config/helpers';
+import { ScanConfigActivity, SchemaMappingKeyDict } from '@/features/scan-config/types';
+import { defineScanConfigWorkflow } from '@/features/scan-config/workflow/define';
+
+export const simulateIonChannelWorkflow = defineScanConfigWorkflow({
+  id: 'simulate-ion-channel-model',
+  activity: ScanConfigActivity.Simulate,
+  entity: {
+    mode: 'static-type',
+    entityType: ExtendedEntitiesTypeDict.IonChannelModel,
+  },
+  campaign: {
+    resolve: resolveSimulationByCampaignId,
+  },
+  editor: {
+    schemaMappingKey: SchemaMappingKeyDict.IonChannelModel,
+    campaignOriginAction: ScanConfigCampaignOriginActionDict.Task,
+    className: 'px-4',
+  },
+});

--- a/src/features/scan-config/workflow/definitions/simulate-memodel-circuit.ts
+++ b/src/features/scan-config/workflow/definitions/simulate-memodel-circuit.ts
@@ -1,22 +1,21 @@
-import { resolveSimulationByCampaignId } from '@/entity-configuration/domain/simulation/small-microcircuit-simulation';
+import { resolveSimulationByCampaignId } from '@/entity-configuration/domain/simulation/memodel-circuit-simulation';
 import { ScanConfigCampaignOriginActionDict } from '@/features/scan-config/helpers';
-import { ScanConfigActivity, SchemaMappingKeyDict } from '@/features/scan-config/types';
+import { ScanConfigActivity } from '@/features/scan-config/types';
 import { defineScanConfigWorkflow } from '@/features/scan-config/workflow/define';
 import { scanConfigEntityQueries } from '@/features/scan-config/workflow/entity-queries';
 import { ScanConfigEntitySourceMode } from '@/features/scan-config/workflow/types';
 
-export const simulateCircuitWorkflow = defineScanConfigWorkflow({
-  id: 'simulate-circuit',
+export const simulateMemodelCircuitWorkflow = defineScanConfigWorkflow({
+  id: 'simulate-memodel-circuit',
   activity: ScanConfigActivity.Simulate,
   entity: {
     mode: ScanConfigEntitySourceMode.RouteId,
-    query: scanConfigEntityQueries.circuit,
+    query: scanConfigEntityQueries.meModel,
   },
   campaign: {
     resolve: resolveSimulationByCampaignId,
   },
   editor: {
-    schemaMappingKey: SchemaMappingKeyDict.Circuit,
     campaignOriginAction: ScanConfigCampaignOriginActionDict.Task,
     className: 'px-4',
   },

--- a/src/features/scan-config/workflow/definitions/simulate-microcircuit.ts
+++ b/src/features/scan-config/workflow/definitions/simulate-microcircuit.ts
@@ -1,0 +1,7 @@
+import { resolveSimulationByCampaignId } from '@/entity-configuration/domain/simulation/microcircuit-simulation';
+import { defineSimulateCircuitScanConfigWorkflow } from '@/features/scan-config/workflow/definitions';
+
+export const simulateMicrocircuitWorkflow = defineSimulateCircuitScanConfigWorkflow({
+  id: 'simulate-microcircuit',
+  resolve: resolveSimulationByCampaignId,
+});

--- a/src/features/scan-config/workflow/definitions/simulate-paired-neuron-circuit.ts
+++ b/src/features/scan-config/workflow/definitions/simulate-paired-neuron-circuit.ts
@@ -1,0 +1,7 @@
+import { resolveSimulationByCampaignId } from '@/entity-configuration/domain/simulation/paired-neurons-simulation';
+import { defineSimulateCircuitScanConfigWorkflow } from '@/features/scan-config/workflow/definitions';
+
+export const simulatePairedNeuronCircuitWorkflow = defineSimulateCircuitScanConfigWorkflow({
+  id: 'simulate-paired-neuron-circuit',
+  resolve: resolveSimulationByCampaignId,
+});

--- a/src/features/scan-config/workflow/definitions/simulate-region-circuit.ts
+++ b/src/features/scan-config/workflow/definitions/simulate-region-circuit.ts
@@ -1,0 +1,7 @@
+import { resolveSimulationByCampaignId } from '@/entity-configuration/domain/simulation/region-circuit-simulation';
+import { defineSimulateCircuitScanConfigWorkflow } from '@/features/scan-config/workflow/definitions';
+
+export const simulateRegionCircuitWorkflow = defineSimulateCircuitScanConfigWorkflow({
+  id: 'simulate-region-circuit',
+  resolve: resolveSimulationByCampaignId,
+});

--- a/src/features/scan-config/workflow/definitions/simulate-single-neuron-circuit.ts
+++ b/src/features/scan-config/workflow/definitions/simulate-single-neuron-circuit.ts
@@ -1,0 +1,7 @@
+import { resolveSimulationByCampaignId } from '@/entity-configuration/domain/simulation/single-neuron-circuit-simulation';
+import { defineSimulateCircuitScanConfigWorkflow } from '@/features/scan-config/workflow/definitions';
+
+export const simulateSingleNeuronCircuitWorkflow = defineSimulateCircuitScanConfigWorkflow({
+  id: 'simulate-single-neuron-circuit',
+  resolve: resolveSimulationByCampaignId,
+});

--- a/src/features/scan-config/workflow/definitions/simulate-small-microcircuit.ts
+++ b/src/features/scan-config/workflow/definitions/simulate-small-microcircuit.ts
@@ -1,0 +1,7 @@
+import { resolveSimulationByCampaignId } from '@/entity-configuration/domain/simulation/small-microcircuit-simulation';
+import { defineSimulateCircuitScanConfigWorkflow } from '@/features/scan-config/workflow/definitions';
+
+export const simulateSmallMicrocircuitWorkflow = defineSimulateCircuitScanConfigWorkflow({
+  id: 'simulate-small-microcircuit',
+  resolve: resolveSimulationByCampaignId,
+});

--- a/src/features/scan-config/workflow/entity-provider.tsx
+++ b/src/features/scan-config/workflow/entity-provider.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import {
+  ScanConfigEntitySourceMode,
+  type TResolvedScanConfigEntity,
+  type TScanConfigEntitySource,
+} from '@/features/scan-config/workflow/types';
+import {
+  useRouteIdWorkflowEntity,
+  useStaticTypeWorkflowEntity,
+} from '@/features/scan-config/workflow/use-workflow-entity';
+
+import type { ReactNode } from 'react';
+import type { WorkspaceContext } from '@/types/common';
+
+type TScanConfigWorkflowEntityProviderProps = {
+  entitySource: TScanConfigEntitySource;
+  workspace: WorkspaceContext;
+  routeParams: Record<string, string | undefined>;
+  children: (entity: TResolvedScanConfigEntity) => ReactNode;
+};
+
+function StaticTypeEntityProvider({
+  entitySource,
+  children,
+}: {
+  entitySource: Extract<
+    TScanConfigEntitySource,
+    { mode: typeof ScanConfigEntitySourceMode.StaticType }
+  >;
+  children: (entity: TResolvedScanConfigEntity) => ReactNode;
+}) {
+  const entity = useStaticTypeWorkflowEntity(entitySource);
+  return children(entity);
+}
+
+function RouteIdEntityProvider({
+  entitySource,
+  workspace,
+  routeParams,
+  children,
+}: TScanConfigWorkflowEntityProviderProps & {
+  entitySource: Extract<
+    TScanConfigEntitySource,
+    { mode: typeof ScanConfigEntitySourceMode.RouteId }
+  >;
+}) {
+  const entity = useRouteIdWorkflowEntity({ entitySource, workspace, routeParams });
+  return children(entity);
+}
+
+/** Picks the correct entity hook implementation for the workflow definition. */
+export function ScanConfigWorkflowEntityProvider({
+  entitySource,
+  workspace,
+  routeParams,
+  children,
+}: TScanConfigWorkflowEntityProviderProps) {
+  if (entitySource.mode === ScanConfigEntitySourceMode.StaticType) {
+    return (
+      <StaticTypeEntityProvider entitySource={entitySource}>{children}</StaticTypeEntityProvider>
+    );
+  }
+
+  return (
+    <RouteIdEntityProvider
+      entitySource={entitySource}
+      workspace={workspace}
+      routeParams={routeParams}
+    >
+      {children}
+    </RouteIdEntityProvider>
+  );
+}

--- a/src/features/scan-config/workflow/entity-queries.ts
+++ b/src/features/scan-config/workflow/entity-queries.ts
@@ -1,11 +1,13 @@
 import { getCellMorphology, getEmCellMesh } from '@/api/entitycore/queries';
 import { getCircuit } from '@/api/entitycore/queries/model/circuit';
+import { getMEModel } from '@/api/entitycore/queries/model/me-model';
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { keyBuilder } from '@/ui/use-query-keys/data';
 
 import type { ICellMorphology } from '@/api/entitycore/types';
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
 import type { IEMCellMesh } from '@/api/entitycore/types/entities/em-cell-mesh';
+import type { IMEModel } from '@/api/entitycore/types/entities/me-model';
 import type { TEntityRouteQuery } from '@/features/scan-config/workflow/types';
 
 export const scanConfigEntityQueries = {
@@ -18,6 +20,16 @@ export const scanConfigEntityQueries = {
       }),
     queryFn: ({ context, id }) => getCircuit({ id, context }),
   } satisfies TEntityRouteQuery<ICircuit>,
+
+  meModel: {
+    queryKey: ({ context, id }) =>
+      keyBuilder.meModel({
+        virtualLabId: context.virtualLabId,
+        projectId: context.projectId,
+        entityId: id,
+      }),
+    queryFn: ({ context, id }) => getMEModel({ id, context }),
+  } satisfies TEntityRouteQuery<IMEModel>,
 
   emCellMesh: {
     queryKey: ({ context, id }) =>

--- a/src/features/scan-config/workflow/entity-queries.ts
+++ b/src/features/scan-config/workflow/entity-queries.ts
@@ -1,0 +1,41 @@
+import { getCellMorphology, getEmCellMesh } from '@/api/entitycore/queries';
+import { getCircuit } from '@/api/entitycore/queries/model/circuit';
+import { EntityTypeDict } from '@/api/entitycore/types';
+import { keyBuilder } from '@/ui/use-query-keys/data';
+
+import type { ICellMorphology } from '@/api/entitycore/types';
+import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
+import type { IEMCellMesh } from '@/api/entitycore/types/entities/em-cell-mesh';
+import type { TEntityRouteQuery } from '@/features/scan-config/workflow/types';
+
+export const scanConfigEntityQueries = {
+  circuit: {
+    queryKey: ({ context, id }) =>
+      keyBuilder.oneCircuit({
+        virtualLabId: context.virtualLabId,
+        projectId: context.projectId,
+        entityId: id,
+      }),
+    queryFn: ({ context, id }) => getCircuit({ id, context }),
+  } satisfies TEntityRouteQuery<ICircuit>,
+
+  emCellMesh: {
+    queryKey: ({ context, id }) =>
+      keyBuilder.entity({
+        context,
+        id,
+        type: EntityTypeDict.EMCellMesh,
+      }),
+    queryFn: ({ context, id }) => getEmCellMesh({ id, context }),
+  } satisfies TEntityRouteQuery<IEMCellMesh>,
+
+  cellMorphology: {
+    queryKey: ({ context, id }) =>
+      keyBuilder.entity({
+        context,
+        id,
+        type: EntityTypeDict.CellMorphology,
+      }),
+    queryFn: ({ context, id }) => getCellMorphology({ id, context }),
+  } satisfies TEntityRouteQuery<ICellMorphology>,
+} as const;

--- a/src/features/scan-config/workflow/index.ts
+++ b/src/features/scan-config/workflow/index.ts
@@ -1,0 +1,26 @@
+export { ScanConfigWorkflow } from '@/features/scan-config/workflow/components';
+export {
+  ScanConfigWorkflowProvider,
+  useScanConfigWorkflow,
+} from '@/features/scan-config/workflow/context';
+export { makeScanConfigWorkflowPage as createScanConfigWorkflowPage } from '@/features/scan-config/workflow/create-page';
+export { defineScanConfigWorkflow } from '@/features/scan-config/workflow/define';
+export * from '@/features/scan-config/workflow/definitions';
+export { scanConfigEntityQueries } from '@/features/scan-config/workflow/entity-queries';
+export {
+  ScanConfigWorkflowConfigurePage,
+  type ScanConfigWorkflowConfigurePageProps,
+} from '@/features/scan-config/workflow/page-template';
+
+export type {
+  TCampaignResolver as CampaignResolver,
+  TCampaignWithFormConfig as CampaignWithFormConfig,
+  TCreateScanConfigWorkflowPageOptions as CreateScanConfigWorkflowPageOptions,
+  TEntityRouteQuery as EntityRouteQuery,
+  TScanConfigCampaignSource as ScanConfigCampaignSource,
+  TScanConfigEditorOptions as ScanConfigEditorOptions,
+  TScanConfigEntitySource as ScanConfigEntitySource,
+  TScanConfigWorkflowContextValue as ScanConfigWorkflowContextValue,
+  TScanConfigWorkflowDefinition as ScanConfigWorkflowDefinition,
+  TScanConfigWorkflowStatus as ScanConfigWorkflowStatus,
+} from '@/features/scan-config/workflow/types';

--- a/src/features/scan-config/workflow/index.ts
+++ b/src/features/scan-config/workflow/index.ts
@@ -3,7 +3,10 @@ export {
   ScanConfigWorkflowProvider,
   useScanConfigWorkflow,
 } from '@/features/scan-config/workflow/context';
-export { makeScanConfigWorkflowPage as createScanConfigWorkflowPage } from '@/features/scan-config/workflow/create-page';
+export {
+  makeScanConfigWorkflowPage as createScanConfigWorkflowPage,
+  makeSimulateCircuitScanConfigPage as createSimulateCircuitScanConfigPage,
+} from '@/features/scan-config/workflow/create-page';
 export { defineScanConfigWorkflow } from '@/features/scan-config/workflow/define';
 export * from '@/features/scan-config/workflow/definitions';
 export { scanConfigEntityQueries } from '@/features/scan-config/workflow/entity-queries';
@@ -11,6 +14,11 @@ export {
   ScanConfigWorkflowConfigurePage,
   type ScanConfigWorkflowConfigurePageProps,
 } from '@/features/scan-config/workflow/page-template';
+export {
+  getSimulateCircuitWorkflow,
+  isSimulateCircuitSourceType,
+  simulateCircuitWorkflowBySourceType,
+} from '@/features/scan-config/workflow/simulate-circuit-workflows';
 
 export type {
   TCampaignResolver as CampaignResolver,

--- a/src/features/scan-config/workflow/page-template.tsx
+++ b/src/features/scan-config/workflow/page-template.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { use } from 'react';
+
+import { ScanConfigWorkflow } from '@/features/scan-config/workflow/components';
+import { ScanConfigWorkflowProvider } from '@/features/scan-config/workflow/context';
+
+import type {
+  TCreateScanConfigWorkflowPageOptions,
+  TScanConfigWorkflowDefinition,
+} from '@/features/scan-config/workflow/types';
+import type { ServerSideComponentProp, WorkspaceContext } from '@/types/common';
+
+type ConfigurePageParams = WorkspaceContext & { id?: string };
+type ConfigurePageSearchParams = {
+  initialCampaignId?: string;
+  [key: string]: string | string[] | undefined;
+};
+
+export type ScanConfigWorkflowConfigurePageProps = ServerSideComponentProp<
+  ConfigurePageParams,
+  ConfigurePageSearchParams
+> & {
+  definition: TScanConfigWorkflowDefinition;
+  aside?: TCreateScanConfigWorkflowPageOptions['aside'];
+  children?: React.ReactNode;
+};
+
+function DefaultScanConfigWorkflowLayout({ aside }: { aside?: React.ReactNode }) {
+  return (
+    <ScanConfigWorkflow.Gate>
+      <ScanConfigWorkflow.Frame>
+        <ScanConfigWorkflow.Editor />
+        {aside ? <ScanConfigWorkflow.Aside>{aside}</ScanConfigWorkflow.Aside> : null}
+      </ScanConfigWorkflow.Frame>
+    </ScanConfigWorkflow.Gate>
+  );
+}
+
+export function ScanConfigWorkflowConfigurePage({
+  definition,
+  aside,
+  searchParams,
+  params,
+  children,
+}: ScanConfigWorkflowConfigurePageProps) {
+  const resolvedSearchParams = use(searchParams);
+  const resolvedParams = use(params);
+  const { virtualLabId, projectId, ...routeParams } = resolvedParams;
+
+  return (
+    <ScanConfigWorkflowProvider
+      definition={definition}
+      workspace={{ virtualLabId, projectId }}
+      routeParams={routeParams}
+      searchParams={resolvedSearchParams}
+    >
+      {children ?? <DefaultScanConfigWorkflowLayout aside={aside} />}
+    </ScanConfigWorkflowProvider>
+  );
+}

--- a/src/features/scan-config/workflow/resolve-configure-segment.ts
+++ b/src/features/scan-config/workflow/resolve-configure-segment.ts
@@ -1,0 +1,46 @@
+import { kebabCase } from 'es-toolkit/compat';
+
+import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import { WorkflowActivityDictValue } from '@/constants';
+import { isSimulateCircuitSourceType } from '@/features/scan-config/workflow/simulate-circuit-workflows';
+
+import type { TEntityTypeDict } from '@/api/entitycore/types';
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import type { TWorkspaceSection } from '@/constants';
+
+const SIMULATE_CIRCUIT_CONFIGURE_SEGMENT = 'circuit';
+
+/**
+ * resolves the pathname segment under `workflows/{section}/configure/` for browse links
+ *
+ * for simulate scan-config, circuit workflows use the shared `circuit` segment; pass `dataType`
+ * in the query when present, ME-model circuit uses `me-model-circuit`
+ *
+ * @param section - Workspace section driving the workflow (simulate, extract, process, …).
+ * @param recordType - API entity type of the selected browse row.
+ * @param dataType - Extended workflow type from the browse page (when present).
+ * @returns URL path segment, e.g. `circuit`, `me-model-circuit`, or `kebabCase(recordType)`.
+ */
+export function resolveSimulateConfigureSegment({
+  section,
+  recordType,
+  dataType,
+}: {
+  section: TWorkspaceSection;
+  recordType: TEntityTypeDict;
+  dataType?: TExtendedEntitiesTypeDict;
+}): string {
+  if (section !== WorkflowActivityDictValue.simulate) {
+    return kebabCase(recordType);
+  }
+
+  if (dataType === ExtendedEntitiesTypeDict.MemodelCircuit) {
+    return kebabCase(ExtendedEntitiesTypeDict.MemodelCircuit);
+  }
+
+  if (dataType && isSimulateCircuitSourceType(dataType)) {
+    return SIMULATE_CIRCUIT_CONFIGURE_SEGMENT;
+  }
+
+  return kebabCase(recordType);
+}

--- a/src/features/scan-config/workflow/simulate-circuit-workflows.ts
+++ b/src/features/scan-config/workflow/simulate-circuit-workflows.ts
@@ -1,0 +1,44 @@
+import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import { simulateMicrocircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-microcircuit';
+import { simulatePairedNeuronCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-paired-neuron-circuit';
+import { simulateRegionCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-region-circuit';
+import { simulateSingleNeuronCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-single-neuron-circuit';
+import { simulateSmallMicrocircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-small-microcircuit';
+
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import type { TScanConfigWorkflowDefinition } from '@/features/scan-config/workflow/types';
+
+/** model types browsed before simulate configure (matches `SimulateWorkflows` source types) */
+export const SIMULATE_CIRCUIT_SOURCE_TYPES = [
+  ExtendedEntitiesTypeDict.SingleNeuronCircuit,
+  ExtendedEntitiesTypeDict.PairedNeuronCircuit,
+  ExtendedEntitiesTypeDict.SmallMicrocircuit,
+  ExtendedEntitiesTypeDict.Microcircuit,
+  ExtendedEntitiesTypeDict.BrainRegion,
+] as const;
+
+export type TSimulateCircuitSourceType = (typeof SIMULATE_CIRCUIT_SOURCE_TYPES)[number];
+
+export const simulateCircuitWorkflowBySourceType = {
+  [ExtendedEntitiesTypeDict.SingleNeuronCircuit]: simulateSingleNeuronCircuitWorkflow,
+  [ExtendedEntitiesTypeDict.PairedNeuronCircuit]: simulatePairedNeuronCircuitWorkflow,
+  [ExtendedEntitiesTypeDict.SmallMicrocircuit]: simulateSmallMicrocircuitWorkflow,
+  [ExtendedEntitiesTypeDict.Microcircuit]: simulateMicrocircuitWorkflow,
+  [ExtendedEntitiesTypeDict.BrainRegion]: simulateRegionCircuitWorkflow,
+} as const satisfies Record<TSimulateCircuitSourceType, TScanConfigWorkflowDefinition>;
+
+export function isSimulateCircuitSourceType(
+  sourceType: TExtendedEntitiesTypeDict
+): sourceType is TSimulateCircuitSourceType {
+  return sourceType in simulateCircuitWorkflowBySourceType;
+}
+
+export function getSimulateCircuitWorkflow(
+  sourceType: TExtendedEntitiesTypeDict
+): TScanConfigWorkflowDefinition | null {
+  if (!isSimulateCircuitSourceType(sourceType)) {
+    return null;
+  }
+
+  return simulateCircuitWorkflowBySourceType[sourceType];
+}

--- a/src/features/scan-config/workflow/types.ts
+++ b/src/features/scan-config/workflow/types.ts
@@ -1,0 +1,113 @@
+import type { QueryKey } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import type { TScanConfigCampaignOriginActionDict } from '@/features/scan-config/helpers';
+import type {
+  Config,
+  TScanConfigActivity,
+  TScanConfigTabs,
+  TSchemaMappingKey,
+  TSupportedEntitiesForScanConfiguration,
+} from '@/features/scan-config/types';
+import type { WorkspaceContext } from '@/types/common';
+
+export type TCampaignWithFormConfig = {
+  config?: {
+    form?: Config;
+  };
+};
+
+export type TCampaignResolver<T extends TCampaignWithFormConfig = TCampaignWithFormConfig> =
+  (args: { id: string; context: WorkspaceContext }) => Promise<T | null>;
+
+export type TEntityRouteQuery<TEntity extends TSupportedEntitiesForScanConfiguration> = {
+  queryKey: (args: { context: WorkspaceContext; id: string }) => QueryKey;
+  queryFn: (args: { context: WorkspaceContext; id: string }) => Promise<TEntity>;
+};
+
+export const ScanConfigEntitySourceMode = {
+  RouteId: 'route-id',
+  StaticType: 'static-type',
+} as const;
+export type TScanConfigEntitySourceMode =
+  (typeof ScanConfigEntitySourceMode)[keyof typeof ScanConfigEntitySourceMode];
+/** How the configure step resolves its target entity(ies). Extend with new modes as flows grow. */
+export type TScanConfigEntitySource =
+  | {
+      mode: typeof ScanConfigEntitySourceMode.RouteId;
+      /** Route param name. Defaults to `id`. */
+      param?: string;
+      query: TEntityRouteQuery<TSupportedEntitiesForScanConfiguration>;
+    }
+  | {
+      mode: typeof ScanConfigEntitySourceMode.StaticType;
+      entityType: TExtendedEntitiesTypeDict;
+    };
+
+export type TScanConfigCampaignSource = {
+  searchParam?: string;
+  resolve: TCampaignResolver;
+};
+
+export type TScanConfigEditorOptions = {
+  schemaMappingKey?: TSchemaMappingKey;
+  defaultTab?: TScanConfigTabs;
+  campaignOriginAction?: TScanConfigCampaignOriginActionDict;
+  className?: string;
+  readOnly?: boolean;
+};
+
+/** Declarative contract for a scan-config configure route. */
+export type TScanConfigWorkflowDefinition = {
+  id: string;
+  activity: TScanConfigActivity;
+  entity: TScanConfigEntitySource;
+  campaign: TScanConfigCampaignSource;
+  editor?: TScanConfigEditorOptions;
+};
+
+export type TResolvedScanConfigEntity = {
+  entity: TSupportedEntitiesForScanConfiguration | null;
+  entityType: TExtendedEntitiesTypeDict;
+  entityId?: string;
+};
+
+export type TResolvedScanConfigCampaign = {
+  initialCampaignId?: string;
+  initialConfig?: Config;
+  campaignData: TCampaignWithFormConfig | null | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  shouldRender: boolean;
+};
+
+export const ScanConfigWorkflowStatus = {
+  Pending: 'pending',
+  Ready: 'ready',
+  Blocked: 'blocked',
+} as const;
+
+export type TScanConfigWorkflowStatus =
+  (typeof ScanConfigWorkflowStatus)[keyof typeof ScanConfigWorkflowStatus];
+
+export type TScanConfigWorkflowContextValue = {
+  definition: TScanConfigWorkflowDefinition;
+  workspace: WorkspaceContext;
+  entity: TResolvedScanConfigEntity;
+  campaign: TResolvedScanConfigCampaign;
+  status: TScanConfigWorkflowStatus;
+  editor: TScanConfigEditorOptions;
+};
+
+export type TScanConfigWorkflowPageProps = {
+  definition: TScanConfigWorkflowDefinition;
+  workspace: WorkspaceContext;
+  routeParams: Record<string, string | undefined>;
+  searchParams: Record<string, string | string[] | undefined>;
+  /** Override default Frame + Editor + Aside layout. */
+  children?: ReactNode;
+};
+
+export type TCreateScanConfigWorkflowPageOptions = {
+  aside?: ReactNode;
+};

--- a/src/features/scan-config/workflow/use-workflow-campaign.ts
+++ b/src/features/scan-config/workflow/use-workflow-campaign.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { useScanConfigOriginCampaign } from '@/features/scan-config/components/hooks/use-scan-origin-campaign';
+
+import type {
+  TResolvedScanConfigCampaign,
+  TScanConfigCampaignSource,
+} from '@/features/scan-config/workflow/types';
+import type { WorkspaceContext } from '@/types/common';
+
+const DEFAULT_CAMPAIGN_SEARCH_PARAM = 'initialCampaignId';
+
+export function useWorkflowCampaign({
+  campaignSource,
+  workspace,
+  searchParams,
+}: {
+  campaignSource: TScanConfigCampaignSource;
+  workspace: WorkspaceContext;
+  searchParams: Record<string, string | string[] | undefined>;
+}): TResolvedScanConfigCampaign {
+  const searchParam = campaignSource.searchParam ?? DEFAULT_CAMPAIGN_SEARCH_PARAM;
+  const raw = searchParams[searchParam];
+  const initialCampaignId = typeof raw === 'string' ? raw : undefined;
+
+  const { campaignData, initialConfig, error, isLoading, shouldRenderScanConfig } =
+    useScanConfigOriginCampaign({
+      initialCampaignId,
+      context: workspace,
+      resolve: campaignSource.resolve,
+    });
+
+  return {
+    initialCampaignId,
+    initialConfig,
+    campaignData,
+    isLoading,
+    error: error ?? null,
+    shouldRender: shouldRenderScanConfig,
+  };
+}

--- a/src/features/scan-config/workflow/use-workflow-entity.ts
+++ b/src/features/scan-config/workflow/use-workflow-entity.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import type {
+  ScanConfigEntitySourceMode,
+  TResolvedScanConfigEntity,
+  TScanConfigEntitySource,
+} from '@/features/scan-config/workflow/types';
+import type { WorkspaceContext } from '@/types/common';
+
+function readRouteEntityId(
+  routeParams: Record<string, string | undefined>,
+  param = 'id'
+): string | undefined {
+  return routeParams[param];
+}
+
+export function useStaticTypeWorkflowEntity(
+  entitySource: Extract<
+    TScanConfigEntitySource,
+    { mode: typeof ScanConfigEntitySourceMode.StaticType }
+  >
+): TResolvedScanConfigEntity {
+  return useMemo(
+    () => ({
+      entity: null,
+      entityType: entitySource.entityType,
+    }),
+    [entitySource.entityType]
+  );
+}
+
+export function useRouteIdWorkflowEntity({
+  entitySource,
+  workspace,
+  routeParams,
+}: {
+  entitySource: Extract<
+    TScanConfigEntitySource,
+    { mode: typeof ScanConfigEntitySourceMode.RouteId }
+  >;
+  workspace: WorkspaceContext;
+  routeParams: Record<string, string | undefined>;
+}): TResolvedScanConfigEntity {
+  const param = entitySource.param ?? 'id';
+  const entityId = readRouteEntityId(routeParams, param);
+
+  if (!entityId) {
+    throw new Error(`Missing route param "${param}" for scan config workflow entity`);
+  }
+
+  const { data: entity } = useSuspenseQuery({
+    queryKey: entitySource.query.queryKey({ context: workspace, id: entityId }),
+    queryFn: () => entitySource.query.queryFn({ context: workspace, id: entityId }),
+  });
+
+  return {
+    entity,
+    entityType: entity.type,
+    entityId: entity.id,
+  };
+}

--- a/src/features/scan-config/workflow/use-workflow-entity.ts
+++ b/src/features/scan-config/workflow/use-workflow-entity.ts
@@ -3,6 +3,8 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
+import { getSupportedEntityTypesForScanConfiguration } from '@/features/scan-config/types';
+
 import type {
   ScanConfigEntitySourceMode,
   TResolvedScanConfigEntity,
@@ -58,7 +60,7 @@ export function useRouteIdWorkflowEntity({
 
   return {
     entity,
-    entityType: entity.type,
+    entityType: getSupportedEntityTypesForScanConfiguration({ entity }),
     entityId: entity.id,
   };
 }

--- a/src/ui/segments/mini-detail-view/actions/simulate-extract-process.tsx
+++ b/src/ui/segments/mini-detail-view/actions/simulate-extract-process.tsx
@@ -5,6 +5,7 @@ import { type EntityCoreObjectTypes, EntityTypeDict } from '@/api/entitycore/typ
 import { CircuitScaleDictionary, type ICircuit } from '@/api/entitycore/types/entities/circuit';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { config } from '@/config';
+import { resolveSimulateConfigureSegment } from '@/features/scan-config/workflow/resolve-configure-segment';
 import { useWorkspace } from '@/ui/hooks/use-workspace';
 import { Button } from '@/ui/molecules/button';
 import {
@@ -35,6 +36,12 @@ export function WorkflowActions<T extends EntityCoreObjectTypes>({
     detailUrl = `${config.ROOT_ROUTE}/${virtualLabId}/${projectId}/data/view/${kebabCase(ExtendedEntitiesTypeDict.MEModelWithSynapses)}/${record.id}`;
   }
 
+  const configureSegment = resolveSimulateConfigureSegment({
+    section,
+    recordType: record.type,
+    dataType,
+  });
+
   return (
     <div className="sticky bottom-0 mt-auto flex items-center justify-center gap-2 self-end p-4">
       <Button
@@ -55,11 +62,11 @@ export function WorkflowActions<T extends EntityCoreObjectTypes>({
       >
         <Link
           href={{
-            pathname: `${config.ROOT_ROUTE}/${virtualLabId}/${projectId}/workflows/${section}/configure/${kebabCase(record.type)}/${record.id}`,
+            pathname: `${config.ROOT_ROUTE}/${virtualLabId}/${projectId}/workflows/${section}/configure/${configureSegment}/${record.id}`,
             query: {
               sessionId: crypto.randomUUID(),
               [PanelQueryParam]: WorkflowSimulatePanels.Configuration,
-              dataType,
+              ...(dataType ? { dataType } : {}),
             },
           }}
         >

--- a/src/ui/segments/workflows/elements/workflow-activity.tsx
+++ b/src/ui/segments/workflows/elements/workflow-activity.tsx
@@ -19,7 +19,7 @@ import { type ITaskConfig, TaskConfigType } from '@/api/entitycore/types/entitie
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { useAppNotification } from '@/components/notification';
 import { config } from '@/config';
-import { DEFAULT_PAGE_MEDIUM_SIZE } from '@/constants';
+import { DEFAULT_PAGE_MEDIUM_SIZE, WorkflowActivityDictValue } from '@/constants';
 import { viewConfig as simulationCampaignExpandedViewConfig } from '@/entity-configuration/definitions/list-expanded-view-defs/simulation/small-microcircuit-simulation';
 import { DetailViewSectionsDict } from '@/entity-configuration/definitions/types';
 import { CircuitExtractionCampaign } from '@/entity-configuration/domain/extraction/extraction-campaign';
@@ -39,6 +39,7 @@ import {
   getTaskCampaignStatusCountMap,
   type TTaskCampaignRow,
 } from '@/entity-configuration/domain/task-functions';
+import { isSimulateCircuitSourceType } from '@/features/scan-config/workflow/simulate-circuit-workflows';
 import { LegacyCampaignStatusCell } from '@/features/task-runner/activity-execution/legacy-status-cell';
 import { ActivityAggregatedStatus } from '@/features/task-runner/activity-execution/status';
 import { ActivityStatusCell } from '@/features/task-runner/activity-execution/status-cell';
@@ -57,7 +58,7 @@ import { BaseTable } from '@/ui/segments/data-table/table';
 import { StatusMap } from '@/ui/segments/project/activities/elements/helpers';
 import { useQueryActivity } from '@/ui/segments/project/activities/elements/use-activity';
 import { ORIGINAL_CAMPAIGN_ID_QUERY } from '@/ui/segments/workflows/build/ion-channel-build/helpers';
-import { ActivityValues, getActivity } from '@/ui/segments/workflows/config';
+import { ActivityValues, getActivity, getWorkflow } from '@/ui/segments/workflows/config';
 import { ActivityAndTypeSelectors } from '@/ui/segments/workflows/elements/browse-header';
 import { renderDateAndHour } from '@/util/date';
 import { cn } from '@/utils/css-class';
@@ -404,9 +405,9 @@ export function WorkflowActivity() {
     }
     if (entityType === ExtendedEntitiesTypeDict.MemodelCircuitSimulation) {
       navigate(
-        `${config.ROOT_ROUTE}/${virtualLabId}/${projectId}/workflows/simulate/configure/memodel/${
+        `${config.ROOT_ROUTE}/${virtualLabId}/${projectId}/workflows/simulate/configure/me-model-circuit/${
           (selectedRow as unknown as ExtendedCampaignsType['data'][0]).entity_id
-        }?dataType=${ExtendedEntitiesTypeDict.MemodelCircuit}&initialCampaignId=${selectedRow?.id}`
+        }?initialCampaignId=${selectedRow?.id}`
       );
 
       return;
@@ -420,11 +421,25 @@ export function WorkflowActivity() {
       );
       return;
     }
-    if (selectedRow?.type === ExtendedEntitiesTypeDict.SimulationCampaign) {
+    if (selectedRow?.type === ExtendedEntitiesTypeDict.SimulationCampaign && entityType) {
+      const workflow = getWorkflow({
+        activity: WorkflowActivityDictValue.simulate,
+        targetType: entityType,
+      });
+      const entityId = (selectedRow as unknown as ExtendedCampaignsType['data'][0]).entity_id;
+      const query = new URLSearchParams({ initialCampaignId: selectedRow.id });
+
+      if (workflow && isSimulateCircuitSourceType(workflow.sourceType)) {
+        query.set('dataType', workflow.sourceType);
+        navigate(
+          `${config.ROOT_ROUTE}/${virtualLabId}/${projectId}/workflows/simulate/configure/circuit/${entityId}?${query}`
+        );
+        return;
+      }
+
+      const configureSegment = workflow ? kebabCase(workflow.sourceType) : 'circuit';
       navigate(
-        `${config.ROOT_ROUTE}/${virtualLabId}/${projectId}/workflows/simulate/configure/circuit/${
-          (selectedRow as unknown as ExtendedCampaignsType['data'][0]).entity_id
-        }?initialCampaignId=${selectedRow.id}`
+        `${config.ROOT_ROUTE}/${virtualLabId}/${projectId}/workflows/simulate/configure/${configureSegment}/${entityId}?${query}`
       );
     }
   };


### PR DESCRIPTION
refactors scan-config **configure** routes into a shared workflow layer: declarative definitions, provider context, and a page factory. workflow pages now is a single `createScanConfigWorkflowPage(definition)` export.

#### Main changes:
- **`useScanConfiguration`** — entity + ObiOne schema + grid endpoint + optional circuit mapping; feeds `ScanConfigContainer` / `ScanConfigTemplate`.
- **`useScanConfigOriginCampaign`**:  loads campaign via `?initialCampaignId=` and workflow-specific `resolve`.
- **`ScanConfigWorkflow`**:  `Provider` → entity load (`route-id` | `static-type`) → campaign → `Gate` / `Frame` / `Editor`.
- **Definitions** under `workflow/definitions/` for simulate circuit, ion channel, extract circuit, process EM cell mesh, build EM synapse mapping.

- entity sources: **`route-id`** (suspense fetch) or **`static-type`** only.


**NOTE:** this PR is the first step to introduce the multi-selection that can be done either in the first step "/new" page, or within the scan configuration, there will be 2 PRs later to be able to achieve the wanted behavior
1. move the selection to session storage
2. implement multi-selection for `em-synapse-mapping`