### PR TITLE
Auth: prevent redirect loop and HTTP 431 on repeat sign-in

### DIFF
--- a/src/app/api/auth/redirect-after-signin/route.ts
+++ b/src/app/api/auth/redirect-after-signin/route.ts
@@ -14,13 +14,8 @@ export async function GET() {
     return response;
   }
 
-  // Fall back to the auth-proxy URL from config, not `request.url`. Under
-  // Amplify Lambda, `request.url` reflects the function's internal binding
-  // (e.g. `https://localhost:3000`) rather than the public host, so building
-  // the fallback off the request would redirect the browser to localhost.
-  // `AUTH_PROXY_URL` is guaranteed at runtime on preview (this route is only
-  // reachable through the preview detour), but the schema marks it optional,
-  // so guard the construction.
+  // Build the fallback from config, not `request.url` — under Amplify Lambda
+  // the latter resolves to the function's internal binding, not the public host.
   if (!serverConfig.AUTH_PROXY_URL) {
     return new NextResponse('Auth proxy is not configured', { status: 500 });
   }

--- a/src/app/api/auth/redirect-after-signin/route.ts
+++ b/src/app/api/auth/redirect-after-signin/route.ts
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
-import { AUTH_PROXY_REDIRECT_TARGET_COOKIE } from '@/auth/constants';
+import { AUTH_PROXY_REDIRECT_TARGET_COOKIE, PREVIEW_DOMAIN_SUFFIX } from '@/auth/constants';
 import { serverConfig } from '@/config/server';
 
 export async function GET() {
@@ -33,7 +33,7 @@ export async function GET() {
 function isValidPreviewDomain(url: string): boolean {
   try {
     const parsed = new URL(url);
-    return parsed.hostname.endsWith('.preview.openbraininstitute.org');
+    return parsed.hostname.endsWith(PREVIEW_DOMAIN_SUFFIX);
   } catch {
     return false;
   }

--- a/src/app/api/auth/redirect-after-signin/route.ts
+++ b/src/app/api/auth/redirect-after-signin/route.ts
@@ -2,11 +2,11 @@ import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 import { AUTH_PROXY_REDIRECT_TARGET_COOKIE } from '@/auth/constants';
+import { serverConfig } from '@/config/server';
 
-export async function GET(request: Request) {
+export async function GET() {
   const cookieStore = await cookies();
   const returnTo = cookieStore.get(AUTH_PROXY_REDIRECT_TARGET_COOKIE)?.value;
-  const requestUrl = new URL(request.url);
 
   if (returnTo && isValidPreviewDomain(returnTo)) {
     const response = NextResponse.redirect(returnTo);
@@ -14,7 +14,17 @@ export async function GET(request: Request) {
     return response;
   }
 
-  const fallbackUrl = new URL('/app', requestUrl.origin);
+  // Fall back to the auth-proxy URL from config, not `request.url`. Under
+  // Amplify Lambda, `request.url` reflects the function's internal binding
+  // (e.g. `https://localhost:3000`) rather than the public host, so building
+  // the fallback off the request would redirect the browser to localhost.
+  // `AUTH_PROXY_URL` is guaranteed at runtime on preview (this route is only
+  // reachable through the preview detour), but the schema marks it optional,
+  // so guard the construction.
+  if (!serverConfig.AUTH_PROXY_URL) {
+    return new NextResponse('Auth proxy is not configured', { status: 500 });
+  }
+  const fallbackUrl = new URL('/app', serverConfig.AUTH_PROXY_URL);
   const response = NextResponse.redirect(fallbackUrl);
   response.cookies.delete(AUTH_PROXY_REDIRECT_TARGET_COOKIE);
   return response;

--- a/src/app/app/log-in/page.tsx
+++ b/src/app/app/log-in/page.tsx
@@ -28,14 +28,13 @@ function isSyncTarget(candidate: string): boolean {
   return parseCandidate(candidate)?.pathname === SYNC_PATH;
 }
 
-// `callbackUrl` is taken from the query string and is fully attacker-controlled.
-// Anywhere we navigate to it directly (bypassing NextAuth's own checks) we must
-// confirm it stays on this origin, otherwise `/app/log-in?callbackUrl=https://evil`
-// becomes a silent open redirect for already-authenticated users.
+// `callbackUrl` is attacker-controlled — guard same-origin to avoid an open redirect.
 function isSameOriginTarget(candidate: string): boolean {
   return parseCandidate(candidate)?.origin === window.location.origin;
 }
 
+// Pass sync-targeted URLs through unchanged; re-wrapping them under `?redirectUrl=`
+// grows `__Secure-next-auth.callback-url` on every re-auth until it hits 431.
 function resolveCallbackUrl(redirectURL: string | null, onboarding: string): string {
   if (!redirectURL) return onboarding;
   if (isSyncTarget(redirectURL)) {
@@ -53,8 +52,7 @@ export default function Page() {
 
   useEffect(() => {
     if (hasInitiated.current) return;
-    // Wait for the session probe so we don't trigger a redundant OAuth
-    // round-trip for a user who already has a valid Keycloak session.
+    // Wait for the session probe to skip a redundant OAuth round-trip for an SSO'd user.
     if (session.status === 'loading') return;
 
     hasInitiated.current = true;
@@ -65,13 +63,6 @@ export default function Page() {
       return;
     }
 
-    // If the incoming `callbackUrl` already targets the sync page (from
-    // `buildPlatformLoginUrl`, from NextAuth middleware intercepting an
-    // unauthenticated sync visit, or from a prior wrap) pass it through
-    // unchanged. Re-wrapping it adds another `?redirectUrl=` layer and
-    // re-encodes every percent in the previous layer, which is what blows
-    // the `__Secure-next-auth.callback-url` cookie past the upstream header
-    // limit on repeated re-auth and ends in HTTP 431.
     const onboarding = `${window.location.origin}${SYNC_PATH}`;
     const callbackUrl = resolveCallbackUrl(redirectURL, onboarding);
 

--- a/src/app/app/log-in/page.tsx
+++ b/src/app/app/log-in/page.tsx
@@ -4,14 +4,14 @@ import { useSearchParams } from 'next/navigation';
 import { signIn, useSession } from 'next-auth/react';
 import { useEffect, useRef } from 'react';
 
-import { AUTH_PROXY_REDIRECT_TARGET_COOKIE } from '@/auth/constants';
+import { AUTH_PROXY_REDIRECT_TARGET_COOKIE, PREVIEW_DOMAIN_SUFFIX } from '@/auth/constants';
 import { config } from '@/config';
 
 const SYNC_PATH = `${config.ROOT_ROUTE}/sync`;
 
 function setAuthProxyRedirectCookie(url: string) {
   // biome-ignore lint/suspicious/noDocumentCookie: Enable auth for preview deployments with only one subdomain registered in Keycloak as redirect_uri
-  document.cookie = `${AUTH_PROXY_REDIRECT_TARGET_COOKIE}=${encodeURIComponent(url)}; path=/; domain=.preview.openbraininstitute.org; secure; samesite=lax`;
+  document.cookie = `${AUTH_PROXY_REDIRECT_TARGET_COOKIE}=${encodeURIComponent(url)}; path=/; domain=${PREVIEW_DOMAIN_SUFFIX}; secure; samesite=lax`;
 }
 
 function parseCandidate(candidate: string): URL | null {

--- a/src/app/app/log-in/page.tsx
+++ b/src/app/app/log-in/page.tsx
@@ -57,7 +57,9 @@ export default function Page() {
 
     hasInitiated.current = true;
 
-    if (session.status === 'authenticated') {
+    // A 'RefreshAccessTokenError' session decrypts as authenticated but can't
+    // mint fresh access tokens — fall through to re-auth instead of bouncing.
+    if (session.status === 'authenticated' && !session.data?.error) {
       const safeTarget = redirectURL && isSameOriginTarget(redirectURL) ? redirectURL : SYNC_PATH;
       window.location.replace(safeTarget);
       return;
@@ -72,7 +74,7 @@ export default function Page() {
     } else {
       signIn('keycloak', { callbackUrl });
     }
-  }, [redirectURL, session.status]);
+  }, [redirectURL, session.status, session.data?.error]);
 
   return (
     <div className="flex flex-col items-center justify-center space-y-4">

--- a/src/app/app/log-in/page.tsx
+++ b/src/app/app/log-in/page.tsx
@@ -28,7 +28,7 @@ function isSyncTarget(candidate: string): boolean {
   return parseCandidate(candidate)?.pathname === SYNC_PATH;
 }
 
-// `callbackUrl` is attacker-controlled — guard same-origin to avoid an open redirect.
+// Guard same-origin to avoid an open redirect, as `callbackUrl` might be attacker-controlled.
 function isSameOriginTarget(candidate: string): boolean {
   return parseCandidate(candidate)?.origin === window.location.origin;
 }

--- a/src/app/app/log-in/page.tsx
+++ b/src/app/app/log-in/page.tsx
@@ -1,32 +1,79 @@
 'use client';
 
 import { useSearchParams } from 'next/navigation';
-import { signIn } from 'next-auth/react';
+import { signIn, useSession } from 'next-auth/react';
 import { useEffect, useRef } from 'react';
 
 import { AUTH_PROXY_REDIRECT_TARGET_COOKIE } from '@/auth/constants';
 import { config } from '@/config';
+
+const SYNC_PATH = `${config.ROOT_ROUTE}/sync`;
 
 function setAuthProxyRedirectCookie(url: string) {
   // biome-ignore lint/suspicious/noDocumentCookie: Enable auth for preview deployments with only one subdomain registered in Keycloak as redirect_uri
   document.cookie = `${AUTH_PROXY_REDIRECT_TARGET_COOKIE}=${encodeURIComponent(url)}; path=/; domain=.preview.openbraininstitute.org; secure; samesite=lax`;
 }
 
+function parseCandidate(candidate: string): URL | null {
+  try {
+    return candidate.startsWith('http')
+      ? new URL(candidate)
+      : new URL(candidate, window.location.origin);
+  } catch {
+    return null;
+  }
+}
+
+function isSyncTarget(candidate: string): boolean {
+  return parseCandidate(candidate)?.pathname === SYNC_PATH;
+}
+
+// `callbackUrl` is taken from the query string and is fully attacker-controlled.
+// Anywhere we navigate to it directly (bypassing NextAuth's own checks) we must
+// confirm it stays on this origin, otherwise `/app/log-in?callbackUrl=https://evil`
+// becomes a silent open redirect for already-authenticated users.
+function isSameOriginTarget(candidate: string): boolean {
+  return parseCandidate(candidate)?.origin === window.location.origin;
+}
+
+function resolveCallbackUrl(redirectURL: string | null, onboarding: string): string {
+  if (!redirectURL) return onboarding;
+  if (isSyncTarget(redirectURL)) {
+    return redirectURL.startsWith('http') ? redirectURL : `${window.location.origin}${redirectURL}`;
+  }
+  return `${onboarding}?redirectUrl=${encodeURIComponent(redirectURL)}`;
+}
+
 export default function Page() {
   const searchParams = useSearchParams();
+  const session = useSession();
   const hasInitiated = useRef(false);
 
   const redirectURL = searchParams.get('callbackUrl');
 
   useEffect(() => {
     if (hasInitiated.current) return;
+    // Wait for the session probe so we don't trigger a redundant OAuth
+    // round-trip for a user who already has a valid Keycloak session.
+    if (session.status === 'loading') return;
 
     hasInitiated.current = true;
 
-    const onboarding = `${window.location.origin}${config.ROOT_ROUTE}/sync`;
-    const callbackUrl = redirectURL
-      ? `${onboarding}?redirectUrl=${encodeURIComponent(redirectURL)}`
-      : onboarding;
+    if (session.status === 'authenticated') {
+      const safeTarget = redirectURL && isSameOriginTarget(redirectURL) ? redirectURL : SYNC_PATH;
+      window.location.replace(safeTarget);
+      return;
+    }
+
+    // If the incoming `callbackUrl` already targets the sync page (from
+    // `buildPlatformLoginUrl`, from NextAuth middleware intercepting an
+    // unauthenticated sync visit, or from a prior wrap) pass it through
+    // unchanged. Re-wrapping it adds another `?redirectUrl=` layer and
+    // re-encodes every percent in the previous layer, which is what blows
+    // the `__Secure-next-auth.callback-url` cookie past the upstream header
+    // limit on repeated re-auth and ends in HTTP 431.
+    const onboarding = `${window.location.origin}${SYNC_PATH}`;
+    const callbackUrl = resolveCallbackUrl(redirectURL, onboarding);
 
     if (config.AUTH_PROXY_URL && !window.location.href.startsWith(config.AUTH_PROXY_URL)) {
       setAuthProxyRedirectCookie(callbackUrl);
@@ -34,7 +81,7 @@ export default function Page() {
     } else {
       signIn('keycloak', { callbackUrl });
     }
-  }, [redirectURL]);
+  }, [redirectURL, session.status]);
 
   return (
     <div className="flex flex-col items-center justify-center space-y-4">

--- a/src/app/showcases/build-platform-login-url.ts
+++ b/src/app/showcases/build-platform-login-url.ts
@@ -3,6 +3,5 @@
  * virtual lab + project and redirects to `.../reports/obi-showcase/{slug}?section=...`.
  */
 export function buildPlatformLoginUrl(slug: string, section: string = 'description'): string {
-  const syncUrl = `/app/virtual-lab/sync?showcaseSlug=${encodeURIComponent(slug)}&showcaseSection=${encodeURIComponent(section)}`;
-  return `/app/log-in?callbackUrl=${encodeURIComponent(syncUrl)}`;
+  return `/app/virtual-lab/sync?showcaseSlug=${encodeURIComponent(slug)}&showcaseSection=${encodeURIComponent(section)}`;
 }

--- a/src/auth/constants.ts
+++ b/src/auth/constants.ts
@@ -1,1 +1,3 @@
 export const AUTH_PROXY_REDIRECT_TARGET_COOKIE = 'auth-proxy-redirect-target';
+
+export const PREVIEW_DOMAIN_SUFFIX = '.preview.openbraininstitute.org';

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,5 +1,6 @@
 import { getServerSession, type NextAuthOptions, type Session, type TokenSet } from 'next-auth';
 
+import { AUTH_PROXY_REDIRECT_TARGET_COOKIE } from '@/auth/constants';
 import { serverConfig as config } from '@/config/server';
 import { log } from '@/utils/logger';
 
@@ -32,6 +33,8 @@ function getSharedCookieDomain(authProxyUrl: string): string {
     return '';
   }
 }
+
+const authProxyHostname = config.AUTH_PROXY_URL ? new URL(config.AUTH_PROXY_URL).hostname : null;
 
 /**
  * Updates or inserts a refresh token in the authentication manager service.
@@ -164,15 +167,26 @@ export const authOptions: NextAuthOptions = {
   ],
   callbacks: {
     async redirect({ url, baseUrl }) {
-      // Used for preview deployments to return back from the auth proxy
-      if (config.AUTH_PROXY_URL) {
-        const authProxyHostname = new URL(config.AUTH_PROXY_URL).hostname;
-        const baseHostname = new URL(baseUrl).hostname;
-        if (baseHostname === authProxyHostname && url.startsWith(baseUrl)) {
-          return `${config.AUTH_PROXY_URL}/api/auth/redirect-after-signin`;
-        }
-      }
-      return url;
+      // Preview-only detour: when a user starts on a non-proxy subdomain we
+      // funnel them through the auth proxy and stash the real target in the
+      // `auth-proxy-redirect-target` cookie. After OAuth, NextAuth lands back
+      // on the proxy domain and we send the browser to `redirect-after-signin`
+      // so it can read that cookie and bounce to the original subdomain.
+      //
+      // If the cookie isn't set, the user logged in directly on the proxy
+      // domain — there's no cross-subdomain dereference to do, so skip the
+      // detour and let NextAuth use `url` as-is. Without this guard we'd
+      // route them through a handler that has nothing to read and would fall
+      // back to a server-derived origin (broken under Amplify Lambda).
+      if (!authProxyHostname || !url.startsWith(baseUrl)) return url;
+      if (new URL(baseUrl).hostname !== authProxyHostname) return url;
+      // Dynamic import: `next/headers` is server-only, but this module is
+      // reachable from client component import graphs (via `auth-fetch`).
+      // Pulling it in at the top level breaks the client build.
+      const { cookies } = await import('next/headers');
+      const cookieStore = await cookies();
+      if (!cookieStore.has(AUTH_PROXY_REDIRECT_TARGET_COOKIE)) return url;
+      return `${config.AUTH_PROXY_URL}/api/auth/redirect-after-signin`;
     },
     async jwt({ token, account, user, profile }) {
       // Initial sign in

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -167,22 +167,14 @@ export const authOptions: NextAuthOptions = {
   ],
   callbacks: {
     async redirect({ url, baseUrl }) {
-      // Preview-only detour: when a user starts on a non-proxy subdomain we
-      // funnel them through the auth proxy and stash the real target in the
-      // `auth-proxy-redirect-target` cookie. After OAuth, NextAuth lands back
-      // on the proxy domain and we send the browser to `redirect-after-signin`
-      // so it can read that cookie and bounce to the original subdomain.
-      //
-      // If the cookie isn't set, the user logged in directly on the proxy
-      // domain — there's no cross-subdomain dereference to do, so skip the
-      // detour and let NextAuth use `url` as-is. Without this guard we'd
-      // route them through a handler that has nothing to read and would fall
-      // back to a server-derived origin (broken under Amplify Lambda).
+      // Preview detour: route post-OAuth back through the proxy's
+      // redirect-after-signin handler, which reads the redirect-target cookie
+      // and bounces to the original subdomain. Skip if no cookie is set
+      // (user signed in directly on the proxy domain — nothing to dereference).
       if (!authProxyHostname || !url.startsWith(baseUrl)) return url;
       if (new URL(baseUrl).hostname !== authProxyHostname) return url;
-      // Dynamic import: `next/headers` is server-only, but this module is
-      // reachable from client component import graphs (via `auth-fetch`).
-      // Pulling it in at the top level breaks the client build.
+      // `next/headers` is server-only but this module is reachable from client
+      // bundles via `auth-fetch`; defer the import to keep it out of them.
       const { cookies } = await import('next/headers');
       const cookieStore = await cookies();
       if (!cookieStore.has(AUTH_PROXY_REDIRECT_TARGET_COOKIE)) return url;

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -1,11 +1,15 @@
 'use client';
 
-import { useEffect } from 'react';
 import { useAtom } from 'jotai';
-import { signIn, useSession } from 'next-auth/react';
-import { Session } from 'next-auth';
-import { usePrevious } from './hooks';
+import { usePathname } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { useEffect } from 'react';
+
 import sessionAtom from '@/state/session';
+
+import { usePrevious } from './hooks';
+
+import type { Session } from 'next-auth';
 
 export type SessionOrNull = Session | null;
 
@@ -41,6 +45,7 @@ export { getClientSession };
 
 export default function useSessionState() {
   const currentSession = useSession();
+  const pathname = usePathname();
   const [session, setSessionState] = useAtom(sessionAtom);
   const previousSession = usePrevious(currentSession);
 
@@ -74,8 +79,10 @@ export default function useSessionState() {
 
   useEffect(() => {
     if (currentSession?.data?.error !== 'RefreshAccessTokenError') return;
-
-    // automatically signIn when a refresh token expires
-    signIn('keycloak');
-  }, [currentSession]);
+    // Route through /app/log-in so the proxy detour runs on preview deployments;
+    // calling signIn() here would target the current host and bypass it.
+    if (pathname === '/app/log-in') return;
+    const target = `${window.location.pathname}${window.location.search}`;
+    window.location.href = `/app/log-in?callbackUrl=${encodeURIComponent(target)}`;
+  }, [currentSession, pathname]);
 }


### PR DESCRIPTION
## Summary

A redirect loop ending in HTTP 431 (Request Header Fields Too Large) on auth. Three independent issues combined to produce it; this PR fixes all three plus an open-redirect surface noticed during review.

## Changes

**`src/app/app/log-in/page.tsx`**
- Probe `useSession()` and short-circuit straight to the target when already authenticated — no redundant OAuth round-trip.
- Validate `callbackUrl` is same-origin before navigating in the authenticated branch (closes an open-redirect via `/app/log-in?callbackUrl=https://evil`).
- Stop re-wrapping `callbackUrl` when it already targets `/sync`. Re-wrapping added a `?redirectUrl=` layer + re-encoded percents on every iteration, growing `__Secure-next-auth.callback-url` past upstream header limits.

**`src/auth/index.ts` — `redirect` callback**
- Gate the preview auth-proxy detour on presence of `auth-proxy-redirect-target` cookie. Direct sign-ins on the proxy domain no longer get routed through a handler that has nothing to read.
- Reorder checks so cheap predicates short-circuit before `await cookies()`; hoist `authProxyHostname` to module scope.
- Defer `next/headers` to a dynamic import (this module is reachable from client bundles via `auth-fetch`).

**`src/app/api/auth/redirect-after-signin/route.ts`**
- Build the fallback URL from `serverConfig.AUTH_PROXY_URL` instead of `request.url`. Under Amplify Lambda the latter resolves to the function's internal binding (`localhost:3000`), which is why direct logins on `main.preview` were bouncing to localhost.

**`src/app/showcases/build-platform-login-url.ts`**
- Link directly to `/sync`. The log-in page intercepts unauthenticated visits already, so the explicit `?callbackUrl=` wrap layer just contributed to cookie growth.

**`src/auth/constants.ts`**
- Extract `PREVIEW_DOMAIN_SUFFIX` so the cookie scope (client write) and the redirect-target allowlist (server read) can't drift apart.

## Test plan

- [x] Sign in on feature branch routes via `develop.preview`. TODO once the PR is merged: the auth proxy host to be updated to `main.preview`, `develop.preview` - to be retired
- [ ] Sign in directly on auth proxy host works
- [x] Visit `/app/log-in` while already authenticated with `?callbackUrl=/app/foo` → goes to `/app/foo` without OAuth round-trip
- [x] Visit `/app/log-in?callbackUrl=https://evil.example.com` while authenticated → falls back to `/sync` instead of redirecting off-platform
- [x] Repeated re-auth flows don't grow `__Secure-next-auth.callback-url`
- [x] Showcase entry URL (`buildPlatformLoginUrl`) still onboards correctly for new/anonymous users