### PR TITLE
Enable whole brain - Brian2 FlyWire simulations

### DIFF
--- a/src/api/entitycore/types/entities/circuit.ts
+++ b/src/api/entitycore/types/entities/circuit.ts
@@ -74,6 +74,8 @@ export type TCircuitScaleDictionary =
 export type TCircuitBuildCategoryDictionary =
   (typeof CircuitBuildCategory)[keyof typeof CircuitBuildCategory]['key'];
 
+export type TCircuitTargetSimulator = 'NEURON' | 'Brian2';
+
 interface CircuitBase {
   description: string;
   number_neurons: number;
@@ -86,6 +88,7 @@ interface CircuitBase {
   contact_email: string | null;
   published_in: string | null;
   has_electrical_cell_models: boolean;
+  target_simulator: TCircuitTargetSimulator | null;
 }
 
 export interface ICircuit

--- a/src/api/entitycore/types/extended-entity-type.ts
+++ b/src/api/entitycore/types/extended-entity-type.ts
@@ -25,6 +25,7 @@ export const ExtendedEntitiesTypeDict = {
   CircuitExtractionCampaign: 'circuit_extraction_campaign',
   SkeletonizationCampaign: 'skeletonization_campaign',
   RegionCircuitSimulation: 'region_circuit_simulation',
+  WholeBrainCircuitSimulation: 'whole_brain_circuit_simulation',
 } as const;
 
 export type TExtendedEntitiesTypeDict =
@@ -41,6 +42,7 @@ const DATA_SIMULATION_LISTING_EXTENDED_TYPES: ReadonlySet<TExtendedEntitiesTypeD
   ExtendedEntitiesTypeDict.MicrocircuitSimulation,
   ExtendedEntitiesTypeDict.IonChannelModelSimulation,
   ExtendedEntitiesTypeDict.RegionCircuitSimulation,
+  ExtendedEntitiesTypeDict.WholeBrainCircuitSimulation,
 ]);
 
 /**

--- a/src/api/entitycore/types/extended-entity-type.ts
+++ b/src/api/entitycore/types/extended-entity-type.ts
@@ -13,12 +13,12 @@ export const ExtendedEntitiesTypeDict = {
   SmallMicrocircuitSimulation: 'small_microcircuit_simulation',
   MicrocircuitSimulation: 'microcircuit_simulation',
   IonChannelModelSimulation: 'ion_channel_model_simulation',
-  NGVCircuit: 'ngv_circuit', // this is temporary
-  BrainRegion: 'brain_region', // this is temporary
-  BrainSystems: 'brain_system', // this is temporary
-  WholeBrain: 'whole_brain', // this is temporary
-  Metabolism: 'metabolism', // this is temporary
-  NGVUnit: 'ngv_unit', // this is temporary
+  NGVCircuit: 'ngv_circuit',
+  BrainRegion: 'brain_region',
+  BrainSystems: 'brain_system',
+  WholeBrain: 'whole_brain',
+  Metabolism: 'metabolism',
+  NGVUnit: 'ngv_unit',
   MEModelWithSynapses: 'me_model_with_synapses',
   SynthesizedCellMorphology: 'synthesized_cell_morphology',
   UniversalCellMorphology: 'universal_cell_morphology',

--- a/src/api/one/types/task.ts
+++ b/src/api/one/types/task.ts
@@ -1,6 +1,7 @@
 export const ObiOneTaskTypeDict = {
   CircuitExtraction: 'circuit_extraction',
   CircuitSimulation: 'circuit_simulation',
+  CircuitSimulationBrian2: 'circuit_simulation_brian2_machine',
   Skeletonization: 'morphology_skeletonization',
   MorphologySkeletonization: 'morphology_skeletonization',
   IonChannelModelSimulationExecution: 'ion_channel_model_simulation_execution',

--- a/src/app/app/virtual-lab/[virtualLabId]/[projectId]/data/(browse)/browse/entity/[type]/page.tsx
+++ b/src/app/app/virtual-lab/[virtualLabId]/[projectId]/data/(browse)/browse/entity/[type]/page.tsx
@@ -36,6 +36,7 @@ const AllowedEntities = [
   ExtendedEntitiesTypeDict.EMCellMesh,
   ExtendedEntitiesTypeDict.IonChannelModelSimulation,
   ExtendedEntitiesTypeDict.RegionCircuitSimulation,
+  ExtendedEntitiesTypeDict.WholeBrainCircuitSimulation,
 ] as const;
 
 export default async function Page({

--- a/src/entity-configuration/definitions/list-expanded-view-defs/index.ts
+++ b/src/entity-configuration/definitions/list-expanded-view-defs/index.ts
@@ -7,6 +7,7 @@ import {
   regionCircuitSimulationExpandedViewConfig,
   singleNeuronCircuitSimulationExpandedViewConfig,
   smallMicrocircuitSimulationExpandedViewConfig,
+  wholeBrainCircuitSimulationExpandedViewConfig,
 } from '@/entity-configuration/definitions/list-expanded-view-defs/simulation';
 import { TaskViewConfig } from '@/features/task-runner/expanded-view';
 
@@ -30,4 +31,6 @@ export const listExpandedViewRegistry: ListExpandedViewRegistry = {
   [ExtendedEntitiesTypeDict.SkeletonizationCampaign]: skeletonizationCampaignExpandedViewConfig,
   [ExtendedEntitiesTypeDict.IonChannelModelSimulation]: ionChannelSimulationExpandedViewConfig,
   [ExtendedEntitiesTypeDict.RegionCircuitSimulation]: regionCircuitSimulationExpandedViewConfig,
+  [ExtendedEntitiesTypeDict.WholeBrainCircuitSimulation]:
+    wholeBrainCircuitSimulationExpandedViewConfig,
 };

--- a/src/entity-configuration/definitions/list-expanded-view-defs/simulation/index.tsx
+++ b/src/entity-configuration/definitions/list-expanded-view-defs/simulation/index.tsx
@@ -5,3 +5,4 @@ export { viewConfig as pairedNeuronsCircuitSimulationExpandedViewConfig } from '
 export { viewConfig as regionCircuitSimulationExpandedViewConfig } from './region-circuit-simulation';
 export { viewConfig as singleNeuronCircuitSimulationExpandedViewConfig } from './single-neuron-circuit-simulation';
 export { viewConfig as smallMicrocircuitSimulationExpandedViewConfig } from './small-microcircuit-simulation';
+export { viewConfig as wholeBrainCircuitSimulationExpandedViewConfig } from './whole-brain-circuit-simulation';

--- a/src/entity-configuration/definitions/list-expanded-view-defs/simulation/whole-brain-circuit-simulation.tsx
+++ b/src/entity-configuration/definitions/list-expanded-view-defs/simulation/whole-brain-circuit-simulation.tsx
@@ -1,0 +1,46 @@
+import { getSimulationStatus } from '@/entity-configuration/domain/simulation';
+import { ActivityStatusRenderer } from '@/features/task-runner/activity-execution/status';
+import {
+  createNameColumn,
+  createScanParameterColumns,
+  createStatusColumn,
+  renderExpandedTable,
+  TaskViewConfig,
+} from '@/features/task-runner/expanded-view';
+
+import type { ISimulation } from '@/api/entitycore/types/entities/simulation';
+import type { ICircuitSimulationCampaign } from '@/api/entitycore/types/entities/simulation-campaign';
+import type { TActivityStatus } from '@/api/entitycore/types/shared/activity';
+import type { ListExpandedViewConfig } from '@/entity-configuration/definitions/list-expanded-view-defs/types';
+
+type TSimulationRow = ISimulation & { status?: TActivityStatus };
+
+export const viewConfig: ListExpandedViewConfig<ICircuitSimulationCampaign> = {
+  expandIconColumnIndex: 6,
+  expandIcon:
+    TaskViewConfig.expandIcon as ListExpandedViewConfig<ICircuitSimulationCampaign>['expandIcon'],
+  render: (simulationCampaign, records) => {
+    const simulations =
+      records.length > 0
+        ? (records as unknown as TSimulationRow[])
+        : ((simulationCampaign.simulations ?? []) as TSimulationRow[]);
+
+    const allScanParamSet = simulations.reduce(
+      (set, simulation) => set.union(new Set(Object.keys(simulation.scan_parameters))),
+      new Set<string>()
+    );
+
+    const columns = [
+      createNameColumn<TSimulationRow>(),
+      ...createScanParameterColumns<TSimulationRow>(allScanParamSet),
+      createStatusColumn<TSimulationRow>((_: unknown, simulation: TSimulationRow) => (
+        <div className="flex items-center justify-center">
+          <ActivityStatusRenderer status={simulation.status ?? getSimulationStatus(simulation)} />
+        </div>
+      )),
+    ];
+
+    return renderExpandedTable<TSimulationRow>({ columns, dataSource: simulations });
+  },
+  isExpandable: () => true,
+};

--- a/src/entity-configuration/definitions/view-defs/model/index.ts
+++ b/src/entity-configuration/definitions/view-defs/model/index.ts
@@ -11,6 +11,7 @@ import { ViewDefForSingleNeuronCircuit } from '@/entity-configuration/definition
 import { ViewDefForSingleNeuronSynaptome } from '@/entity-configuration/definitions/view-defs/model/single-neuron-synaptome';
 import { ViewDefForSmallMicrocircuit } from '@/entity-configuration/definitions/view-defs/model/small-micro-circuit';
 import { ViewDefForSynthesizedCellMorphology } from '@/entity-configuration/definitions/view-defs/model/synthesized-morphology';
+import { ViewDefForWholeBrain } from '@/entity-configuration/definitions/view-defs/model/whole-brain';
 
 import type { ViewDefinitionConfig } from '@/entity-configuration/definitions/view-defs/types';
 
@@ -24,6 +25,7 @@ export const ViewsDefinition: { [key: string]: ViewDefinitionConfig } = {
   [ExtendedEntitiesTypeDict.PairedNeuronCircuit]: ViewDefForPairedNeuronCircuit,
   [ExtendedEntitiesTypeDict.SmallMicrocircuit]: ViewDefForSmallMicrocircuit,
   [ExtendedEntitiesTypeDict.Microcircuit]: ViewDefForMicrocircuit,
+  [ExtendedEntitiesTypeDict.WholeBrain]: ViewDefForWholeBrain,
   [ExtendedEntitiesTypeDict.Circuit]: ViewDefForCircuit,
   [ExtendedEntitiesTypeDict.IonChannelModel]: ViewDefForIonChannelModel,
   [ExtendedEntitiesTypeDict.MEModelWithSynapses]: ViewDefForMEModelWithSynapsesCircuit,

--- a/src/entity-configuration/definitions/view-defs/model/whole-brain.ts
+++ b/src/entity-configuration/definitions/view-defs/model/whole-brain.ts
@@ -1,0 +1,34 @@
+import { EntityCoreFields } from '@/entity-configuration/definitions/fields-defs/enums';
+import { EntitySlug } from '@/entity-configuration/domain/slug';
+
+import type { ViewDefinitionConfig } from '@/entity-configuration/definitions/view-defs/types';
+
+export const ViewDefForWholeBrain: ViewDefinitionConfig = {
+  title: 'Whole brain (beta)',
+  name: EntitySlug.WholeBrain,
+  curated: false,
+  columns: [
+    EntityCoreFields.Name,
+    EntityCoreFields.Description,
+    EntityCoreFields.BrainRegion,
+    EntityCoreFields.SpeciesName,
+    EntityCoreFields.CircuitScale,
+    EntityCoreFields.CircuitNumberNeurons,
+    EntityCoreFields.CircuitNumberSynapses,
+    EntityCoreFields.CircuitNumberConnections,
+    EntityCoreFields.CreatedBy,
+    EntityCoreFields.RegistrationDate,
+  ],
+  miniDetailView: [
+    { field: EntityCoreFields.SpeciesName },
+    { field: EntityCoreFields.BrainRegion },
+    { field: EntityCoreFields.CircuitScale },
+    { field: EntityCoreFields.CircuitSubCircuit },
+    { field: EntityCoreFields.CircuitNumberNeurons },
+    { field: EntityCoreFields.CircuitNumberSynapses },
+    { field: EntityCoreFields.CircuitNumberConnections },
+    { field: EntityCoreFields.CircuitBuildCategory },
+    { field: EntityCoreFields.RegistrationDate },
+    { field: EntityCoreFields.License },
+  ],
+};

--- a/src/entity-configuration/definitions/view-defs/simulation/index.ts
+++ b/src/entity-configuration/definitions/view-defs/simulation/index.ts
@@ -10,6 +10,7 @@ import { viewDefForSingleNeuronCircuitSimulation } from './single-neuron-circuit
 import { viewDefForSingleNeuronSimulation } from './single-neuron-simulation';
 import { viewDefForSingleNeuronSynaptomeSimulation } from './single-neuron-synaptome-simulation';
 import { viewDefForSmallMicrocircuitSimulation } from './small-microcircuit-simulation';
+import { viewDefForWholeBrainCircuitSimulation } from './whole-brain-circuit-simulation';
 
 import type { ViewDefinitionConfig } from '@/entity-configuration/definitions/view-defs/types';
 
@@ -25,4 +26,5 @@ export const ViewsDefinition: { [key: string]: ViewDefinitionConfig } = {
   [ExtendedEntitiesTypeDict.MemodelCircuitSimulation]: viewDefForMEModelCircuitSimulation,
   [ExtendedEntitiesTypeDict.IonChannelModelSimulation]: viewDefForIonChannelModelSimulation,
   [ExtendedEntitiesTypeDict.RegionCircuitSimulation]: viewDefForRegionCircuitSimulation,
+  [ExtendedEntitiesTypeDict.WholeBrainCircuitSimulation]: viewDefForWholeBrainCircuitSimulation,
 };

--- a/src/entity-configuration/definitions/view-defs/simulation/whole-brain-circuit-simulation.ts
+++ b/src/entity-configuration/definitions/view-defs/simulation/whole-brain-circuit-simulation.ts
@@ -1,0 +1,36 @@
+import { EntityCoreFields } from '@/entity-configuration/definitions/fields-defs/enums';
+import {
+  DataTypeGroup,
+  type ViewDefinitionConfig,
+} from '@/entity-configuration/definitions/view-defs/types';
+import { EntitySlug } from '@/entity-configuration/domain/slug';
+
+export const viewDefForWholeBrainCircuitSimulation: ViewDefinitionConfig = {
+  title: 'Whole brain circuit Simulation (beta)',
+  group: DataTypeGroup.SimulationData,
+  name: EntitySlug.WholeBrainCircuitSimulation,
+  curated: false,
+  columns: [
+    EntityCoreFields.Name,
+    EntityCoreFields.Description,
+    EntityCoreFields.CircuitName,
+    EntityCoreFields.CreatedBy,
+    EntityCoreFields.RegistrationDate,
+    EntityCoreFields.LegacyActivityStatus,
+  ],
+  filterableFields: [
+    EntityCoreFields.Name,
+    EntityCoreFields.CreatedBy,
+    EntityCoreFields.RegistrationDate,
+  ],
+  displayableFields: [
+    EntityCoreFields.Name,
+    EntityCoreFields.CreatedBy,
+    EntityCoreFields.RegistrationDate,
+  ],
+  miniDetailView: [
+    { field: EntityCoreFields.CircuitName },
+    { field: EntityCoreFields.LegacyActivityStatus },
+    { field: EntityCoreFields.RegistrationDate },
+  ],
+};

--- a/src/entity-configuration/domain/index.ts
+++ b/src/entity-configuration/domain/index.ts
@@ -22,6 +22,7 @@ import { SingleNeuronCircuit } from '@/entity-configuration/domain/model/single-
 import { SingleNeuronSynaptome } from '@/entity-configuration/domain/model/single-neuron-synaptome';
 import { SmallMicrocircuit } from '@/entity-configuration/domain/model/small-microcircuit';
 import { SynthesizedCellMorphology } from '@/entity-configuration/domain/model/synthesized-morphology';
+import { WholeBrain } from '@/entity-configuration/domain/model/whole-brain';
 import { Notebook } from '@/entity-configuration/domain/notebook';
 import { SkeletonizationCampaign } from '@/entity-configuration/domain/processing/skeletonization-campaign';
 import {
@@ -64,6 +65,7 @@ export const EntityCoreModelConfiguration = {
   SmallMicrocircuit,
   Microcircuit,
   BrainRegion,
+  WholeBrain,
   Circuit,
   IonChannelModel,
   IonChannelModelingCampaign,

--- a/src/entity-configuration/domain/index.ts
+++ b/src/entity-configuration/domain/index.ts
@@ -36,6 +36,7 @@ import { PairedNeuronCircuitSimulation } from '@/entity-configuration/domain/sim
 import { RegionCircuitSimulation } from '@/entity-configuration/domain/simulation/region-circuit-simulation';
 import { SingeNeuronCircuitSimulation } from '@/entity-configuration/domain/simulation/single-neuron-circuit-simulation';
 import { SmallMicrocircuitSimulation } from '@/entity-configuration/domain/simulation/small-microcircuit-simulation';
+import { WholeBrainCircuitSimulation } from '@/entity-configuration/domain/simulation/whole-brain-circuit-simulation';
 
 import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
 
@@ -82,6 +83,7 @@ const EntityCoreSimulationConfiguration = {
   MicrocircuitSimulation,
   IonChannelModelSimulation,
   RegionCircuitSimulation,
+  WholeBrainCircuitSimulation,
 };
 
 const EntityCoreExtractionConfiguration = {

--- a/src/entity-configuration/domain/model/whole-brain.ts
+++ b/src/entity-configuration/domain/model/whole-brain.ts
@@ -1,0 +1,55 @@
+import { getCircuit, getCircuits } from '@/api/entitycore/queries/model/circuit';
+import { CircuitScaleDictionary, type ICircuit } from '@/api/entitycore/types/entities/circuit';
+import { EntityTypeDict } from '@/api/entitycore/types/entity-type';
+import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import { DetailViewSectionsDict } from '@/entity-configuration/definitions/types';
+import { EntityTypeGroup } from '@/entity-configuration/domain/group';
+import { EntitySlug } from '@/entity-configuration/domain/slug';
+
+import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
+
+export const circuitScaleFilter = {
+  scale__in: [CircuitScaleDictionary.WholeBrain],
+};
+
+export const WholeBrain: EntityCoreTypeConfig<ICircuit> = {
+  group: EntityTypeGroup.Models,
+  title: 'Whole brain (beta)',
+  extendedType: ExtendedEntitiesTypeDict.WholeBrain,
+  type: EntityTypeDict.Circuit,
+  slug: EntitySlug.WholeBrain,
+  api: {
+    config: {
+      allowedFacets: true,
+      ilikeSearchEnabled: true,
+      extraQueryKeyBuilder: circuitScaleFilter,
+    },
+    query: {
+      list: (...params) => {
+        return getCircuits({
+          ...params,
+          context: params[0].context,
+          withFacets: params[0].withFacets,
+          filters: {
+            ...circuitScaleFilter,
+            ...params[0].filters,
+          },
+        });
+      },
+      one: getCircuit,
+    },
+  },
+  asset: {
+    extension: 'application/json',
+  },
+  detailViewSections: [
+    DetailViewSectionsDict.Overview,
+    DetailViewSectionsDict.Analysis,
+    DetailViewSectionsDict.RelatedPublications,
+    DetailViewSectionsDict.RelatedArtifacts,
+  ],
+  isBookmarkable: false,
+  isDownloadable: true,
+  isCopyable: true,
+  isSimulatable: true,
+} as const;

--- a/src/entity-configuration/domain/simulation/whole-brain-circuit-simulation.ts
+++ b/src/entity-configuration/domain/simulation/whole-brain-circuit-simulation.ts
@@ -1,0 +1,127 @@
+import { downloadAsset } from '@/api/entitycore/queries/assets';
+import { getCircuit } from '@/api/entitycore/queries/model/circuit';
+import {
+  createSimulationCampaign,
+  getSimulationCampaign,
+} from '@/api/entitycore/queries/simulation/campaign';
+import { getSimulations } from '@/api/entitycore/queries/simulation/campaign/simulation';
+import { CircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit';
+import { EntityTypeDict } from '@/api/entitycore/types/entity-type';
+import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import { AssetLabel } from '@/api/entitycore/types/shared/global';
+import { getAssetElement } from '@/api/entitycore/utils';
+import { DetailViewSectionsDict } from '@/entity-configuration/definitions/types';
+import { EntityTypeGroup } from '@/entity-configuration/domain/group';
+import {
+  count,
+  listByScale,
+  rows as listSimulationRows,
+} from '@/entity-configuration/domain/simulation/simulation-campaign';
+import { EntitySlug } from '@/entity-configuration/domain/slug';
+import { wholeBrainSimulationFlag } from '@/features/feature-flags/flags';
+
+import { migrateConfig } from './utils';
+
+import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
+import type { ICircuitSimulationCampaign } from '@/api/entitycore/types/entities/simulation-campaign';
+import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
+import type { WorkspaceContext } from '@/types/common';
+
+const SCALE = CircuitScaleDictionary.WholeBrain;
+const list = listByScale(SCALE);
+
+export async function resolveSimulationByCampaignId({
+  id,
+  context,
+  populate = ['entity', 'config'],
+}: {
+  id: string;
+  context?: WorkspaceContext | null;
+  populate?: Array<string>;
+}) {
+  const campaign = await getSimulationCampaign({ id, context });
+
+  if (!campaign) {
+    throw new Error(`No campaign with id ${id} found`);
+  }
+
+  const source = await getSimulations({
+    context,
+    filters: { simulation_campaign_id: id },
+  });
+
+  const simulation = source.data.at(0);
+  const assets = campaign?.assets ?? [];
+  const configAsset = getAssetElement({
+    assets,
+    filter: (asset) => asset.label === AssetLabel.campaign_generation_config,
+  });
+
+  if (!configAsset) throw Error('No campaign config asset found');
+
+  let config = null;
+  let entity: ICircuit | null = null;
+
+  if (simulation?.entity_id && populate.includes('entity')) {
+    entity = await getCircuit({ id: simulation?.entity_id, context });
+  }
+
+  if (populate.includes('config')) {
+    const rawConfig = await downloadAsset({
+      entityId: campaign.id,
+      entityType: EntityTypeDict.SimulationCampaign,
+      id: configAsset?.id,
+      ctx: context,
+      asRawResponse: true,
+    });
+    config = await rawConfig.json();
+
+    migrateConfig(config);
+  }
+
+  return {
+    campaign,
+    simulation,
+    entity,
+    config,
+  };
+}
+
+type TResolvedSimulationByCampaign = Awaited<ReturnType<typeof resolveSimulationByCampaignId>>;
+type TResolvedSimulationByCampaigns = Awaited<ReturnType<typeof list>>;
+
+export const WholeBrainCircuitSimulation: EntityCoreTypeConfig<
+  ICircuitSimulationCampaign,
+  TResolvedSimulationByCampaign,
+  TResolvedSimulationByCampaigns
+> = {
+  group: EntityTypeGroup.Simulations,
+  title: 'Whole brain circuit (beta)',
+  extendedType: ExtendedEntitiesTypeDict.WholeBrainCircuitSimulation,
+  requiredFeatures: [wholeBrainSimulationFlag.key],
+  discriminator: { key: 'scale', value: [SCALE] },
+  type: EntityTypeDict.SimulationCampaign,
+  slug: EntitySlug.WholeBrainCircuitSimulation,
+  api: {
+    config: {
+      allowedFacets: true,
+      ilikeSearchEnabled: true,
+    },
+    query: {
+      count: count({ circuit__scale: SCALE }),
+      list,
+      one: getSimulationCampaign,
+      resolve: resolveSimulationByCampaignId,
+      create: createSimulationCampaign,
+    },
+    expandRow: (record, context) => listSimulationRows({ id: record.id, context }),
+  },
+  asset: {
+    extension: 'application/json',
+  },
+  detailViewSections: [DetailViewSectionsDict.Overview],
+  isBookmarkable: false,
+  isDownloadable: false,
+  isCopyable: true,
+  isSimulatable: false,
+} as const;

--- a/src/entity-configuration/domain/slug.ts
+++ b/src/entity-configuration/domain/slug.ts
@@ -18,6 +18,7 @@ export const ModelEntitySlug = {
   SmallMicrocircuit: 'small-microcircuit',
   Microcircuit: 'microcircuit',
   BrainRegion: 'brain-region',
+  WholeBrain: 'whole-brain',
   Circuit: 'circuit',
   IonChannelModel: 'ion-channel-model',
   IonChannelModelingCampaign: 'ion-channel-modeling-campaign',

--- a/src/entity-configuration/domain/slug.ts
+++ b/src/entity-configuration/domain/slug.ts
@@ -36,6 +36,7 @@ const SimulationEntitySlug = {
   MicrocircuitSimulation: 'microcircuit-simulation',
   IonChannelModelSimulation: 'ion-channel-model-simulation',
   RegionCircuitSimulation: 'region-circuit-simulation',
+  WholeBrainCircuitSimulation: 'whole-brain-circuit-simulation',
 } as const;
 
 const ExtractionEntitySlug = {

--- a/src/features/feature-flags/flags.ts
+++ b/src/features/feature-flags/flags.ts
@@ -28,10 +28,19 @@ export const emSynapseMappingActivityFlag = defineFlag<boolean>({
   visible: () => ['local', 'preview'].includes(config.DEPLOYMENT_ENV),
 });
 
+export const wholeBrainSimulationFlag = defineFlag<boolean>({
+  key: 'whole-brain-simulation',
+  defaultValue: false,
+  values: [true, false],
+  description: 'Whole brain / Brian2 FlyWire simulations',
+  visible: () => ['local', 'preview'].includes(config.DEPLOYMENT_ENV),
+});
+
 export const flags = [
   aiPanelStateFlag,
   extractionActivityFlag,
   emSynapseMappingActivityFlag,
+  wholeBrainSimulationFlag,
 ] as const;
 
 export type FlagKey = (typeof flags)[number]['key'];

--- a/src/features/scan-config/types.ts
+++ b/src/features/scan-config/types.ts
@@ -108,6 +108,7 @@ export type TabType = 'configuration' | 'simulations';
 export const SchemaNameDict = {
   // simulation
   CircuitSimulationScanConfig: 'CircuitSimulationScanConfig',
+  Brian2CircuitSimulationScanConfig: 'Brian2CircuitSimulationScanConfig',
   MEModelSimulationScanConfig: 'MEModelSimulationScanConfig',
   MEModelWithSynapsesCircuitSimulationScanConfig: 'MEModelWithSynapsesCircuitSimulationScanConfig',
   IonChannelModelSimulationScanConfig: 'IonChannelModelSimulationScanConfig',

--- a/src/features/scan-config/types.ts
+++ b/src/features/scan-config/types.ts
@@ -483,4 +483,5 @@ export type TSupportedEntityTypesForScanConfiguration =
   | typeof ExtendedEntitiesTypeDict.EMCellMesh
   | typeof ExtendedEntitiesTypeDict.CellMorphology
   | typeof ExtendedEntitiesTypeDict.UniversalCellMorphology
-  | typeof ExtendedEntitiesTypeDict.SingleNeuronCircuit;
+  | typeof ExtendedEntitiesTypeDict.SingleNeuronCircuit
+  | typeof ExtendedEntitiesTypeDict.WholeBrain;

--- a/src/features/scan-config/use-cases/simulations/results.tsx
+++ b/src/features/scan-config/use-cases/simulations/results.tsx
@@ -298,9 +298,12 @@ export default function SimulationsTab({
     setSelectedSimulationIds([]);
   };
 
-  const shouldTreatSimulationAsTask =
-    get(model, 'scale', null) === CircuitScaleDictionary.Microcircuit ||
-    get(model, 'scale', null) === CircuitScaleDictionary.Region;
+  const shouldTreatSimulationAsTask = [
+    CircuitScaleDictionary.Microcircuit,
+    CircuitScaleDictionary.Region,
+    CircuitScaleDictionary.System,
+    CircuitScaleDictionary.WholeBrain,
+  ].includes(get(model, 'scale', null));
 
   // TODO Refactor
   const run = async (simIds: string[]) => {

--- a/src/features/scan-config/use-cases/simulations/results.tsx
+++ b/src/features/scan-config/use-cases/simulations/results.tsx
@@ -223,11 +223,16 @@ export default function SimulationsTab({
     let nSubmissions = 0;
     let lowFundsError = false;
 
+    const taskType =
+      model && 'target_simulator' in model && model.target_simulator === 'Brian2'
+        ? ObiOneTaskTypeDict.CircuitSimulationBrian2
+        : ObiOneTaskTypeDict.CircuitSimulation;
+
     for (const simId of simIds) {
       try {
         const res = await runTask({
           ctx: { virtualLabId, projectId },
-          task_type: ObiOneTaskTypeDict.CircuitSimulation,
+          task_type: taskType,
           config_id: simId,
         });
         log('info', res);

--- a/src/features/scan-config/use-cases/simulations/results.tsx
+++ b/src/features/scan-config/use-cases/simulations/results.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import { get } from 'es-toolkit/compat';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { match } from 'ts-pattern';
 
@@ -38,11 +37,20 @@ import { keyBuilder } from '@/ui/use-query-keys/workspace';
 import { getErrorMessage } from '@/utils/error';
 import { log } from '@/utils/logger';
 
+import type { TCircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit';
 import type { ISimulation } from '@/api/entitycore/types/entities/simulation';
 import type { TScanConfigCampaignOriginActionDict } from '@/features/scan-config/helpers';
 import type { TActivityCustomFile } from '@/features/scan-config/types';
 
 const LOW_FUNDS_ERROR_CODE = 'ACCOUNTING_INSUFFICIENT_FUNDS_ERROR';
+
+const TASK_LAUNCH_SCALES: ReadonlySet<TCircuitScaleDictionary> = new Set([
+  CircuitScaleDictionary.Microcircuit,
+  CircuitScaleDictionary.Region,
+  CircuitScaleDictionary.System,
+  CircuitScaleDictionary.WholeBrain,
+]);
+
 type SimulationTabProps = {
   campaignId: string;
   virtualLabId: string;
@@ -298,12 +306,8 @@ export default function SimulationsTab({
     setSelectedSimulationIds([]);
   };
 
-  const shouldTreatSimulationAsTask = [
-    CircuitScaleDictionary.Microcircuit,
-    CircuitScaleDictionary.Region,
-    CircuitScaleDictionary.System,
-    CircuitScaleDictionary.WholeBrain,
-  ].includes(get(model, 'scale', null));
+  const scale = model && 'scale' in model ? model.scale : null;
+  const shouldTreatSimulationAsTask = scale !== null && TASK_LAUNCH_SCALES.has(scale);
 
   // TODO Refactor
   const run = async (simIds: string[]) => {

--- a/src/features/scan-config/use-cases/simulations/results.tsx
+++ b/src/features/scan-config/use-cases/simulations/results.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { get } from 'es-toolkit/compat';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { match } from 'ts-pattern';
 
@@ -306,7 +307,7 @@ export default function SimulationsTab({
     setSelectedSimulationIds([]);
   };
 
-  const scale = model && 'scale' in model ? model.scale : null;
+  const scale = get(model, 'scale', null);
   const shouldTreatSimulationAsTask = scale !== null && TASK_LAUNCH_SCALES.has(scale);
 
   // TODO Refactor

--- a/src/features/scan-config/workflow/definitions/index.ts
+++ b/src/features/scan-config/workflow/definitions/index.ts
@@ -37,3 +37,4 @@ export { simulatePairedNeuronCircuitWorkflow } from '@/features/scan-config/work
 export { simulateRegionCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-region-circuit';
 export { simulateSingleNeuronCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-single-neuron-circuit';
 export { simulateSmallMicrocircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-small-microcircuit';
+export { simulateWholeBrainCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-whole-brain-circuit';

--- a/src/features/scan-config/workflow/definitions/simulate-whole-brain-circuit.ts
+++ b/src/features/scan-config/workflow/definitions/simulate-whole-brain-circuit.ts
@@ -1,0 +1,7 @@
+import { resolveSimulationByCampaignId } from '@/entity-configuration/domain/simulation/whole-brain-circuit-simulation';
+import { defineSimulateCircuitScanConfigWorkflow } from '@/features/scan-config/workflow/definitions';
+
+export const simulateWholeBrainCircuitWorkflow = defineSimulateCircuitScanConfigWorkflow({
+  id: 'simulate-whole-brain-circuit',
+  resolve: resolveSimulationByCampaignId,
+});

--- a/src/features/scan-config/workflow/simulate-circuit-workflows.ts
+++ b/src/features/scan-config/workflow/simulate-circuit-workflows.ts
@@ -6,6 +6,7 @@ import { simulatePairedNeuronCircuitWorkflow } from '@/features/scan-config/work
 import { simulateRegionCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-region-circuit';
 import { simulateSingleNeuronCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-single-neuron-circuit';
 import { simulateSmallMicrocircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-small-microcircuit';
+import { simulateWholeBrainCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-whole-brain-circuit';
 
 import type { TCircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit';
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
@@ -19,6 +20,7 @@ export const SIMULATE_CIRCUIT_SOURCE_TYPES = [
   ExtendedEntitiesTypeDict.Microcircuit,
   ExtendedEntitiesTypeDict.BrainRegion,
   ExtendedEntitiesTypeDict.MEModelWithSynapses,
+  ExtendedEntitiesTypeDict.WholeBrain,
 ] as const;
 
 export type TSimulateCircuitSourceType = (typeof SIMULATE_CIRCUIT_SOURCE_TYPES)[number];
@@ -30,6 +32,7 @@ export const simulateCircuitWorkflowBySourceType = {
   [ExtendedEntitiesTypeDict.Microcircuit]: simulateMicrocircuitWorkflow,
   [ExtendedEntitiesTypeDict.BrainRegion]: simulateRegionCircuitWorkflow,
   [ExtendedEntitiesTypeDict.MEModelWithSynapses]: simulateMEModelWithSynapsesCircuitWorkflow,
+  [ExtendedEntitiesTypeDict.WholeBrain]: simulateWholeBrainCircuitWorkflow,
 } as const satisfies Record<TSimulateCircuitSourceType, TScanConfigWorkflowDefinition>;
 
 export function isSimulateCircuitSourceType(
@@ -67,6 +70,8 @@ export function getSimulateCircuitSourceTypeByScale(
       return ExtendedEntitiesTypeDict.Microcircuit;
     case CircuitScaleDictionary.Region:
       return ExtendedEntitiesTypeDict.BrainRegion;
+    case CircuitScaleDictionary.WholeBrain:
+      return ExtendedEntitiesTypeDict.WholeBrain;
     default:
       return null;
   }

--- a/src/ui/layouts/data-view-layout.tsx
+++ b/src/ui/layouts/data-view-layout.tsx
@@ -32,6 +32,7 @@ const LeftMenuUnsupportedEntityTypes = [
   ExtendedEntitiesTypeDict.EmSynapseMappingCampaign,
   ExtendedEntitiesTypeDict.SkeletonizationCampaign,
   ExtendedEntitiesTypeDict.RegionCircuitSimulation,
+  ExtendedEntitiesTypeDict.WholeBrainCircuitSimulation,
 ] as const;
 
 export async function DataViewLayout({

--- a/src/ui/segments/detail-view/overview/index.tsx
+++ b/src/ui/segments/detail-view/overview/index.tsx
@@ -69,6 +69,7 @@ const LegacySimulationCampaigns = [
   ExtendedEntitiesTypeDict.MicrocircuitSimulation,
   ExtendedEntitiesTypeDict.MemodelCircuitSimulation,
   ExtendedEntitiesTypeDict.RegionCircuitSimulation,
+  ExtendedEntitiesTypeDict.WholeBrainCircuitSimulation,
 ] as const;
 
 type TLegacySimulationCampaignConfig = {
@@ -258,7 +259,8 @@ export default async function Overview({
         defaultTab={{
           __activity: ScanConfigActivity.Simulate,
           id:
-            extendedType === ExtendedEntitiesTypeDict.MicrocircuitSimulation
+            extendedType === ExtendedEntitiesTypeDict.MicrocircuitSimulation ||
+            extendedType === ExtendedEntitiesTypeDict.WholeBrainCircuitSimulation
               ? SimulateScanConfigTabs.simulations
               : ExtractScanConfigTabs.configuration,
         }}

--- a/src/ui/segments/explore/helpers.ts
+++ b/src/ui/segments/explore/helpers.ts
@@ -21,6 +21,7 @@ import { SingeNeuronCircuitSimulation } from '@/entity-configuration/domain/simu
 import { SingleNeuronSimulation } from '@/entity-configuration/domain/simulation/single-neuron-simulation';
 import { SingleNeuronSynaptomeSimulation } from '@/entity-configuration/domain/simulation/single-neuron-synaptome-simulation';
 import { SmallMicrocircuitSimulation } from '@/entity-configuration/domain/simulation/small-microcircuit-simulation';
+import { WholeBrainCircuitSimulation } from '@/entity-configuration/domain/simulation/whole-brain-circuit-simulation';
 
 export const ExperimentalEntitiesTileTypes = {
   ReconstructionMorphology: CellMorphology,
@@ -52,6 +53,7 @@ export const SimulationEntitiesTileTypes = {
   MicrocircuitSimulation,
   IonChannelModelSimulation,
   RegionCircuitSimulation,
+  WholeBrainCircuitSimulation,
 } as const;
 
 export function getEntityTypeFromUrlOnEntityScope(url: string) {

--- a/src/ui/segments/workflows/config/activities/simulate.ts
+++ b/src/ui/segments/workflows/config/activities/simulate.ts
@@ -1,4 +1,5 @@
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import { wholeBrainSimulationFlag } from '@/features/feature-flags/flags';
 import { SchemaNameDict } from '@/features/scan-config/types';
 import { simulateIonChannelWorkflow } from '@/features/scan-config/workflow/definitions/simulate-ion-channel';
 import { simulateMemodelCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-memodel-circuit';
@@ -7,11 +8,13 @@ import { simulatePairedNeuronCircuitWorkflow } from '@/features/scan-config/work
 import { simulateRegionCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-region-circuit';
 import { simulateSingleNeuronCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-single-neuron-circuit';
 import { simulateSmallMicrocircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-small-microcircuit';
+import { simulateWholeBrainCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-whole-brain-circuit';
 
 import {
   circuitSimulationConfigureBinding,
   ionChannelSimulationConfigureBinding,
   memodelCircuitSimulationConfigureBinding,
+  wholeBrainBrian2SimulationConfigureBinding,
 } from '../scan-config-binding';
 import { WorkflowBrowseDefaults, WorkflowStagePresets } from '../types';
 
@@ -234,9 +237,21 @@ export const SimulateWorkflows: readonly IWorkflowDescriptor[] = [
   },
   {
     ...WorkflowBrowseDefaults,
-    ...WorkflowStagePresets.Disabled,
+    ...WorkflowStagePresets.ScanConfig,
     sourceType: ExtendedEntitiesTypeDict.WholeBrain,
-    targetType: ExtendedEntitiesTypeDict.WholeBrain,
-    disabled: true,
+    targetType: ExtendedEntitiesTypeDict.WholeBrainCircuitSimulation,
+    breadcrumb: {
+      root: 'Whole brain simulation',
+      steps: { selection: 'Select whole brain' },
+    },
+    scanConfig: {
+      definition: simulateWholeBrainCircuitWorkflow,
+      schemaName: SchemaNameDict.Brian2CircuitSimulationScanConfig,
+      configureBinding: wholeBrainBrian2SimulationConfigureBinding(),
+    },
+    configurationInputs: [{ type: ExtendedEntitiesTypeDict.WholeBrain }],
+    requiredFeatures: [wholeBrainSimulationFlag.key],
+    order: 10,
+    disabled: false,
   },
 ];

--- a/src/ui/segments/workflows/config/scan-config-binding.ts
+++ b/src/ui/segments/workflows/config/scan-config-binding.ts
@@ -23,6 +23,7 @@ export type TScanConfigFromIdType =
 
 export const ScanConfigGeneratedApiPath = {
   CircuitSimulation: 'circuit-simulation-scan-config-generate-grid',
+  Brian2CircuitSimulation: 'brian-2-circuit-simulation-scan-config-generate-grid',
   MEModelWithSynapsesCircuitSimulation:
     'me-model-with-synapses-circuit-simulation-scan-config-generate-grid',
   MEModelSimulation: 'me-model-simulation-scan-config-generate-grid',
@@ -162,5 +163,17 @@ export function buildEmSynapseMappingConfigureBinding(): TScanConfigConfigureBin
     },
     generatedApiPath: ScanConfigGeneratedApiPath.EMSynapseMapping,
     mergeBrowseSelectionIntoSingleGroup: true,
+  };
+}
+
+export function wholeBrainBrian2SimulationConfigureBinding(): TScanConfigConfigureBinding {
+  return {
+    browseType: ExtendedEntitiesTypeDict.WholeBrain,
+    scanConfigEntityType: ExtendedEntitiesTypeDict.WholeBrain,
+    fromIdTypeByBrowseType: {
+      [ExtendedEntitiesTypeDict.WholeBrain]: ScanConfigFromIdType.CircuitFromID,
+    },
+    generatedApiPath: ScanConfigGeneratedApiPath.Brian2CircuitSimulation,
+    schemaMappingKey: SchemaMappingKeyDict.Circuit,
   };
 }

--- a/src/ui/segments/workflows/elements/workflow-activity.tsx
+++ b/src/ui/segments/workflows/elements/workflow-activity.tsx
@@ -76,6 +76,7 @@ const NotAllowedResultsActionEntityTypes: TExtendedEntitiesTypeDict[] = [
   ExtendedEntitiesTypeDict.MemodelCircuitSimulation,
   ExtendedEntitiesTypeDict.MicrocircuitSimulation,
   ExtendedEntitiesTypeDict.RegionCircuitSimulation,
+  ExtendedEntitiesTypeDict.WholeBrainCircuitSimulation,
   ExtendedEntitiesTypeDict.CircuitExtractionCampaign,
   ExtendedEntitiesTypeDict.IonChannelModelSimulation,
   ExtendedEntitiesTypeDict.SkeletonizationCampaign,


### PR DESCRIPTION
## Summary

Adds FlyWire whole-brain Brian2 simulation support end-to-end, and refactors scan-config dispatch so circuit-specific routing lives next to the Circuit domain config instead of leaking into the generic `useScanConfiguration` hook.

### New entity types

- **`WholeBrain`** — dedicated domain config + view-def wrapping `EntityTypeDict.Circuit` with `scale__in: ['whole_brain']`. Surfaces whole-brain circuits in Data → Model and Workflows → Simulate.
- **`WholeBrainCircuitSimulation`** — domain config, view-def, and list-expanded view-def for the resulting simulation entity.

### Brian2 dispatch

- Circuit type now carries `target_simulator: 'NEURON' | 'Brian2'`.
- `simulate` dispatch on the Circuit domain config returns the Brian2 schema (`Brian2CircuitSimulationScanConfig`) and obi-one endpoint (`brian-2-circuit-simulation-scan-config-generate-grid`) when `target_simulator === 'Brian2'`, otherwise the default.
- Launches submit with task type `circuit_simulation_brian2_machine` via `ObiOneTaskTypeDict.CircuitSimulationBrian2`.

### Workflow wiring

- New simulate-whole-brain-circuit workflow definition registered in `simulateCircuitWorkflowBySourceType`.
- WholeBrain entry added to `SimulateWorkflows`, gated by the new `whole-brain-simulation` feature flag (local + preview only).

### Scan-config refactor

- Added optional `scanConfig?: ScanConfigDispatchMap<T>` to `EntityCoreTypeConfig<T>`. Each entity declares its own per-activity entries (`extract` / `simulate` / `process` / `build`) — either static `{ apiPath, schemaName }` or a function `(entity) => ...` for conditional dispatch (e.g. Brian2).
- Deleted `getGeneratedApiUrl` / `getScanConfigSchemaName` (two large ts-pattern blocks). Replaced with a single 15-line `resolveScanConfigDispatch` helper.
- `useScanConfiguration` no longer extracts `target_simulator` or knows about any entity-specific field; it just reads the entity config's `scanConfig[activity]`.
- New `ScanConfigApiPathDict` mirrors `SchemaNameDict` — all obi-one endpoint slugs are dict-referenced instead of inlined as raw strings.

Adding Brian2 support to additional circuit scales (microcircuit, paired-neuron, region, …) is now a per-config change with no hook signature churn.

## Test plan

- [x] Enable `whole-brain-simulation` flag locally.
- [x] Workflows → Simulate → "Whole brain" lists whole-brain-scaled circuits (e.g. FlyWire test circuit).
- [x] Clicking "Use model" navigates to `…/configure/circuit/<id>?…&dataType=whole_brain` and renders the Brian2 scan-config form (no 404).
- [x] Submitting a simulation sends `task_type: 'circuit_simulation_brian2_machine'`; campaign appears under Data → Simulations.
- [x] Regression: every other scan-config flow loads — small-microcircuit / microcircuit / paired-neuron / single-neuron / region simulate; circuit extract; EM-cell-mesh process (skeletonization); universal-cell-morphology build (EM synapse mapping); MEModel / IonChannelModel / MEModelWithSynapses simulate.