### PR TITLE
Fixed deleted synapses still visible in 3D

### DIFF
--- a/src/ui/segments/workflows/simulate/single-neuron/shared/steps/neuron-visualizer.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/shared/steps/neuron-visualizer.tsx
@@ -1,21 +1,6 @@
 'use client';
 
-import { FullscreenOutlined, MinusOutlined, PlusOutlined } from '@ant-design/icons';
-import { motion } from 'motion/react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import React, { useMemo, useTransition } from 'react';
-
 import { NeuronViewerContainer } from '@/components/neuron-viewer/neuron-viewer-with-actions';
-import {
-  type ThreeDVisualizerQueryParamKeys,
-  threeDVisualizerQueryParam,
-  threeDVisualizerState,
-} from '@/ui/segments/workflows/simulate/single-neuron/shared/constant';
-import { cn } from '@/utils/css-class';
-
-import { useFullscreenSwitcher } from './hooks';
-
-import styles from './neuron-visualizer.module.css';
 
 type Props = {
   sessionId: string;

--- a/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/item.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/item.tsx
@@ -10,7 +10,7 @@ import { Form, Select } from 'antd';
 import find from 'es-toolkit/compat/find';
 import { useAtom } from 'jotai';
 import { useParams } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Color } from 'three';
 
 import { getSingleNeuronSynaptomePlacement } from '@/api/small-scale-simulator';
@@ -47,6 +47,8 @@ import { OptionRender } from '@/ui/segments/workflows/simulate/single-neuron/sin
 import { FrequencyFormItem } from '@/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/frequency-input';
 import { cn } from '@/utils/css-class';
 
+import { SynapticInputDeletionConfirmationDialog } from './synaptic-input-deletion-confirmation-dialog';
+
 import type { TSingleNeuronSynaptomeConfiguration } from '@/api/entitycore/types/entities/single-neuron-synaptome';
 import type { WorkspaceContext } from '@/types/common';
 import type { UpdateSynapseSimulationProperty } from '@/types/small-scale-simulator/single-neuron';
@@ -75,6 +77,7 @@ export function SynapticInputItem({
   sessionId,
   disableControls,
 }: Props) {
+  const [deleteConfirmDialogOpen, setDeleteConfirmDialogOpen] = React.useState(false);
   const breakpoint = useDefaultBreakpoint();
   const { error: notifyError } = useAppNotification();
   const { virtualLabId, projectId } = useParams<WorkspaceContext>();
@@ -177,137 +180,138 @@ export function SynapticInputItem({
       newValue,
     });
   };
-
+  const handleDelete = () => {
+    removeForm();
+    abortController.current.abort();
+  };
   useEffect(() => {
     return () => {
       abortController.current.abort();
     };
   }, []);
-  return (
-    <div className="flex w-full flex-col items-start justify-start gap-1.5">
-      <div
-        id={`synaptic-input-${index}`}
-        className="flex w-full min-w-max items-center justify-between gap-2 text-lg font-bold"
-      >
-        <div className="flex w-full items-center justify-between gap-2">
-          <div className="flex items-center gap-4">
-            <div
-              className={cn(
-                'bg-primary-8 flex h-12 w-12 items-center justify-center rounded-full',
-                'text-center align-middle font-bold text-white'
-              )}
-            >
-              {index + 1}
-            </div>
-            <span className="text-neutral-3 font-light uppercase">Synaptic input</span>
-          </div>
-          <div className="flex items-center justify-center gap-1">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  rounded
-                  type="button"
-                  aria-label={synapseDisplayed ? 'Hide synapses' : 'Show synapses'}
-                  title={synapseDisplayed ? 'Hide synapses' : 'Show synapses'}
-                  variant="outline"
-                  onClick={synapseDisplayed ? onHideSynapse : onShowSynapse}
-                  disabled={visualizeLoading || disableControls}
-                  className="text-primary-9 group disabled:bg-neutral-1 disabled:text-neutral-2 h-12 w-12"
-                >
-                  {resolveIcon(synapseDisplayed, visualizeLoading)}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent
-                side="bottom"
-                sideOffset={0}
-                className="text-primary-9 bg-white shadow-lg select-none"
-                arrowClassName="bg-white"
-              >
-                {synapseDisplayed ? 'Hide synapses' : 'Show synapses'}
-              </TooltipContent>
-            </Tooltip>
 
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  rounded
-                  aria-label={`Delete synaptic input ${index}`}
-                  type="button"
-                  title="Delete synapses"
-                  variant="outline"
-                  className="text-primary-9 hover:text-primary-8 disabled:bg-neutral-1 disabled:text-neutral-2 h-12 w-12"
-                  disabled={disableControls}
-                >
-                  <DeleteOutlined />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent
-                side="bottom"
-                sideOffset={5}
-                className="text-primary-9 flex max-w-60 flex-col items-center justify-center gap-2 bg-white shadow-lg select-none"
-                arrowClassName="bg-white"
+  return (
+    <>
+      <div className="flex w-full flex-col items-start justify-start gap-1.5">
+        <div
+          id={`synaptic-input-${index}`}
+          className="flex w-full min-w-max items-center justify-between gap-2 text-lg font-bold"
+        >
+          <div className="flex w-full items-center justify-between gap-2">
+            <div className="flex items-center gap-4">
+              <div
+                className={cn(
+                  'bg-primary-8 flex h-12 w-12 items-center justify-center rounded-full',
+                  'text-center align-middle font-bold text-white'
+                )}
               >
-                <p className="text-primary-9 text-justify text-sm">
-                  Are you sure you want to delete this synaptic input configuration?
-                </p>
-                <Button
-                  onClick={() => {
-                    removeForm();
-                    abortController.current.abort();
-                  }}
-                  className="self-end"
+                {index + 1}
+              </div>
+              <span className="text-neutral-3 font-light uppercase">Synaptic input</span>
+            </div>
+            <div className="flex items-center justify-center gap-1">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    rounded
+                    type="button"
+                    aria-label={synapseDisplayed ? 'Hide synapses' : 'Show synapses'}
+                    title={synapseDisplayed ? 'Hide synapses' : 'Show synapses'}
+                    variant="outline"
+                    onClick={synapseDisplayed ? onHideSynapse : onShowSynapse}
+                    disabled={visualizeLoading || disableControls}
+                    className="text-primary-9 group disabled:bg-neutral-1 disabled:text-neutral-2 h-12 w-12"
+                  >
+                    {resolveIcon(synapseDisplayed, visualizeLoading)}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent
+                  side="bottom"
+                  sideOffset={0}
+                  className="text-primary-9 bg-white shadow-lg select-none"
+                  arrowClassName="bg-white"
                 >
-                  Confirm
-                </Button>
-              </TooltipContent>
-            </Tooltip>
+                  {synapseDisplayed ? 'Hide synapses' : 'Show synapses'}
+                </TooltipContent>
+              </Tooltip>
+
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    rounded
+                    aria-label={`Delete synaptic input ${index}`}
+                    type="button"
+                    title="Delete synapses"
+                    variant="outline"
+                    className="text-primary-9 hover:text-primary-8 disabled:bg-neutral-1 disabled:text-neutral-2 h-12 w-12"
+                    disabled={disableControls}
+                    onClick={() => setDeleteConfirmDialogOpen(true)}
+                  >
+                    <DeleteOutlined />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent
+                  side="bottom"
+                  sideOffset={0}
+                  className="text-primary-9 bg-white shadow-lg select-none"
+                  arrowClassName="bg-white"
+                >
+                  Remove this synaptic input from the list
+                </TooltipContent>
+              </Tooltip>
+            </div>
           </div>
         </div>
-      </div>
-      <div className="border-neutral-2 flex w-full flex-col rounded-2xl border px-5 pt-2 pb-4">
-        <div className="flex flex-col">
-          <Form.Item
-            label={label('synapse group', true)}
-            name={[formName, 'id']}
-            rules={[{ required: true, type: 'string' }]}
-            labelAlign="left"
-          >
-            <Select
-              showSearch
-              placeholder="Select synapse set"
-              onChange={onIdChange}
-              options={options}
-              className={cn(
-                'border-neutral-3! rounded-md border-[1px]!',
-                '[&_.ant-select-selection-item]:text-primary-9! [&_.ant-select-selection-item]:font-bold',
-                '[&_.ant-select-selection-placeholder]:text-base! [&_.ant-select-selection-placeholder]:font-light!',
-                '[&_.ant-select-selector]:rounded-md! [&_.ant-select-selector]:border-none! [&_.ant-select-selector]:shadow-none!'
-              )}
-              classNames={{
-                popup: {
-                  root: cn(
-                    '[&_.ant-select-item-option-content]:text-primary-9!',
-                    '[&_.rc-virtual-list-holder-inner]:gap-1'
-                  ),
-                },
-              }}
-              placement="bottomLeft"
-              size={breakpoint === 'l' ? 'middle' : 'large'}
-              optionRender={OptionRender}
-              prefix={<div className="h-3 w-3 rounded-full" style={{ backgroundColor: color }} />}
-            />
-          </Form.Item>
+        <div className="border-neutral-2 flex w-full flex-col rounded-2xl border px-5 pt-2 pb-4">
+          <div className="flex flex-col">
+            <Form.Item
+              label={label('synapse group', true)}
+              name={[formName, 'id']}
+              rules={[{ required: true, type: 'string' }]}
+              labelAlign="left"
+            >
+              <Select
+                showSearch
+                placeholder="Select synapse set"
+                onChange={onIdChange}
+                options={options}
+                className={cn(
+                  'border-neutral-3! rounded-md border-[1px]!',
+                  '[&_.ant-select-selection-item]:text-primary-9! [&_.ant-select-selection-item]:font-bold',
+                  '[&_.ant-select-selection-placeholder]:text-base! [&_.ant-select-selection-placeholder]:font-light!',
+                  '[&_.ant-select-selector]:rounded-md! [&_.ant-select-selector]:border-none! [&_.ant-select-selector]:shadow-none!'
+                )}
+                classNames={{
+                  popup: {
+                    root: cn(
+                      '[&_.ant-select-item-option-content]:text-primary-9!',
+                      '[&_.rc-virtual-list-holder-inner]:gap-1'
+                    ),
+                  },
+                }}
+                placement="bottomLeft"
+                size={breakpoint === 'l' ? 'middle' : 'large'}
+                optionRender={OptionRender}
+                prefix={<div className="h-3 w-3 rounded-full" style={{ backgroundColor: color }} />}
+              />
+            </Form.Item>
+          </div>
+          <ConfigInputList index={index} formName={formName} onChange={onChange} />
+          <FrequencyFormItem
+            index={index}
+            formName={formName}
+            onChange={onChange}
+            simIndexWithVariableFrequency={synapseWithFrequencyStep}
+            sessionId={sessionId}
+          />
         </div>
-        <ConfigInputList index={index} formName={formName} onChange={onChange} />
-        <FrequencyFormItem
-          index={index}
-          formName={formName}
-          onChange={onChange}
-          simIndexWithVariableFrequency={synapseWithFrequencyStep}
-          sessionId={sessionId}
-        />
       </div>
-    </div>
+      <SynapticInputDeletionConfirmationDialog
+        open={deleteConfirmDialogOpen}
+        onOpenChange={setDeleteConfirmDialogOpen}
+        onConfirm={handleDelete}
+      />
+    </>
   );
 }
 

--- a/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/item.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/item.tsx
@@ -181,6 +181,7 @@ export function SynapticInputItem({
     });
   };
   const handleDelete = () => {
+    setDeleteConfirmDialogOpen(false);
     removeForm();
     abortController.current.abort();
   };

--- a/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/synaptic-input-deletion-confirmation-dialog/index.ts
+++ b/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/synaptic-input-deletion-confirmation-dialog/index.ts
@@ -1,0 +1,1 @@
+export * from './synaptic-input-deletion-confirmation-dialog';

--- a/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/synaptic-input-deletion-confirmation-dialog/synaptic-input-deletion-confirmation-dialog.module.css
+++ b/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/synaptic-input-deletion-confirmation-dialog/synaptic-input-deletion-confirmation-dialog.module.css
@@ -1,12 +1,30 @@
 dialog.synapticInputDeletionConfirmationDialog {
+  --transition-duration: 200ms;
   margin: auto;
   padding: 1em;
   border-radius: 0.5em;
   box-shadow: 0 0.5em 1em #000a;
   width: 240px;
+  opacity: 1;
+  transition:
+    opacity var(--transition-duration) ease,
+    overlay var(--transition-duration) ease allow-discrete,
+    display var(--transition-duration) ease allow-discrete;
+
+  @starting-style {
+    opacity: 0;
+  }
 
   &::backdrop {
     background: #0005;
+    transition:
+      background var(--transition-duration) ease,
+      overlay var(--transition-duration) ease allow-discrete,
+      display var(--transition-duration) ease allow-discrete;
+
+    @starting-style {
+      background: #0000;
+    }
   }
 
   > footer {

--- a/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/synaptic-input-deletion-confirmation-dialog/synaptic-input-deletion-confirmation-dialog.module.css
+++ b/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/synaptic-input-deletion-confirmation-dialog/synaptic-input-deletion-confirmation-dialog.module.css
@@ -1,31 +1,19 @@
 dialog.synapticInputDeletionConfirmationDialog {
-  position: fixed;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  max-height: 100%;
-  display: grid;
-  place-items: center;
-  background: #0005;
-  z-index: 999999;
+  margin: auto;
+  padding: 1em;
+  border-radius: 0.5em;
+  box-shadow: 0 0.5em 1em #000a;
+  width: 240px;
 
-  > div {
-    padding: 1em;
-    border-radius: 0.5em;
-    box-shadow: 0 0.5em 1em #000a;
-    width: 240px;
-    background: #fff;
+  &::backdrop {
+    background: #0005;
+  }
 
-    > footer {
-      display: flex;
-      flex-wrap: nowrap;
-      flex-direction: row;
-      justify-content: space-between;
-      align-items: center;
-      gap: 1em;
-      margin-top: 1em;
-    }
+  > footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1em;
+    margin-top: 1em;
   }
 }

--- a/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/synaptic-input-deletion-confirmation-dialog/synaptic-input-deletion-confirmation-dialog.module.css
+++ b/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/synaptic-input-deletion-confirmation-dialog/synaptic-input-deletion-confirmation-dialog.module.css
@@ -1,0 +1,31 @@
+dialog.synapticInputDeletionConfirmationDialog {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  display: grid;
+  place-items: center;
+  background: #0005;
+  z-index: 999999;
+
+  > div {
+    padding: 1em;
+    border-radius: 0.5em;
+    box-shadow: 0 0.5em 1em #000a;
+    width: 240px;
+    background: #fff;
+
+    > footer {
+      display: flex;
+      flex-wrap: nowrap;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1em;
+      margin-top: 1em;
+    }
+  }
+}

--- a/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/synaptic-input-deletion-confirmation-dialog/synaptic-input-deletion-confirmation-dialog.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/synaptic-input-deletion-confirmation-dialog/synaptic-input-deletion-confirmation-dialog.tsx
@@ -1,0 +1,50 @@
+import { Button } from '@/ui/molecules/button';
+import { cn } from '@/utils/css-class';
+
+import styles from './synaptic-input-deletion-confirmation-dialog.module.css';
+
+export interface SynapticInputDeletionConfirmationDialogProps {
+  className?: string;
+  open: boolean;
+  onOpenChange(open: boolean): void;
+  /**
+   * the user has clicked "confirm".
+   */
+  onConfirm(): void;
+}
+
+export function SynapticInputDeletionConfirmationDialog({
+  className,
+  open,
+  onOpenChange,
+  onConfirm,
+}: SynapticInputDeletionConfirmationDialogProps) {
+  const handleClose = () => onOpenChange(false);
+
+  if (!open) return null;
+
+  return (
+    <dialog
+      className={cn(className, styles.synapticInputDeletionConfirmationDialog)}
+      open={open}
+      onClose={handleClose}
+      closedby="any"
+      onClick={handleClose}
+      onKeyDown={handleClose}
+    >
+      <div>
+        <p className="text-primary-9 text-justify text-sm">
+          Are you sure you want to delete this synaptic input configuration?
+        </p>
+        <footer>
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button variant="success" onClick={onConfirm}>
+            Confirm
+          </Button>
+        </footer>
+      </div>
+    </dialog>
+  );
+}

--- a/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/synaptic-input-deletion-confirmation-dialog/synaptic-input-deletion-confirmation-dialog.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/synaptic-input-deletion-confirmation-dialog/synaptic-input-deletion-confirmation-dialog.tsx
@@ -51,7 +51,13 @@ export function SynapticInputDeletionConfirmationDialog({
         <Button variant="outline" onClick={handleClose}>
           Cancel
         </Button>
-        <Button variant="success" onClick={onConfirm}>
+        <Button
+          variant="success"
+          onClick={() => {
+            handleClose();
+            onConfirm();
+          }}
+        >
           Confirm
         </Button>
       </footer>

--- a/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/synaptic-input-deletion-confirmation-dialog/synaptic-input-deletion-confirmation-dialog.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/item/synaptic-input-deletion-confirmation-dialog/synaptic-input-deletion-confirmation-dialog.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { Button } from '@/ui/molecules/button';
 import { cn } from '@/utils/css-class';
 
@@ -19,32 +21,40 @@ export function SynapticInputDeletionConfirmationDialog({
   onOpenChange,
   onConfirm,
 }: SynapticInputDeletionConfirmationDialogProps) {
-  const handleClose = () => onOpenChange(false);
+  const refDialog = React.useRef<HTMLDialogElement | null>(null);
+  const handleClose = () => {
+    const dialog = refDialog.current;
+    if (!dialog) return;
 
-  if (!open) return null;
+    dialog.close();
+    onOpenChange(false);
+  };
+  React.useEffect(() => {
+    const dialog = refDialog.current;
+    if (!dialog) return;
+
+    if (open) dialog.showModal();
+    else dialog.close();
+  }, [open]);
 
   return (
     <dialog
+      ref={refDialog}
       className={cn(className, styles.synapticInputDeletionConfirmationDialog)}
-      open={open}
-      onClose={handleClose}
       closedby="any"
-      onClick={handleClose}
-      onKeyDown={handleClose}
+      onClose={handleClose}
     >
-      <div>
-        <p className="text-primary-9 text-justify text-sm">
-          Are you sure you want to delete this synaptic input configuration?
-        </p>
-        <footer>
-          <Button variant="outline" onClick={handleClose}>
-            Cancel
-          </Button>
-          <Button variant="success" onClick={onConfirm}>
-            Confirm
-          </Button>
-        </footer>
-      </div>
+      <p className="text-primary-9 text-justify text-sm">
+        Are you sure you want to delete this synaptic input configuration?
+      </p>
+      <footer>
+        <Button variant="outline" onClick={handleClose}>
+          Cancel
+        </Button>
+        <Button variant="success" onClick={onConfirm}>
+          Confirm
+        </Button>
+      </footer>
     </dialog>
   );
 }

--- a/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/synaptics.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/synaptics.tsx
@@ -103,7 +103,7 @@ export function SynapticsConfiguration({ sessionId, memodelId, synaptome }: Prop
   };
 
   const onConfigProperty = ({ id, key: configKey, newValue }: UpdateSynapseSimulationProperty) => {
-    let color = placementConfigForForm(id)?.color!;
+    let color = placementConfigForForm(id)?.color;
     if (configKey === 'id') {
       color = data?.synapses.find((sc: TSingleNeuronSynaptomeConfiguration) => sc.id === newValue)
         ?.color!;

--- a/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/synaptics.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/synaptics.tsx
@@ -60,7 +60,7 @@ export function SynapticsConfiguration({ sessionId, memodelId, synaptome }: Prop
   const breakpoint = useDefaultBreakpoint();
   const spcKey = getSessionKey(STIMULATION_PROTOCOL_CONFIGURATION_SESSION_KEY, sessionId);
   const { virtualLabId, projectId } = useWorkspace();
-  const [synapsesPlacement] = useAtom(SynapsesPlacementAtomFamily(sessionId));
+  const [synapsesPlacement, setSynapsesPlacement] = useAtom(SynapsesPlacementAtomFamily(sessionId));
   const key = getSessionKey(SYNAPTIC_INPUTS_CONFIGURATION_SESSION_KEY, sessionId);
   const [state, update] = useAtom(SynaptomeConfigurationAtomFamily(key));
   const [stimulationState, updateStimulation] = useAtom(StimulationConfigurationAtomFamily(spcKey));
@@ -81,7 +81,7 @@ export function SynapticsConfiguration({ sessionId, memodelId, synaptome }: Prop
     const simConfigForForm = state.find((_: SynapseConfiguration, ind) => ind === simFormIndex);
     return data?.synapses.find((s) => s.id === simConfigForForm?.id);
   };
-  const onRemoveSynapseConfig = (_key: number) => {
+  const onRemoveSynapseConfig = (key: number) => {
     const safeStorage = typeof window !== 'undefined' ? sessionStorage : null;
     if (safeStorage) {
       state.forEach((_, index) => {
@@ -93,7 +93,13 @@ export function SynapticsConfiguration({ sessionId, memodelId, synaptome }: Prop
       });
     }
 
-    update(state.filter((_, index) => index !== _key) ?? []);
+    const removedConfigId = state[key]?.config_id;
+    if (removedConfigId && synapsesPlacement?.[removedConfigId]) {
+      const { [removedConfigId]: _, ...rest } = synapsesPlacement;
+      setSynapsesPlacement(rest);
+    }
+
+    update(state.filter((_, index) => index !== key) ?? []);
   };
 
   const onConfigProperty = ({ id, key: configKey, newValue }: UpdateSynapseSimulationProperty) => {

--- a/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/synaptics.tsx
+++ b/src/ui/segments/workflows/simulate/single-neuron/single-neuron-synaptome/synaptics.tsx
@@ -81,7 +81,7 @@ export function SynapticsConfiguration({ sessionId, memodelId, synaptome }: Prop
     const simConfigForForm = state.find((_: SynapseConfiguration, ind) => ind === simFormIndex);
     return data?.synapses.find((s) => s.id === simConfigForForm?.id);
   };
-  const onRemoveSynapseConfig = (key: number) => {
+  const onRemoveSynapseConfig = (synapseConfigKey: number) => {
     const safeStorage = typeof window !== 'undefined' ? sessionStorage : null;
     if (safeStorage) {
       state.forEach((_, index) => {
@@ -93,13 +93,13 @@ export function SynapticsConfiguration({ sessionId, memodelId, synaptome }: Prop
       });
     }
 
-    const removedConfigId = state[key]?.config_id;
+    const removedConfigId = state[synapseConfigKey]?.config_id;
     if (removedConfigId && synapsesPlacement?.[removedConfigId]) {
       const { [removedConfigId]: _, ...rest } = synapsesPlacement;
       setSynapsesPlacement(rest);
     }
 
-    update(state.filter((_, index) => index !== key) ?? []);
+    update(state.filter((_, index) => index !== synapseConfigKey) ?? []);
   };
 
   const onConfigProperty = ({ id, key: configKey, newValue }: UpdateSynapseSimulationProperty) => {


### PR DESCRIPTION
This PR does 3 things:

1. Replaces the tooltip-based delete confirmation with a proper modal dialog ( SynapticInputDeletionConfirmationDialog)
2. Cleans up synapse placement state when removing a synaptic input config
3. Simplifies `neuron-visualizer.tsx` by removing unused imports

It relates to this ticket: https://github.com/openbraininstitute/prod-singlecell-simulation/issues/278

The preview has been validated by @ayimaok and @darshanmandge 