### PR TITLE
Circuit download: per-component archives, config files, JSON metadata

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -93,6 +93,11 @@
             "groups": [
               {
                 "type": false,
+                "source": [":NODE:"]
+              },
+              ":BLANK_LINE:",
+              {
+                "type": false,
                 "source": [":PACKAGE:"]
               },
               ":BLANK_LINE:",
@@ -120,6 +125,10 @@
                 ]
               },
               ":BLANK_LINE:",
+              {
+                "type": true,
+                "source": [":NODE:"]
+              },
               {
                 "type": true,
                 "source": [":PACKAGE:"]

--- a/src/api/entity-download/asset-folder.ts
+++ b/src/api/entity-download/asset-folder.ts
@@ -4,15 +4,7 @@ type CreateAssetFolderTicketResponse = {
   ticketId: string;
 };
 
-export async function createAssetFolderDownloadTicket({
-  entityType,
-  entityId,
-  assetId,
-  prefix,
-  filename,
-  virtualLabId,
-  projectId,
-}: {
+type CreateAssetFolderTicketParams = {
   entityType: TEntityTypeDict;
   entityId: string;
   assetId: string;
@@ -20,7 +12,11 @@ export async function createAssetFolderDownloadTicket({
   filename: string;
   virtualLabId?: string;
   projectId?: string;
-}): Promise<CreateAssetFolderTicketResponse> {
+};
+
+export async function createAssetFolderDownloadTicket(
+  params: CreateAssetFolderTicketParams
+): Promise<CreateAssetFolderTicketResponse> {
   const url = `${window.location.origin}/api/entity-download/asset-folder/ticket`;
   const response = await fetch(url, {
     method: 'post',
@@ -28,15 +24,7 @@ export async function createAssetFolderDownloadTicket({
       accept: 'application/json',
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({
-      entityType,
-      entityId,
-      assetId,
-      prefix,
-      filename,
-      virtualLabId,
-      projectId,
-    }),
+    body: JSON.stringify(params),
   });
   if (response.ok) {
     return response.json();

--- a/src/api/entity-download/asset-folder.ts
+++ b/src/api/entity-download/asset-folder.ts
@@ -1,0 +1,51 @@
+import type { TEntityTypeDict } from '@/api/entitycore/types';
+
+type CreateAssetFolderTicketResponse = {
+  ticketId: string;
+};
+
+export async function createAssetFolderDownloadTicket({
+  entityType,
+  entityId,
+  assetId,
+  prefix,
+  filename,
+  virtualLabId,
+  projectId,
+}: {
+  entityType: TEntityTypeDict;
+  entityId: string;
+  assetId: string;
+  prefix: string;
+  filename: string;
+  virtualLabId?: string;
+  projectId?: string;
+}): Promise<CreateAssetFolderTicketResponse> {
+  const url = `${window.location.origin}/api/entity-download/asset-folder/ticket`;
+  const response = await fetch(url, {
+    method: 'post',
+    headers: {
+      accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      entityType,
+      entityId,
+      assetId,
+      prefix,
+      filename,
+      virtualLabId,
+      projectId,
+    }),
+  });
+  if (response.ok) {
+    return response.json();
+  }
+  throw new Error(
+    `Error #${response.status} creating asset folder download ticket: ${response.statusText}`
+  );
+}
+
+export function getAssetFolderDownloadUrl(ticketId: string): string {
+  return `${window.location.origin}/api/entity-download/asset-folder/ticket/${ticketId}`;
+}

--- a/src/app/api/entity-download/[entityType]/route.ts
+++ b/src/app/api/entity-download/[entityType]/route.ts
@@ -44,7 +44,11 @@ export async function POST(request: NextRequest, { params }: { params: { entityT
   const reqDataRaw = await request.json();
   const reqData = downloadRequestSchema.parse(reqDataRaw);
 
-  const downloadStream = await createDownloadStream({ entityType, ...reqData });
+  const downloadStream = await createDownloadStream({
+    kind: 'entity-batch',
+    entityType,
+    ...reqData,
+  });
 
   return new NextResponse(downloadStream, {
     headers: getDownloadStreamHeaders({

--- a/src/app/api/entity-download/[entityType]/ticket/[ticketId]/route.ts
+++ b/src/app/api/entity-download/[entityType]/ticket/[ticketId]/route.ts
@@ -36,6 +36,11 @@ export async function GET(
       return NextResponse.json({ error: 'Download ticket not found or expired' }, { status: 404 });
     }
 
+    // Only entity-batch tickets are valid on this route
+    if (ticket.kind !== 'entity-batch') {
+      return NextResponse.json({ error: 'Invalid ticket kind for this route' }, { status: 400 });
+    }
+
     // If the ticket is for a different entity type, reject the request
     if (ticket.entityType !== entityType) {
       return NextResponse.json(
@@ -46,12 +51,7 @@ export async function GET(
 
     ticketStore.deleteTicket(ticketId);
 
-    const downloadStream = await createDownloadStream({
-      entityType: ticket.entityType,
-      virtualLabId: ticket.virtualLabId,
-      projectId: ticket.projectId,
-      entityIds: ticket.entityIds,
-    });
+    const downloadStream = await createDownloadStream(ticket);
 
     return new NextResponse(downloadStream, {
       headers: getDownloadStreamHeaders({

--- a/src/app/api/entity-download/asset-folder/ticket/[ticketId]/route.ts
+++ b/src/app/api/entity-download/asset-folder/ticket/[ticketId]/route.ts
@@ -1,0 +1,43 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { auth } from '@/auth';
+import { createDownloadStream } from '@/features/entity-download/download-stream';
+import { ticketStore } from '@/features/entity-download/ticket-store';
+import { getDownloadStreamHeaders } from '@/features/entity-download/utils';
+
+/**
+ * Streams a tar.gz of all files under `ticket.prefix` inside a single asset.
+ */
+export async function GET(_request: NextRequest, { params }: { params: { ticketId: string } }) {
+  const { ticketId } = await params;
+
+  const session = await auth();
+  if (!session) {
+    return new Response('Unauthorized', {
+      status: 401,
+      statusText: 'The supplied authentication is not authorized for this action',
+    });
+  }
+
+  try {
+    const ticket = ticketStore.getTicket(ticketId);
+
+    if (!ticket) {
+      return NextResponse.json({ error: 'Download ticket not found or expired' }, { status: 404 });
+    }
+
+    if (ticket.kind !== 'asset-folder') {
+      return NextResponse.json({ error: 'Invalid ticket kind for this route' }, { status: 400 });
+    }
+
+    ticketStore.deleteTicket(ticketId);
+
+    const downloadStream = await createDownloadStream(ticket);
+
+    return new NextResponse(downloadStream, {
+      headers: getDownloadStreamHeaders({ filename: ticket.filename }),
+    });
+  } catch {
+    return NextResponse.json({ error: 'Failed to process download request' }, { status: 500 });
+  }
+}

--- a/src/app/api/entity-download/asset-folder/ticket/route.ts
+++ b/src/app/api/entity-download/asset-folder/ticket/route.ts
@@ -7,26 +7,21 @@ import { ticketStore } from '@/features/entity-download/ticket-store';
 
 import type { TEntityTypeDict } from '@/api/entitycore/types';
 
-// Schema for ticket creation request
-const createTicketSchema = z.object({
+const createAssetFolderTicketSchema = z.object({
+  entityType: z.enum(['circuit']),
+  entityId: z.uuid(),
+  assetId: z.uuid(),
+  prefix: z.string().min(1),
+  filename: z.string().min(1),
   virtualLabId: z.uuid().optional().nullable(),
   projectId: z.uuid().optional().nullable(),
-  entityIds: z.uuid().array().max(100),
 });
 
 /**
- * Creates a download ticket for a batch of entity IDs
- *
- * @returns A ticket ID that can be used to initiate the download
- *
- * Expected JSON body:
- * {
- *   virtualLabId?: string | null,  // Optional UUID of virtual lab context
- *   projectId?: string | null,     // Optional UUID of project context
- *   entityIds: string[]            // Array of entity UUIDs to download (max 100)
- * }
+ * Creates a download ticket for a folder inside one asset of a single entity.
+ * The GET endpoint streams a tar.gz of every file under `prefix`.
  */
-export async function POST(request: NextRequest, { params }: { params: { entityType: string } }) {
+export async function POST(request: NextRequest) {
   const session = await auth();
   if (!session) {
     return new Response('Unauthorized', {
@@ -35,19 +30,18 @@ export async function POST(request: NextRequest, { params }: { params: { entityT
     });
   }
 
-  const { entityType: entityTypeRaw } = await params;
-  const entityType = snakeCase(entityTypeRaw) as TEntityTypeDict;
-
   try {
-    const reqData = createTicketSchema.parse(await request.json());
+    const reqData = createAssetFolderTicketSchema.parse(await request.json());
 
-    // Store the download information with creation timestamp
     const ticketId = ticketStore.createTicket({
-      kind: 'entity-batch',
-      entityType,
+      kind: 'asset-folder',
+      entityType: snakeCase(reqData.entityType) as TEntityTypeDict,
+      entityId: reqData.entityId,
+      assetId: reqData.assetId,
+      prefix: reqData.prefix,
+      filename: reqData.filename,
       virtualLabId: reqData.virtualLabId,
       projectId: reqData.projectId,
-      entityIds: reqData.entityIds,
     });
 
     return NextResponse.json({ ticketId });
@@ -55,7 +49,6 @@ export async function POST(request: NextRequest, { params }: { params: { entityT
     if (error instanceof z.ZodError) {
       return NextResponse.json({ error: error.issues }, { status: 400 });
     }
-
     return NextResponse.json({ error: 'Failed to create download ticket' }, { status: 500 });
   }
 }

--- a/src/app/api/entity-download/presigned-url/route.ts
+++ b/src/app/api/entity-download/presigned-url/route.ts
@@ -1,21 +1,22 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { downloadAsset } from '@/api/entitycore/queries/assets';
+import { EntityTypeDict } from '@/api/entitycore/types';
 import { auth } from '@/auth';
 import { formatBytes } from '@/utils/format';
 import { log } from '@/utils/logger';
 
-import type { TEntityTypeDict } from '@/api/entitycore/types';
+const querySchema = z.object({
+  entityType: z.enum(EntityTypeDict),
+  entityId: z.uuid(),
+  virtualLabId: z.uuid(),
+  projectId: z.uuid(),
+  configAssetId: z.uuid(),
+  assetPath: z.string().min(1),
+});
 
 export async function GET(request: NextRequest) {
-  const query = request.nextUrl.searchParams;
-  const entityType = query.get('entityType')! as TEntityTypeDict;
-  const entityId = query.get('entityId')!;
-  const virtualLabId = query.get('virtualLabId')!;
-  const projectId = query.get('projectId')!;
-  const configAssetId = query.get('configAssetId')!;
-  const assetPath = query.get('assetPath')!;
-
   const session = await auth();
 
   if (!session) {
@@ -24,11 +25,18 @@ export async function GET(request: NextRequest) {
       statusText: 'The supplied authentication is not authorized for this action',
     });
   }
+
+  const parsed = querySchema.safeParse(Object.fromEntries(request.nextUrl.searchParams));
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues }, { status: 400 });
+  }
+  const { entityType, entityId, virtualLabId, projectId, configAssetId, assetPath } = parsed.data;
+
   try {
     const response = await downloadAsset({
       entityType,
-      entityId: entityId!,
-      id: configAssetId!,
+      entityId,
+      id: configAssetId,
       assetPath,
       asRawResponse: true,
       ctx: { virtualLabId, projectId },

--- a/src/features/entity-download/download-stream.ts
+++ b/src/features/entity-download/download-stream.ts
@@ -1,3 +1,7 @@
+import { pipeline, Readable } from 'node:stream';
+import { promisify } from 'node:util';
+import { createGzip } from 'node:zlib';
+
 import tar from 'tar-stream';
 
 import { getEntityFilesHandlerMap } from '@/features/entity-download/file-handlers';
@@ -8,10 +12,6 @@ import type {
   EntityBatchDownloadTicket,
 } from '@/features/entity-download/ticket-store';
 import type { FileEntry } from '@/features/entity-download/types';
-
-import { pipeline, Readable } from 'node:stream';
-import { promisify } from 'node:util';
-import { createGzip } from 'node:zlib';
 
 type CreateDownloadStreamParams =
   | Omit<EntityBatchDownloadTicket, 'createdAt'>

--- a/src/features/entity-download/download-stream.ts
+++ b/src/features/entity-download/download-stream.ts
@@ -1,38 +1,28 @@
 import tar from 'tar-stream';
 
 import { getEntityFilesHandlerMap } from '@/features/entity-download/file-handlers';
+import { getAssetFolderFiles } from '@/features/entity-download/file-handlers/asset-folder';
 
-import type { TEntityTypeDict } from '@/api/entitycore/types';
+import type {
+  AssetFolderDownloadTicket,
+  EntityBatchDownloadTicket,
+} from '@/features/entity-download/ticket-store';
+import type { FileEntry } from '@/features/entity-download/types';
 
 import { pipeline, Readable } from 'node:stream';
 import { promisify } from 'node:util';
 import { createGzip } from 'node:zlib';
 
-type CreateDownloadStreamParams = {
-  entityIds: string[];
-  entityType: TEntityTypeDict;
-  projectId?: string | null;
-  virtualLabId?: string | null;
-};
+type CreateDownloadStreamParams =
+  | Omit<EntityBatchDownloadTicket, 'createdAt'>
+  | Omit<AssetFolderDownloadTicket, 'createdAt'>;
 
 /**
- * Creates a download stream for a specific entity type with associated files.
+ * Creates a tar.gz download stream for either an entity-batch or an asset-folder ticket.
  *
- * @param {CreateDownloadStreamParams} params - Parameters for creating the download stream
- * @param {TEntityTypeDict} params.entityType - The type of entity being downloaded
- * @param {string} params.virtualLabId - The ID of the virtual lab
- * @param {string} params.projectId - The ID of the project
- * @param {string[]} params.entityIds - The IDs of the entities to download
- * @returns {ReadableStream} A web-compatible readable stream of compressed tar files
- * @throws {Error} If no handler is found for the specified entity type
+ * @throws {Error} If an entity-batch ticket has no handler for its entity type.
  */
-
-export async function createDownloadStream({
-  entityIds,
-  entityType,
-  projectId,
-  virtualLabId,
-}: CreateDownloadStreamParams) {
+export async function createDownloadStream(params: CreateDownloadStreamParams) {
   const tarPack = tar.pack();
   const gzip = createGzip({ level: 3 });
 
@@ -45,13 +35,7 @@ export async function createDownloadStream({
   // TODO: pass abort signal to getFilesGenerator
   // const { signal } = controller;
 
-  const getFilesGenerator = getEntityFilesHandlerMap[entityType];
-  if (!getFilesGenerator) {
-    throw new Error(`No handler found for entity type ${entityType}`);
-  }
-
-  const ctx = virtualLabId && projectId ? { virtualLabId, projectId } : undefined;
-  const fileEntries = getFilesGenerator(entityIds, ctx);
+  const fileEntries = getFileEntriesGenerator(params);
 
   (async () => {
     try {
@@ -69,4 +53,32 @@ export async function createDownloadStream({
 
   return downloadStream;
 }
+
+function getFileEntriesGenerator(params: CreateDownloadStreamParams): AsyncGenerator<FileEntry> {
+  if (params.kind === 'asset-folder') {
+    const ctx =
+      params.virtualLabId && params.projectId
+        ? { virtualLabId: params.virtualLabId, projectId: params.projectId }
+        : undefined;
+    return getAssetFolderFiles({
+      entityType: params.entityType,
+      entityId: params.entityId,
+      assetId: params.assetId,
+      prefix: params.prefix,
+      ctx,
+    });
+  }
+
+  const getFilesGenerator = getEntityFilesHandlerMap[params.entityType];
+  if (!getFilesGenerator) {
+    throw new Error(`No handler found for entity type ${params.entityType}`);
+  }
+
+  const ctx =
+    params.virtualLabId && params.projectId
+      ? { virtualLabId: params.virtualLabId, projectId: params.projectId }
+      : undefined;
+  return getFilesGenerator(params.entityIds, ctx);
+}
+
 const streamPipeline = promisify(pipeline);

--- a/src/features/entity-download/download-stream.ts
+++ b/src/features/entity-download/download-stream.ts
@@ -28,8 +28,7 @@ export async function createDownloadStream(params: CreateDownloadStreamParams) {
 
   tarPack.pipe(gzip);
 
-  // FIX: @pavlo, please remove type casting
-  const downloadStream = Readable.toWeb(gzip) as unknown as ReadableStream<Uint8Array>;
+  const downloadStream = Readable.toWeb(gzip) as ReadableStream<Uint8Array>;
 
   const controller = new AbortController();
   // TODO: pass abort signal to getFilesGenerator

--- a/src/features/entity-download/file-handlers/asset-folder.ts
+++ b/src/features/entity-download/file-handlers/asset-folder.ts
@@ -2,6 +2,7 @@ import { Readable } from 'node:stream';
 
 import { downloadAsset, listDirectoryOfAssets } from '@/api/entitycore/queries/assets';
 
+import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
 import type { TEntityTypeDict } from '@/api/entitycore/types';
 import type { FileEntry } from '@/features/entity-download/types';
 import type { WorkspaceContext } from '@/types/common';
@@ -75,8 +76,7 @@ export async function* getAssetFolderFiles({
 
     yield {
       path: relativePath,
-      // FIXME: align with createAssetFileEntry — remove cast once types are reconciled
-      stream: Readable.fromWeb(response.body as any),
+      stream: Readable.fromWeb(response.body as NodeReadableStream),
       size,
     };
   }

--- a/src/features/entity-download/file-handlers/asset-folder.ts
+++ b/src/features/entity-download/file-handlers/asset-folder.ts
@@ -6,6 +6,22 @@ import type { TEntityTypeDict } from '@/api/entitycore/types';
 import type { FileEntry } from '@/features/entity-download/types';
 import type { WorkspaceContext } from '@/types/common';
 
+/**
+ * Normalize a folder prefix so it can be used as a directory boundary with
+ * `String.prototype.startsWith` against an asset listing.
+ *
+ * Strips a leading `./` (SONATA manifest-relative form) and any leading `/`,
+ * trims trailing `/`, then appends exactly one `/`. An empty or root-only
+ * prefix returns `''`, which the caller treats as "match every file".
+ *
+ * @example
+ * normalizePrefix('')           // ''
+ * normalizePrefix('/')          // ''
+ * normalizePrefix('./')         // ''
+ * normalizePrefix('./mod')      // 'mod/'
+ * normalizePrefix('/mod/')      // 'mod/'
+ * normalizePrefix('mechanisms') // 'mechanisms/'
+ */
 function normalizePrefix(prefix: string): string {
   let p = prefix.replace(/^\.\//, '');
   p = p.replace(/^\/+/, '');

--- a/src/features/entity-download/file-handlers/asset-folder.ts
+++ b/src/features/entity-download/file-handlers/asset-folder.ts
@@ -1,10 +1,10 @@
+import { Readable } from 'node:stream';
+
 import { downloadAsset, listDirectoryOfAssets } from '@/api/entitycore/queries/assets';
 
 import type { TEntityTypeDict } from '@/api/entitycore/types';
 import type { FileEntry } from '@/features/entity-download/types';
 import type { WorkspaceContext } from '@/types/common';
-
-import { Readable } from 'node:stream';
 
 function normalizePrefix(prefix: string): string {
   let p = prefix.replace(/^\.\//, '');

--- a/src/features/entity-download/file-handlers/asset-folder.ts
+++ b/src/features/entity-download/file-handlers/asset-folder.ts
@@ -1,0 +1,67 @@
+import { downloadAsset, listDirectoryOfAssets } from '@/api/entitycore/queries/assets';
+
+import type { TEntityTypeDict } from '@/api/entitycore/types';
+import type { FileEntry } from '@/features/entity-download/types';
+import type { WorkspaceContext } from '@/types/common';
+
+import { Readable } from 'node:stream';
+
+function normalizePrefix(prefix: string): string {
+  let p = prefix.replace(/^\.\//, '');
+  p = p.replace(/^\/+/, '');
+  p = p.replace(/\/+$/, '');
+  return p.length > 0 ? `${p}/` : '';
+}
+
+/**
+ * Streams every file inside an asset directory whose path starts with `prefix`.
+ * Yields one FileEntry per file, with the path made relative to `prefix`.
+ */
+export async function* getAssetFolderFiles({
+  entityType,
+  entityId,
+  assetId,
+  prefix,
+  ctx,
+}: {
+  entityType: TEntityTypeDict;
+  entityId: string;
+  assetId: string;
+  prefix: string;
+  ctx?: WorkspaceContext;
+}): AsyncGenerator<FileEntry> {
+  const listing = await listDirectoryOfAssets({ entityType, entityId, id: assetId, ctx });
+  const normalized = normalizePrefix(prefix);
+
+  const matchingPaths = Object.keys(listing.files).filter((p) =>
+    normalized === '' ? true : p.startsWith(normalized)
+  );
+
+  for (const filePath of matchingPaths) {
+    const response = await downloadAsset({
+      ctx,
+      entityType,
+      entityId,
+      id: assetId,
+      assetPath: filePath,
+      asRawResponse: true,
+      retryOnError: false,
+    });
+
+    if (!response.body) continue;
+
+    const relativePath = normalized === '' ? filePath : filePath.slice(normalized.length);
+    const sizeHeader = Number(response.headers.get('content-length'));
+    const size =
+      Number.isFinite(sizeHeader) && sizeHeader > 0
+        ? sizeHeader
+        : (listing.files[filePath]?.size ?? 0);
+
+    yield {
+      path: relativePath,
+      // FIXME: align with createAssetFileEntry — remove cast once types are reconciled
+      stream: Readable.fromWeb(response.body as any),
+      size,
+    };
+  }
+}

--- a/src/features/entity-download/file-handlers/cell-morphology.ts
+++ b/src/features/entity-download/file-handlers/cell-morphology.ts
@@ -2,12 +2,13 @@ import { getCellMorphology } from '@/api/entitycore/queries';
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { ASSET_BASE_PATH } from '@/features/entity-download/constants';
 import { Metadata } from '@/features/entity-download/metadata';
-import type { ReconstructionMorphologyJsonMetadata } from '@/features/entity-download/types';
 import {
   createAssetFileEntry,
   createTemplateFileEntry,
   getMetadataCsvEntryBase,
 } from '@/features/entity-download/utils';
+
+import type { ReconstructionMorphologyJsonMetadata } from '@/features/entity-download/types';
 import type { WorkspaceContext } from '@/types/common';
 
 export async function* getCellMorphologyFiles(entityIds: string[], ctx?: WorkspaceContext) {

--- a/src/features/entity-download/file-handlers/circuit.ts
+++ b/src/features/entity-download/file-handlers/circuit.ts
@@ -1,5 +1,4 @@
 import { getCircuit } from '@/api/entitycore/queries/model/circuit';
-
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { ASSET_BASE_PATH } from '@/features/entity-download/constants';
 import { Metadata } from '@/features/entity-download/metadata';
@@ -8,10 +7,11 @@ import {
   createTemplateFileEntry,
   getMetadataCsvEntryBase,
 } from '@/features/entity-download/utils';
+
 import type { WorkspaceContext } from '@/types/common';
 
 export async function* getCircuitFiles(entityIds: string[], ctx?: WorkspaceContext) {
-  const metadata = new Metadata<Record<string, any>>();
+  const metadata = new Metadata<Record<string, unknown>>();
 
   try {
     yield await createTemplateFileEntry(EntityTypeDict.Circuit);

--- a/src/features/entity-download/file-handlers/electrical-cell-recording.ts
+++ b/src/features/entity-download/file-handlers/electrical-cell-recording.ts
@@ -2,12 +2,13 @@ import { getElectricalCellRecording } from '@/api/entitycore/queries';
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { ASSET_BASE_PATH } from '@/features/entity-download/constants';
 import { Metadata } from '@/features/entity-download/metadata';
-import type { ElectricalCellRecordingJsonMetadata } from '@/features/entity-download/types';
 import {
   createAssetFileEntry,
   createTemplateFileEntry,
   getMetadataCsvEntryBase,
 } from '@/features/entity-download/utils';
+
+import type { ElectricalCellRecordingJsonMetadata } from '@/features/entity-download/types';
 import type { WorkspaceContext } from '@/types/common';
 
 export async function* getElectricalCellRecordingFiles(

--- a/src/features/entity-download/file-handlers/em-cell-mesh.ts
+++ b/src/features/entity-download/file-handlers/em-cell-mesh.ts
@@ -2,12 +2,13 @@ import { getEmCellMesh } from '@/api/entitycore/queries/experimental/em-cell-mes
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { ASSET_BASE_PATH } from '@/features/entity-download/constants';
 import { Metadata } from '@/features/entity-download/metadata';
-import type { EMCellMeshJsonMetadata } from '@/features/entity-download/types';
 import {
   createAssetFileEntry,
   createTemplateFileEntry,
   getMetadataCsvEntryBase,
 } from '@/features/entity-download/utils';
+
+import type { EMCellMeshJsonMetadata } from '@/features/entity-download/types';
 import type { WorkspaceContext } from '@/types/common';
 
 export async function* getEMCellMeshFiles(entityIds: string[], ctx?: WorkspaceContext) {

--- a/src/features/entity-download/file-handlers/emodel.ts
+++ b/src/features/entity-download/file-handlers/emodel.ts
@@ -2,12 +2,13 @@ import { getCellMorphology, getEModel } from '@/api/entitycore/queries';
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { ASSET_BASE_PATH } from '@/features/entity-download/constants';
 import { Metadata } from '@/features/entity-download/metadata';
-import type { EmodelJsonMetadata } from '@/features/entity-download/types';
 import {
   createAssetFileEntry,
   createTemplateFileEntry,
   getMetadataCsvEntryBase,
 } from '@/features/entity-download/utils';
+
+import type { EmodelJsonMetadata } from '@/features/entity-download/types';
 import type { WorkspaceContext } from '@/types/common';
 
 export async function* getEmodelFiles(entityIds: string[], ctx?: WorkspaceContext) {

--- a/src/features/entity-download/file-handlers/experimental-bouton-density.ts
+++ b/src/features/entity-download/file-handlers/experimental-bouton-density.ts
@@ -1,8 +1,9 @@
 import { getExperimentalBoutonDensity } from '@/api/entitycore/queries';
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { Metadata } from '@/features/entity-download/metadata';
-import type { ExperimentalBoutonDensityJsonMetadata } from '@/features/entity-download/types';
 import { createTemplateFileEntry, getMetadataCsvEntryBase } from '@/features/entity-download/utils';
+
+import type { ExperimentalBoutonDensityJsonMetadata } from '@/features/entity-download/types';
 import type { WorkspaceContext } from '@/types/common';
 
 export async function* getExperimentalBoutonDensityFiles(

--- a/src/features/entity-download/file-handlers/experimental-neuron-density.ts
+++ b/src/features/entity-download/file-handlers/experimental-neuron-density.ts
@@ -1,8 +1,9 @@
 import { getExperimentalNeuronDensity } from '@/api/entitycore/queries';
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { Metadata } from '@/features/entity-download/metadata';
-import type { ExperimentalNeuronDensityJsonMetadata } from '@/features/entity-download/types';
 import { createTemplateFileEntry, getMetadataCsvEntryBase } from '@/features/entity-download/utils';
+
+import type { ExperimentalNeuronDensityJsonMetadata } from '@/features/entity-download/types';
 import type { WorkspaceContext } from '@/types/common';
 
 export async function* getExperimentalNeuronDensityFiles(

--- a/src/features/entity-download/file-handlers/experimental-synapses-per-connection.ts
+++ b/src/features/entity-download/file-handlers/experimental-synapses-per-connection.ts
@@ -1,8 +1,9 @@
 import { getExperimentalSynapsesPerConnection } from '@/api/entitycore/queries';
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { Metadata } from '@/features/entity-download/metadata';
-import type { ExperimentalSynapsesPerConnectionJsonMetadata } from '@/features/entity-download/types';
 import { createTemplateFileEntry, getMetadataCsvEntryBase } from '@/features/entity-download/utils';
+
+import type { ExperimentalSynapsesPerConnectionJsonMetadata } from '@/features/entity-download/types';
 import type { WorkspaceContext } from '@/types/common';
 
 export async function* getExperimentalSynapsesPerConnectionFiles(

--- a/src/features/entity-download/file-handlers/ion-channel-model.ts
+++ b/src/features/entity-download/file-handlers/ion-channel-model.ts
@@ -1,5 +1,4 @@
 import { getIonChannelModel } from '@/api/entitycore/queries/model/ion-channel-model';
-
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { AssetLabel } from '@/api/entitycore/types/shared/global';
 import { ASSET_BASE_PATH } from '@/features/entity-download/constants';
@@ -9,10 +8,11 @@ import {
   createTemplateFileEntry,
   getMetadataCsvEntryBase,
 } from '@/features/entity-download/utils';
+
 import type { WorkspaceContext } from '@/types/common';
 
 export async function* getIonChannelModelFiles(entityIds: string[], ctx?: WorkspaceContext) {
-  const metadata = new Metadata<Record<string, any>>();
+  const metadata = new Metadata<Record<string, unknown>>();
 
   try {
     yield await createTemplateFileEntry(EntityTypeDict.IonChannelModel);

--- a/src/features/entity-download/file-handlers/ion-channel-recording.ts
+++ b/src/features/entity-download/file-handlers/ion-channel-recording.ts
@@ -2,12 +2,13 @@ import { getIonChannelRecording } from '@/api/entitycore/queries';
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { ASSET_BASE_PATH } from '@/features/entity-download/constants';
 import { Metadata } from '@/features/entity-download/metadata';
-import type { IonChannelRecordingJsonMetadata } from '@/features/entity-download/types';
 import {
   createAssetFileEntry,
   createTemplateFileEntry,
   getMetadataCsvEntryBase,
 } from '@/features/entity-download/utils';
+
+import type { IonChannelRecordingJsonMetadata } from '@/features/entity-download/types';
 import type { WorkspaceContext } from '@/types/common';
 
 export async function* getIonChannelRecordingFiles(entityIds: string[], ctx?: WorkspaceContext) {

--- a/src/features/entity-download/file-handlers/memodel.ts
+++ b/src/features/entity-download/file-handlers/memodel.ts
@@ -2,12 +2,13 @@ import { getCellMorphology, getEModel, getMEModel } from '@/api/entitycore/queri
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { ASSET_BASE_PATH } from '@/features/entity-download/constants';
 import { Metadata } from '@/features/entity-download/metadata';
-import type { MemodelJsonMetadata } from '@/features/entity-download/types';
 import {
   createAssetFileEntry,
   createTemplateFileEntry,
   getMetadataCsvEntryBase,
 } from '@/features/entity-download/utils';
+
+import type { MemodelJsonMetadata } from '@/features/entity-download/types';
 import type { WorkspaceContext } from '@/types/common';
 
 export async function* getMEmodelFiles(entityIds: string[], ctx?: WorkspaceContext) {

--- a/src/features/entity-download/file-handlers/single-neuron-simulation.ts
+++ b/src/features/entity-download/file-handlers/single-neuron-simulation.ts
@@ -1,5 +1,4 @@
 import { getSingleNeuronSimulation } from '@/api/entitycore/queries';
-
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { ASSET_BASE_PATH } from '@/features/entity-download/constants';
 import { Metadata } from '@/features/entity-download/metadata';
@@ -8,10 +7,11 @@ import {
   createTemplateFileEntry,
   getMetadataCsvEntryBase,
 } from '@/features/entity-download/utils';
+
 import type { WorkspaceContext } from '@/types/common';
 
 export async function* getSingleNeuronSimulationFiles(entityIds: string[], ctx?: WorkspaceContext) {
-  const metadata = new Metadata<Record<string, any>>();
+  const metadata = new Metadata<Record<string, unknown>>();
 
   try {
     yield await createTemplateFileEntry(EntityTypeDict.SingleNeuronSimulation);

--- a/src/features/entity-download/file-handlers/single-neuron-synaptome-simulation.ts
+++ b/src/features/entity-download/file-handlers/single-neuron-synaptome-simulation.ts
@@ -1,5 +1,4 @@
 import { getSingleNeuronSynaptomeSimulation } from '@/api/entitycore/queries';
-
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { ASSET_BASE_PATH } from '@/features/entity-download/constants';
 import { Metadata } from '@/features/entity-download/metadata';
@@ -8,13 +7,14 @@ import {
   createTemplateFileEntry,
   getMetadataCsvEntryBase,
 } from '@/features/entity-download/utils';
+
 import type { WorkspaceContext } from '@/types/common';
 
 export async function* getSingleNeuronSynaptomeSimulationFiles(
   entityIds: string[],
   ctx?: WorkspaceContext
 ) {
-  const metadata = new Metadata<Record<string, any>>();
+  const metadata = new Metadata<Record<string, unknown>>();
 
   try {
     yield await createTemplateFileEntry(EntityTypeDict.SingleNeuronSimulation);

--- a/src/features/entity-download/file-handlers/single-neuron-synaptome.ts
+++ b/src/features/entity-download/file-handlers/single-neuron-synaptome.ts
@@ -3,12 +3,13 @@ import { getSingleNeuronSynaptome } from '@/api/entitycore/queries/model/single-
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { ASSET_BASE_PATH } from '@/features/entity-download/constants';
 import { Metadata } from '@/features/entity-download/metadata';
-import type { SingleNeuronSynaptomeJsonMetadata } from '@/features/entity-download/types';
 import {
   createAssetFileEntry,
   createTemplateFileEntry,
   getMetadataCsvEntryBase,
 } from '@/features/entity-download/utils';
+
+import type { SingleNeuronSynaptomeJsonMetadata } from '@/features/entity-download/types';
 import type { WorkspaceContext } from '@/types/common';
 
 export async function* getSingleNeuronSynaptomeFiles(entityIds: string[], ctx?: WorkspaceContext) {

--- a/src/features/entity-download/metadata.ts
+++ b/src/features/entity-download/metadata.ts
@@ -1,5 +1,6 @@
+import { Readable } from 'node:stream';
+
 import { format } from 'fast-csv';
-import { Readable } from 'stream';
 
 import { bufferStream } from '@/features/entity-download/utils';
 

--- a/src/features/entity-download/ticket-store.ts
+++ b/src/features/entity-download/ticket-store.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from 'crypto';
 
-import type { TEntityTypeDict } from '@/api/entitycore/types';
-import type { PartialBy } from '@/types/common';
 import { logError, logInfo } from '@/utils/logger';
 
-type DownloadTicket = {
+import type { TEntityTypeDict } from '@/api/entitycore/types';
+
+export type EntityBatchDownloadTicket = {
+  kind: 'entity-batch';
   entityType: TEntityTypeDict;
   virtualLabId?: string | null;
   projectId?: string | null;
@@ -12,7 +13,23 @@ type DownloadTicket = {
   createdAt: number;
 };
 
-type DownloadTicketRequest = PartialBy<DownloadTicket, 'createdAt'>;
+export type AssetFolderDownloadTicket = {
+  kind: 'asset-folder';
+  entityType: TEntityTypeDict;
+  entityId: string;
+  assetId: string;
+  prefix: string;
+  filename: string;
+  virtualLabId?: string | null;
+  projectId?: string | null;
+  createdAt: number;
+};
+
+export type DownloadTicket = EntityBatchDownloadTicket | AssetFolderDownloadTicket;
+
+type DownloadTicketRequest =
+  | Omit<EntityBatchDownloadTicket, 'createdAt'>
+  | Omit<AssetFolderDownloadTicket, 'createdAt'>;
 
 // Ticket expiration time in milliseconds (60 seconds)
 const TICKET_EXPIRATION_MS = 60 * 1000;
@@ -53,7 +70,7 @@ class TicketStore {
 
     // Generate a unique ticket ID
     const ticketId = randomUUID();
-    const newTicket = { ...ticket, createdAt: Date.now() };
+    const newTicket = { ...ticket, createdAt: Date.now() } as DownloadTicket;
     this.tickets.set(ticketId, newTicket);
 
     return ticketId;

--- a/src/features/entity-download/ticket-store.ts
+++ b/src/features/entity-download/ticket-store.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 import { logError, logInfo } from '@/utils/logger';
 

--- a/src/features/entity-download/ticket-store.ts
+++ b/src/features/entity-download/ticket-store.ts
@@ -70,7 +70,7 @@ class TicketStore {
 
     // Generate a unique ticket ID
     const ticketId = randomUUID();
-    const newTicket = { ...ticket, createdAt: Date.now() } as DownloadTicket;
+    const newTicket = { ...ticket, createdAt: Date.now() };
     this.tickets.set(ticketId, newTicket);
 
     return ticketId;

--- a/src/features/entity-download/types.ts
+++ b/src/features/entity-download/types.ts
@@ -1,4 +1,4 @@
-import type { Readable } from 'stream';
+import type { Readable } from 'node:stream';
 
 export type FileEntry = {
   path: string;

--- a/src/features/entity-download/types.ts
+++ b/src/features/entity-download/types.ts
@@ -26,45 +26,45 @@ export type CsvEntry = CsvEntryBase & {
 };
 
 export type ElectricalCellRecordingJsonMetadata = {
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 export type IonChannelRecordingJsonMetadata = {
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 export type EmodelJsonMetadata = {
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 export type ExperimentalBoutonDensityJsonMetadata = {
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 export type ExperimentalNeuronDensityJsonMetadata = {
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 export type ExperimentalSynapsesPerConnectionJsonMetadata = {
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 export type MemodelJsonMetadata = {
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 export type ReconstructionMorphologyJsonMetadata = {
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 export type SingleNeuronSynaptomeJsonMetadata = {
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 export type NotebookJsonMetadata = {
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 export type EMCellMeshJsonMetadata = {
-  [key: string]: any;
+  [key: string]: unknown;
 };

--- a/src/features/entity-download/utils.ts
+++ b/src/features/entity-download/utils.ts
@@ -10,6 +10,7 @@ import template from 'es-toolkit/compat/template';
 import { downloadAsset } from '@/api/entitycore/queries/assets';
 import { getSession } from '@/auth-fetch';
 
+import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
 import type { TEntityTypeDict } from '@/api/entitycore/types';
 import type { IEntity } from '@/api/entitycore/types/entities/entity';
 import type { IAsset } from '@/api/entitycore/types/shared/global';
@@ -98,8 +99,7 @@ export async function createAssetFileEntry({
   }
   return {
     path,
-    // FIXME: @pavlo, please remove type casting
-    stream: Readable.fromWeb(response.body as any),
+    stream: Readable.fromWeb(response.body as NodeReadableStream),
     size: Number(response.headers.get('content-length')),
   };
 }

--- a/src/features/entity-download/utils.ts
+++ b/src/features/entity-download/utils.ts
@@ -1,16 +1,18 @@
 import fs from 'node:fs/promises';
 import fsPath from 'node:path';
 import { Readable } from 'node:stream';
+
 import { format } from 'date-fns';
 import get from 'es-toolkit/compat/get';
 import kebabCase from 'es-toolkit/compat/kebabCase';
 import template from 'es-toolkit/compat/template';
 
 import { downloadAsset } from '@/api/entitycore/queries/assets';
+import { getSession } from '@/auth-fetch';
+
 import type { TEntityTypeDict } from '@/api/entitycore/types';
 import type { IEntity } from '@/api/entitycore/types/entities/entity';
 import type { IAsset } from '@/api/entitycore/types/shared/global';
-import { getSession } from '@/auth-fetch';
 import type {
   CsvEntryBase,
   CsvSimulationEntryBase,

--- a/src/ui/segments/explore/circuit/elements/download-panel/components-config.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/components-config.tsx
@@ -139,7 +139,7 @@ export default function ComponentsConfig({ circuit }: { circuit: ICircuit }) {
             description={electricalModelsContentConfiguration.description}
             mimeType={electricalModelsContentConfiguration.mimeType}
             entries={electricalEntries}
-            archiveBaseName={(e) => `${circuit.id}-${e.label || 'electrical-models'}`}
+            archiveBaseName={(e) => e.label || 'electrical-models'}
             emptyMessage="No electrical models directory in this circuit."
             downloadConfig={{
               entityId: circuit.id,
@@ -152,7 +152,7 @@ export default function ComponentsConfig({ circuit }: { circuit: ICircuit }) {
             description={mechanismsContentConfiguration.description}
             mimeType={mechanismsContentConfiguration.mimeType}
             entries={mechanismsEntry ? [mechanismsEntry] : []}
-            archiveBaseName={() => `${circuit.id}-mechanisms`}
+            archiveBaseName={() => 'mechanisms'}
             emptyMessage="No mechanisms directory in this circuit."
             downloadConfig={{
               entityId: circuit.id,

--- a/src/ui/segments/explore/circuit/elements/download-panel/components-config.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/components-config.tsx
@@ -1,0 +1,167 @@
+import { useQuery } from '@tanstack/react-query';
+import isString from 'es-toolkit/compat/isString';
+import { useSetAtom } from 'jotai';
+import { useParams } from 'next/navigation';
+import { useEffect } from 'react';
+import { match, P } from 'ts-pattern';
+
+import { AssetLabel } from '@/api/entitycore/types/shared/global';
+import { getAssetElement } from '@/api/entitycore/utils';
+import { NetworkConfigItem } from '@/ui/segments/explore/circuit/elements/download-panel/config-item';
+import {
+  configurationFilesContentConfiguration,
+  electricalModelsContentConfiguration,
+  mechanismsContentConfiguration,
+} from '@/ui/segments/explore/circuit/elements/download-panel/content-configuration';
+import { DownloadPanelError } from '@/ui/segments/explore/circuit/elements/download-panel/error';
+import { FolderConfigGroup } from '@/ui/segments/explore/circuit/elements/download-panel/folder-config-item';
+import {
+  buildConfigurationFiles,
+  buildElectricalModelsEntries,
+  buildMechanismsEntry,
+  resolveCircuitConfigAndDirectory,
+  updateFileCounterAtom,
+} from '@/ui/segments/explore/circuit/elements/download-panel/helpers';
+import { AssetDefaultPath } from '@/ui/segments/explore/circuit/elements/download-panel/network-morphology-config';
+import { SkeletonItem } from '@/ui/segments/explore/circuit/elements/download-panel/skeleton';
+import { keyBuilder } from '@/ui/use-query-keys/data';
+
+import type {
+  ICircuit,
+  ICircuitSonataConfiguration,
+} from '@/api/entitycore/types/entities/circuit';
+import type { WorkspaceContext } from '@/types/common';
+import type { TConfigChild } from '@/ui/segments/explore/circuit/elements/download-panel/config-item';
+
+export default function ComponentsConfig({ circuit }: { circuit: ICircuit }) {
+  const { virtualLabId, projectId } = useParams<WorkspaceContext>();
+
+  const updateFileCounter = useSetAtom(updateFileCounterAtom(circuit.id));
+  const configAsset = getAssetElement({
+    assets: circuit?.assets,
+    filter: (asset) => asset.label === AssetLabel.sonata_circuit,
+  });
+  const configAssetId = configAsset?.id ?? '';
+
+  const query = useQuery({
+    queryKey: keyBuilder.asset({
+      entityId: circuit.id,
+      assetId: configAssetId,
+      assetPath: AssetDefaultPath,
+      context: { virtualLabId, projectId },
+    }),
+    queryFn: () =>
+      resolveCircuitConfigAndDirectory<ICircuitSonataConfiguration>({
+        entityId: circuit.id,
+        assetId: configAssetId,
+        assetPath: AssetDefaultPath,
+        context: { virtualLabId, projectId },
+      }),
+    enabled: !!circuit && !!configAssetId,
+  });
+
+  const config = query.data?.config ?? null;
+  const directory = query.data?.directory ?? null;
+
+  const configurationFiles = config && directory ? buildConfigurationFiles(config, directory) : [];
+  const electricalEntries =
+    config && directory ? buildElectricalModelsEntries(config, directory) : [];
+  const mechanismsEntry = config && directory ? buildMechanismsEntry(config, directory) : null;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: stable updater
+  useEffect(() => {
+    updateFileCounter({
+      configuration_files: configurationFiles.filter((f) => f.size).length,
+      electrical_models: electricalEntries.reduce((acc, e) => acc + e.fileCount, 0),
+      mechanisms: mechanismsEntry?.fileCount ?? 0,
+    });
+  }, [
+    configurationFiles.length,
+    electricalEntries.length,
+    mechanismsEntry?.fileCount,
+    updateFileCounter,
+  ]);
+
+  return match(query)
+    .with({ isLoading: true }, () => (
+      <div className="flex flex-col gap-10">
+        <SkeletonItem itemsCount={3} />
+        <SkeletonItem className="opacity-75" itemsCount={2} />
+      </div>
+    ))
+    .with(
+      { data: { error: P.string.select('error') }, error: P.select('catchError') },
+      ({ error }) => {
+        let err = '';
+        if (isString(error)) err = error;
+        else if (error?.directory && error?.config)
+          err = 'Failed to load circuit configuration and directory assets';
+        else if (error?.directory) err = error.directory;
+        else if (error?.config) err = error.config;
+        return (
+          <DownloadPanelError
+            icon={null}
+            title="Circuit components"
+            description={err}
+            cls={{ container: 'text-white' }}
+          />
+        );
+      }
+    )
+    .with({ data: { directory: P.nonNullable, config: P.nonNullable } }, () => {
+      const configItems: TConfigChild[] = configurationFiles.map((f) => ({
+        asset: { path: f.path, name: f.title, size: f.size, last_modified: null },
+        title: f.title,
+        mimeType: f.path.split('.').pop() ?? 'json',
+        description: f.path,
+      }));
+
+      return (
+        <>
+          <NetworkConfigItem
+            key="configuration_files"
+            name={configurationFilesContentConfiguration.name}
+            description={configurationFilesContentConfiguration.description}
+            count={configItems.filter((i) => i.asset?.size).length}
+            mimeType={configurationFilesContentConfiguration.mimeType}
+            items={configItems}
+            showType={null}
+            showPrefix={null}
+            forceDownload
+            downloadConfig={{
+              entityId: circuit.id,
+              assetConfigId: configAsset?.id,
+              context: { virtualLabId, projectId },
+            }}
+          />
+          <FolderConfigGroup
+            name={electricalModelsContentConfiguration.name}
+            description={electricalModelsContentConfiguration.description}
+            mimeType={electricalModelsContentConfiguration.mimeType}
+            entries={electricalEntries}
+            archiveBaseName={(e) => `${circuit.id}-${e.label || 'electrical-models'}`}
+            emptyMessage="No electrical models directory in this circuit."
+            downloadConfig={{
+              entityId: circuit.id,
+              assetConfigId: configAssetId,
+              context: { virtualLabId, projectId },
+            }}
+          />
+          <FolderConfigGroup
+            name={mechanismsContentConfiguration.name}
+            description={mechanismsContentConfiguration.description}
+            mimeType={mechanismsContentConfiguration.mimeType}
+            entries={mechanismsEntry ? [mechanismsEntry] : []}
+            archiveBaseName={() => `${circuit.id}-mechanisms`}
+            emptyMessage="No mechanisms directory in this circuit."
+            downloadConfig={{
+              entityId: circuit.id,
+              assetConfigId: configAssetId,
+              context: { virtualLabId, projectId },
+            }}
+          />
+        </>
+      );
+    })
+    .otherwise(() => null);
+}

--- a/src/ui/segments/explore/circuit/elements/download-panel/components-config.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/components-config.tsx
@@ -9,9 +9,11 @@ import { AssetLabel } from '@/api/entitycore/types/shared/global';
 import { getAssetElement } from '@/api/entitycore/utils';
 import { NetworkConfigItem } from '@/ui/segments/explore/circuit/elements/download-panel/config-item';
 import {
-  configurationFilesContentConfiguration,
+  configurationFileContentConfiguration,
   electricalModelsContentConfiguration,
+  idMappingContentConfiguration,
   mechanismsContentConfiguration,
+  nodeSetsFileContentConfiguration,
 } from '@/ui/segments/explore/circuit/elements/download-panel/content-configuration';
 import { DownloadPanelError } from '@/ui/segments/explore/circuit/elements/download-panel/error';
 import { FolderConfigGroup } from '@/ui/segments/explore/circuit/elements/download-panel/folder-config-item';
@@ -31,7 +33,11 @@ import type {
   ICircuitSonataConfiguration,
 } from '@/api/entitycore/types/entities/circuit';
 import type { WorkspaceContext } from '@/types/common';
-import type { TConfigChild } from '@/ui/segments/explore/circuit/elements/download-panel/config-item';
+import type {
+  ConfigItemProps,
+  TConfigChild,
+} from '@/ui/segments/explore/circuit/elements/download-panel/config-item';
+import type { ConfigurationFileItem } from '@/ui/segments/explore/circuit/elements/download-panel/helpers';
 
 export default function ComponentsConfig({ circuit }: { circuit: ICircuit }) {
   const { virtualLabId, projectId } = useParams<WorkspaceContext>();
@@ -63,20 +69,27 @@ export default function ComponentsConfig({ circuit }: { circuit: ICircuit }) {
   const config = query.data?.config ?? null;
   const directory = query.data?.directory ?? null;
 
-  const configurationFiles = config && directory ? buildConfigurationFiles(config, directory) : [];
+  const configurationFiles =
+    config && directory ? buildConfigurationFiles(config, directory) : null;
   const electricalEntries =
     config && directory ? buildElectricalModelsEntries(config, directory) : [];
   const mechanismsEntry = config && directory ? buildMechanismsEntry(config, directory) : null;
 
+  const countItem = (item: ConfigurationFileItem | null) => (item?.size ? 1 : 0);
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: stable updater
   useEffect(() => {
     updateFileCounter({
-      configuration_files: configurationFiles.filter((f) => f.size).length,
+      configuration_file: countItem(configurationFiles?.circuitConfig ?? null),
+      node_sets_file: countItem(configurationFiles?.nodeSetsFile ?? null),
+      id_mapping: countItem(configurationFiles?.idMapping ?? null),
       electrical_models: electricalEntries.reduce((acc, e) => acc + e.fileCount, 0),
       mechanisms: mechanismsEntry?.fileCount ?? 0,
     });
   }, [
-    configurationFiles.length,
+    configurationFiles?.circuitConfig.size,
+    configurationFiles?.nodeSetsFile?.size,
+    configurationFiles?.idMapping?.size,
     electricalEntries.length,
     mechanismsEntry?.fileCount,
     updateFileCounter,
@@ -109,31 +122,57 @@ export default function ComponentsConfig({ circuit }: { circuit: ICircuit }) {
       }
     )
     .with({ data: { directory: P.nonNullable, config: P.nonNullable } }, () => {
-      const configItems: TConfigChild[] = configurationFiles.map((f) => ({
-        asset: { path: f.path, name: f.title, size: f.size, last_modified: null },
-        title: f.title,
-        mimeType: f.path.split('.').pop() ?? 'json',
-        description: f.path,
-      }));
+      const toConfigItem = (f: ConfigurationFileItem): TConfigChild => {
+        const filename = f.path.split('/').pop() || f.path;
+        const hasDirectory = filename !== f.path;
+        return {
+          asset: { path: f.path, name: filename, size: f.size, last_modified: null },
+          title: filename,
+          mimeType: f.path.split('.').pop() ?? 'json',
+          description: hasDirectory ? f.path : null,
+        };
+      };
+
+      const fileSections: Array<{
+        contentConfiguration: Pick<ConfigItemProps, 'key' | 'name' | 'description' | 'mimeType'>;
+        item: ConfigurationFileItem | null;
+      }> = [
+        {
+          contentConfiguration: configurationFileContentConfiguration,
+          item: configurationFiles?.circuitConfig ?? null,
+        },
+        {
+          contentConfiguration: nodeSetsFileContentConfiguration,
+          item: configurationFiles?.nodeSetsFile ?? null,
+        },
+        {
+          contentConfiguration: idMappingContentConfiguration,
+          item: configurationFiles?.idMapping ?? null,
+        },
+      ];
 
       return (
         <>
-          <NetworkConfigItem
-            key="configuration_files"
-            name={configurationFilesContentConfiguration.name}
-            description={configurationFilesContentConfiguration.description}
-            count={configItems.filter((i) => i.asset?.size).length}
-            mimeType={configurationFilesContentConfiguration.mimeType}
-            items={configItems}
-            showType={null}
-            showPrefix={null}
-            forceDownload
-            downloadConfig={{
-              entityId: circuit.id,
-              assetConfigId: configAsset?.id,
-              context: { virtualLabId, projectId },
-            }}
-          />
+          {fileSections.map(({ contentConfiguration, item }) =>
+            item ? (
+              <NetworkConfigItem
+                key={contentConfiguration.key}
+                name={contentConfiguration.name}
+                description={contentConfiguration.description}
+                count={item.size ? 1 : 0}
+                mimeType={contentConfiguration.mimeType}
+                items={[toConfigItem(item)]}
+                showType={null}
+                showPrefix={null}
+                forceDownload
+                downloadConfig={{
+                  entityId: circuit.id,
+                  assetConfigId: configAsset?.id,
+                  context: { virtualLabId, projectId },
+                }}
+              />
+            ) : null
+          )}
           <FolderConfigGroup
             name={electricalModelsContentConfiguration.name}
             description={electricalModelsContentConfiguration.description}

--- a/src/ui/segments/explore/circuit/elements/download-panel/config-item.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/config-item.tsx
@@ -187,8 +187,8 @@ export function NetworkConfigItem({
 
   return (
     <div className={classNames('w-full', className)}>
-      <div className="mb-6 flex flex-row justify-between">
-        <div className="flex flex-col">
+      <div className="mb-6 flex flex-row justify-between gap-x-6">
+        <div className="flex min-w-0 flex-1 flex-col">
           <div className="flex flex-row items-center text-xl font-bold tracking-wider text-white uppercase before:mr-2 before:block before:h-3 before:w-3 before:rounded-full before:bg-white before:content-['']">
             {name}
           </div>

--- a/src/ui/segments/explore/circuit/elements/download-panel/config-item.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/config-item.tsx
@@ -1,19 +1,20 @@
-import { kebabCase, get } from 'es-toolkit/compat';
-import { ReactNode } from 'react';
 import { Button } from 'antd';
+import { get, kebabCase } from 'es-toolkit/compat';
+import { saveAs } from 'file-saver';
 
-import { getEntityCorePresignedUrl } from '@/services/entity-download/pre-singed-url';
-import { renderEmptyOrValue } from '@/entity-configuration/definitions/renderer';
-import { useAppNotification } from '@/components/notification';
 import { EntityTypeDict } from '@/api/entitycore/types';
-import { DownloadIcon } from '@/components/icons';
-import { formatBytes } from '@/utils/format';
-import { classNames } from '@/util/utils';
 import { tryCatch } from '@/api/utils';
+import { DownloadIcon } from '@/components/icons';
+import { useAppNotification } from '@/components/notification';
+import { renderEmptyOrValue } from '@/entity-configuration/definitions/renderer';
+import { getEntityCorePresignedUrl } from '@/services/entity-download/pre-singed-url';
+import { classNames } from '@/util/utils';
+import { formatBytes } from '@/utils/format';
 import { log } from '@/utils/logger';
 
-import type { TCircuitContentConfigurationKeys } from '@/ui/segments/explore/circuit/elements/download-panel/content-configuration';
+import type { ReactNode } from 'react';
 import type { DirectoryItem } from '@/api/entitycore/types/shared/global';
+import type { TCircuitContentConfigurationKeys } from '@/ui/segments/explore/circuit/elements/download-panel/content-configuration';
 import type { Nullable } from '@/utils/type';
 
 export type TConfigChild = {
@@ -108,6 +109,13 @@ export type ConfigItemProps = {
   emptyMessage?: string | null;
   items: Array<TConfigChild>;
   className?: string;
+  // Presigned URLs point at S3 (cross-origin), so the browser ignores the
+  // `download` attribute and renders inline-friendly types (json, txt) in a
+  // new tab instead of saving them. When true, fetch the URL into a Blob and
+  // hand it to file-saver — Blob URLs are same-origin so `download` is
+  // honored. Leave false for large binaries (h5, etc.) to avoid buffering
+  // the whole file in memory.
+  forceDownload?: boolean;
   downloadConfig: {
     entityId: string | undefined;
     assetConfigId: string | undefined;
@@ -128,6 +136,7 @@ export function NetworkConfigItem({
   mimeType,
   items,
   className,
+  forceDownload = false,
   downloadConfig,
 }: ConfigItemProps) {
   const notify = useAppNotification();
@@ -144,7 +153,27 @@ export function NetworkConfigItem({
       })
     );
     if (data) {
-      window.open(data.url, '_blank', 'noopener,noreferrer');
+      if (forceDownload) {
+        const filename = path.split('/').filter(Boolean).pop() || path;
+        const { data: blob, error: fetchError } = await tryCatch(
+          fetch(data.url).then((r) => r.blob())
+        );
+        if (blob) saveAs(blob, filename);
+        if (fetchError) {
+          log('error', 'Error downloading file:', fetchError);
+          notify.error({
+            message: 'Download Error',
+            description: get(
+              fetchError,
+              'message',
+              'An error occurred while downloading the file.'
+            ),
+            placement: 'topRight',
+          });
+        }
+      } else {
+        window.open(data.url, '_blank', 'noopener,noreferrer');
+      }
     }
     if (error) {
       log('error', 'Error downloading entire circuit:', error);

--- a/src/ui/segments/explore/circuit/elements/download-panel/content-configuration.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/content-configuration.tsx
@@ -30,7 +30,7 @@ export const connectivityMetricsContentConfiguration: CircuitContentConfiguratio
         rel="noopener noreferrer"
         className="underline underline-offset-2"
       >
-        See more here
+        Documentation
       </a>
       .
     </p>
@@ -50,7 +50,7 @@ export const morphologiesContentConfiguration: CircuitContentConfigurationProps 
         rel="noopener noreferrer"
         className="underline underline-offset-2"
       >
-        See more here
+        Documentation
       </a>
       .
     </p>
@@ -70,7 +70,7 @@ export const configurationFileContentConfiguration: CircuitContentConfigurationP
         rel="noopener noreferrer"
         className="underline underline-offset-2"
       >
-        See more here
+        Documentation
       </a>
       .
     </p>
@@ -90,7 +90,7 @@ export const nodeSetsFileContentConfiguration: CircuitContentConfigurationProps 
         rel="noopener noreferrer"
         className="underline underline-offset-2"
       >
-        See more here
+        Documentation
       </a>
       .
     </p>
@@ -121,7 +121,7 @@ export const electricalModelsContentConfiguration: CircuitContentConfigurationPr
         rel="noopener noreferrer"
         className="underline underline-offset-2"
       >
-        See more here
+        Documentation
       </a>
       .
     </p>
@@ -141,7 +141,7 @@ export const mechanismsContentConfiguration: CircuitContentConfigurationProps = 
         rel="noopener noreferrer"
         className="underline underline-offset-2"
       >
-        See more here
+        Documentation
       </a>
       .
     </p>
@@ -157,12 +157,21 @@ export const networksContentConfiguration: CircuitContentConfigurationProps[] = 
       <p className="text-primary-1 w-3/4 text-base font-light">
         Files containing information on the population of neurons in the circuit.{' '}
         <a
-          href="https://sonata-extension.readthedocs.io/en/latest/sonata_population.html"
+          href="https://sonata-extension.readthedocs.io/en/latest/sonata_population.html#nodes"
           target="_blank"
           rel="noopener noreferrer"
           className="underline underline-offset-2"
         >
-          See more here
+          Documentation
+        </a>
+        ,{' '}
+        <a
+          href="https://sonata-extension.readthedocs.io/en/latest/sonata_tech.html"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-2"
+        >
+          Technical Description
         </a>
         .
       </p>
@@ -176,12 +185,21 @@ export const networksContentConfiguration: CircuitContentConfigurationProps[] = 
       <p className="text-primary-1 w-3/4 text-base font-light">
         Files containing information on the connections between neurons in the circuit.{' '}
         <a
-          href="https://sonata-extension.readthedocs.io/en/latest/sonata_population.html"
+          href="https://sonata-extension.readthedocs.io/en/latest/sonata_population.html#edges"
           target="_blank"
           rel="noopener noreferrer"
           className="underline underline-offset-2"
         >
-          See more here
+          Documentation
+        </a>
+        ,{' '}
+        <a
+          href="https://sonata-extension.readthedocs.io/en/latest/sonata_tech.html"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-2"
+        >
+          Technical Description
         </a>
         .
       </p>

--- a/src/ui/segments/explore/circuit/elements/download-panel/content-configuration.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/content-configuration.tsx
@@ -5,7 +5,9 @@ export type TCircuitContentConfigurationKeys =
   | 'nodes'
   | 'edges'
   | 'morphologies'
-  | 'configuration_files'
+  | 'configuration_file'
+  | 'node_sets_file'
+  | 'id_mapping'
   | 'electrical_models'
   | 'mechanisms';
 
@@ -56,12 +58,52 @@ export const morphologiesContentConfiguration: CircuitContentConfigurationProps 
   mimeType: 'h5',
 };
 
-export const configurationFilesContentConfiguration: CircuitContentConfigurationProps = {
-  key: 'configuration_files',
-  name: 'Configuration files',
+export const configurationFileContentConfiguration: CircuitContentConfigurationProps = {
+  key: 'configuration_file',
+  name: 'Configuration file',
   description: (
     <p className="text-primary-1 w-3/4 text-base font-light">
-      The SONATA circuit config, node sets file, and id mapping file.
+      SONATA circuit config JSON file.{' '}
+      <a
+        href="https://github.com/AllenInstitute/sonata/blob/master/docs/SONATA_DEVELOPER_GUIDE.md#tying-it-all-together---the-networkcircuit-config-file"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline underline-offset-2"
+      >
+        See more here
+      </a>
+      .
+    </p>
+  ),
+  mimeType: 'json',
+};
+
+export const nodeSetsFileContentConfiguration: CircuitContentConfigurationProps = {
+  key: 'node_sets_file',
+  name: 'Node sets file',
+  description: (
+    <p className="text-primary-1 w-3/4 text-base font-light">
+      SONATA node sets JSON file.{' '}
+      <a
+        href="https://github.com/AllenInstitute/sonata/blob/master/docs/SONATA_DEVELOPER_GUIDE.md#node-sets-file"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline underline-offset-2"
+      >
+        See more here
+      </a>
+      .
+    </p>
+  ),
+  mimeType: 'json',
+};
+
+export const idMappingContentConfiguration: CircuitContentConfigurationProps = {
+  key: 'id_mapping',
+  name: 'ID mapping',
+  description: (
+    <p className="text-primary-1 w-3/4 text-base font-light">
+      ID mapping JSON file for extracted sub-circuits, containing the original neuron IDs.
     </p>
   ),
   mimeType: 'json',
@@ -72,7 +114,7 @@ export const electricalModelsContentConfiguration: CircuitContentConfigurationPr
   name: 'Electrical models',
   description: (
     <p className="text-primary-1 w-3/4 text-base font-light">
-      Neuron electrical model templates (.hoc files), packaged as one archive per directory.
+      Electrical neuron model templates (.hoc files), packaged as one archive per directory.
     </p>
   ),
   mimeType: 'tar.gz',
@@ -83,7 +125,7 @@ export const mechanismsContentConfiguration: CircuitContentConfigurationProps = 
   name: 'Mechanisms',
   description: (
     <p className="text-primary-1 w-3/4 text-base font-light">
-      NEURON mechanism source files (.mod), packaged as a single archive.
+      Biophysical mechanism files (.mod), packaged as a single archive.
     </p>
   ),
   mimeType: 'tar.gz',

--- a/src/ui/segments/explore/circuit/elements/download-panel/content-configuration.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/content-configuration.tsx
@@ -65,7 +65,7 @@ export const configurationFileContentConfiguration: CircuitContentConfigurationP
     <p className="text-primary-1 w-3/4 text-base font-light">
       SONATA circuit config JSON file.{' '}
       <a
-        href="https://github.com/AllenInstitute/sonata/blob/master/docs/SONATA_DEVELOPER_GUIDE.md#tying-it-all-together---the-networkcircuit-config-file"
+        href="https://sonata-extension.readthedocs.io/en/latest/sonata_config.html"
         target="_blank"
         rel="noopener noreferrer"
         className="underline underline-offset-2"
@@ -85,7 +85,7 @@ export const nodeSetsFileContentConfiguration: CircuitContentConfigurationProps 
     <p className="text-primary-1 w-3/4 text-base font-light">
       SONATA node sets JSON file.{' '}
       <a
-        href="https://github.com/AllenInstitute/sonata/blob/master/docs/SONATA_DEVELOPER_GUIDE.md#node-sets-file"
+        href="https://sonata-extension.readthedocs.io/en/latest/sonata_nodeset.html"
         target="_blank"
         rel="noopener noreferrer"
         className="underline underline-offset-2"
@@ -114,7 +114,16 @@ export const electricalModelsContentConfiguration: CircuitContentConfigurationPr
   name: 'Electrical models',
   description: (
     <p className="text-primary-1 w-3/4 text-base font-light">
-      Electrical neuron model templates (.hoc files), packaged as one archive per directory.
+      Electrical neuron model templates (.hoc files), packaged as one archive per directory.{' '}
+      <a
+        href="https://sonata-extension.readthedocs.io/en/latest/hoc-emodel.html"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline underline-offset-2"
+      >
+        See more here
+      </a>
+      .
     </p>
   ),
   mimeType: 'tar.gz',
@@ -125,7 +134,16 @@ export const mechanismsContentConfiguration: CircuitContentConfigurationProps = 
   name: 'Mechanisms',
   description: (
     <p className="text-primary-1 w-3/4 text-base font-light">
-      Biophysical mechanism files (.mod), packaged as a single archive.
+      Biophysical mechanism files (.mod), packaged as a single archive.{' '}
+      <a
+        href="https://sonata-extension.readthedocs.io/en/latest/mod_files.html"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline underline-offset-2"
+      >
+        See more here
+      </a>
+      .
     </p>
   ),
   mimeType: 'tar.gz',
@@ -139,7 +157,7 @@ export const networksContentConfiguration: CircuitContentConfigurationProps[] = 
       <p className="text-primary-1 w-3/4 text-base font-light">
         Files containing information on the population of neurons in the circuit.{' '}
         <a
-          href="https://github.com/AllenInstitute/sonata/blob/master/docs/SONATA_DEVELOPER_GUIDE.md#neuron_networks_nodes"
+          href="https://sonata-extension.readthedocs.io/en/latest/sonata_population.html"
           target="_blank"
           rel="noopener noreferrer"
           className="underline underline-offset-2"
@@ -158,7 +176,7 @@ export const networksContentConfiguration: CircuitContentConfigurationProps[] = 
       <p className="text-primary-1 w-3/4 text-base font-light">
         Files containing information on the connections between neurons in the circuit.{' '}
         <a
-          href="https://github.com/AllenInstitute/sonata/blob/master/docs/SONATA_DEVELOPER_GUIDE.md#neuron_networks_edges"
+          href="https://sonata-extension.readthedocs.io/en/latest/sonata_population.html"
           target="_blank"
           rel="noopener noreferrer"
           className="underline underline-offset-2"

--- a/src/ui/segments/explore/circuit/elements/download-panel/content-configuration.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/content-configuration.tsx
@@ -4,7 +4,10 @@ export type TCircuitContentConfigurationKeys =
   | 'connectivity_metrics'
   | 'nodes'
   | 'edges'
-  | 'morphologies';
+  | 'morphologies'
+  | 'configuration_files'
+  | 'electrical_models'
+  | 'mechanisms';
 
 type CircuitContentConfigurationProps = {
   key: TCircuitContentConfigurationKeys;
@@ -51,6 +54,39 @@ export const morphologiesContentConfiguration: CircuitContentConfigurationProps 
     </p>
   ),
   mimeType: 'h5',
+};
+
+export const configurationFilesContentConfiguration: CircuitContentConfigurationProps = {
+  key: 'configuration_files',
+  name: 'Configuration files',
+  description: (
+    <p className="text-primary-1 w-3/4 text-base font-light">
+      The SONATA circuit config, node sets file, and id mapping file.
+    </p>
+  ),
+  mimeType: 'json',
+};
+
+export const electricalModelsContentConfiguration: CircuitContentConfigurationProps = {
+  key: 'electrical_models',
+  name: 'Electrical models',
+  description: (
+    <p className="text-primary-1 w-3/4 text-base font-light">
+      Neuron electrical model templates (.hoc files), packaged as one archive per directory.
+    </p>
+  ),
+  mimeType: 'tar.gz',
+};
+
+export const mechanismsContentConfiguration: CircuitContentConfigurationProps = {
+  key: 'mechanisms',
+  name: 'Mechanisms',
+  description: (
+    <p className="text-primary-1 w-3/4 text-base font-light">
+      NEURON mechanism source files (.mod), packaged as a single archive.
+    </p>
+  ),
+  mimeType: 'tar.gz',
 };
 
 export const networksContentConfiguration: CircuitContentConfigurationProps[] = [

--- a/src/ui/segments/explore/circuit/elements/download-panel/content-configuration.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/content-configuration.tsx
@@ -166,7 +166,7 @@ export const networksContentConfiguration: CircuitContentConfigurationProps[] = 
         </a>
         ,{' '}
         <a
-          href="https://sonata-extension.readthedocs.io/en/latest/sonata_tech.html"
+          href="https://sonata-extension.readthedocs.io/en/latest/sonata_tech.html#node-file"
           target="_blank"
           rel="noopener noreferrer"
           className="underline underline-offset-2"
@@ -194,7 +194,7 @@ export const networksContentConfiguration: CircuitContentConfigurationProps[] = 
         </a>
         ,{' '}
         <a
-          href="https://sonata-extension.readthedocs.io/en/latest/sonata_tech.html"
+          href="https://sonata-extension.readthedocs.io/en/latest/sonata_tech.html#edge-file"
           target="_blank"
           rel="noopener noreferrer"
           className="underline underline-offset-2"

--- a/src/ui/segments/explore/circuit/elements/download-panel/entire-circuit-export.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/entire-circuit-export.tsx
@@ -72,6 +72,7 @@ export default function EntireCircuitExport({ circuit }: Props) {
             >
               See more here
             </a>
+            .
           </p>
         </div>
         <div className="text-primary-1 flex flex-row items-center gap-x-3 font-semibold">

--- a/src/ui/segments/explore/circuit/elements/download-panel/entire-circuit-export.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/entire-circuit-export.tsx
@@ -65,7 +65,7 @@ export default function EntireCircuitExport({ circuit }: Props) {
           <p className="text-primary-2 text-sm leading-normal font-light hyphens-auto">
             The complete circuit compressed in SONATA format.{' '}
             <a
-              href="https://sonata-extension.readthedocs.io/en/latest/"
+              href="https://sonata-extension.readthedocs.io/en/latest/sonata_overview.html"
               target="_blank"
               rel="noopener noreferrer"
               className="underline underline-offset-2"

--- a/src/ui/segments/explore/circuit/elements/download-panel/entire-circuit-export.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/entire-circuit-export.tsx
@@ -1,15 +1,15 @@
-import { useParams } from 'next/navigation';
-import { get } from 'es-toolkit/compat';
 import { Button } from 'antd';
+import { get } from 'es-toolkit/compat';
+import { useParams } from 'next/navigation';
 
-import { getEntityCorePresignedUrl } from '@/services/entity-download/pre-singed-url';
-import { AssetLabel } from '@/api/entitycore/types/shared/global';
-import { useAppNotification } from '@/components/notification';
-import { getAssetElement } from '@/api/entitycore/utils';
 import { EntityTypeDict } from '@/api/entitycore/types';
-import { DownloadIcon } from '@/components/icons';
-import { formatBytes } from '@/utils/format';
+import { AssetLabel } from '@/api/entitycore/types/shared/global';
+import { getAssetElement } from '@/api/entitycore/utils';
 import { tryCatch } from '@/api/utils';
+import { DownloadIcon } from '@/components/icons';
+import { useAppNotification } from '@/components/notification';
+import { getEntityCorePresignedUrl } from '@/services/entity-download/pre-singed-url';
+import { formatBytes } from '@/utils/format';
 import { log } from '@/utils/logger';
 
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
@@ -63,7 +63,7 @@ export default function EntireCircuitExport({ circuit }: Props) {
             Download full circuit
           </div>
           <p className="text-primary-2 text-sm leading-normal font-light hyphens-auto">
-            The complete circuit compressed in SONATA format,
+            The complete circuit compressed in SONATA format,{' '}
             <a
               href="https://sonata-extension.readthedocs.io/en/latest/"
               target="_blank"
@@ -74,7 +74,7 @@ export default function EntireCircuitExport({ circuit }: Props) {
             </a>
           </p>
         </div>
-        <div className="text-primary-1 flex flex-row gap-x-3 font-semibold">
+        <div className="text-primary-1 flex flex-row items-center gap-x-3 font-semibold">
           <div>{totalSize}</div>
           <div>{extension}</div>
           <Button

--- a/src/ui/segments/explore/circuit/elements/download-panel/entire-circuit-export.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/entire-circuit-export.tsx
@@ -63,14 +63,14 @@ export default function EntireCircuitExport({ circuit }: Props) {
             Download full circuit
           </div>
           <p className="text-primary-2 text-sm leading-normal font-light hyphens-auto">
-            The complete circuit compressed in SONATA format,{' '}
+            The complete circuit compressed in SONATA format.{' '}
             <a
               href="https://sonata-extension.readthedocs.io/en/latest/"
               target="_blank"
               rel="noopener noreferrer"
               className="underline underline-offset-2"
             >
-              see more here
+              See more here
             </a>
           </p>
         </div>

--- a/src/ui/segments/explore/circuit/elements/download-panel/entire-circuit-export.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/entire-circuit-export.tsx
@@ -70,7 +70,7 @@ export default function EntireCircuitExport({ circuit }: Props) {
               rel="noopener noreferrer"
               className="underline underline-offset-2"
             >
-              See more here
+              Documentation
             </a>
             .
           </p>

--- a/src/ui/segments/explore/circuit/elements/download-panel/folder-config-item.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/folder-config-item.tsx
@@ -1,0 +1,162 @@
+import { Button, Tooltip } from 'antd';
+import { get } from 'es-toolkit/compat';
+
+import {
+  createAssetFolderDownloadTicket,
+  getAssetFolderDownloadUrl,
+} from '@/api/entity-download/asset-folder';
+import { EntityTypeDict } from '@/api/entitycore/types';
+import { tryCatch } from '@/api/utils';
+import { DownloadIcon } from '@/components/icons';
+import { useAppNotification } from '@/components/notification';
+import { renderEmptyOrValue } from '@/entity-configuration/definitions/renderer';
+import { classNames } from '@/util/utils';
+import { formatBytes } from '@/utils/format';
+import { log } from '@/utils/logger';
+
+import type { ReactNode } from 'react';
+import type { FolderEntry } from '@/ui/segments/explore/circuit/elements/download-panel/helpers';
+
+export type FolderDownloadConfig = {
+  entityId: string;
+  assetConfigId: string;
+  context: { virtualLabId: string; projectId: string };
+};
+
+type FolderGroupItemProps = {
+  entry: FolderEntry;
+  archiveBaseName: string;
+  mimeType: string;
+  downloadConfig: FolderDownloadConfig;
+};
+
+function FolderRow({ entry, archiveBaseName, mimeType, downloadConfig }: FolderGroupItemProps) {
+  const notify = useAppNotification();
+  const disabled = entry.fileCount === 0;
+
+  const onClick = async () => {
+    const { entityId, assetConfigId, context } = downloadConfig;
+    const filename = `${archiveBaseName}.tar.gz`;
+    const { data, error } = await tryCatch(
+      createAssetFolderDownloadTicket({
+        entityType: EntityTypeDict.Circuit,
+        entityId,
+        assetId: assetConfigId,
+        prefix: entry.prefix,
+        filename,
+        virtualLabId: context.virtualLabId,
+        projectId: context.projectId,
+      })
+    );
+    if (data) {
+      window.open(getAssetFolderDownloadUrl(data.ticketId), '_blank', 'noopener,noreferrer');
+    }
+    if (error) {
+      log('error', 'Error downloading folder archive:', error);
+      notify.error({
+        message: 'Download Error',
+        description: get(error, 'message', 'An error occurred while preparing the folder archive.'),
+        placement: 'topRight',
+      });
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col">
+      <div className="flex w-full flex-row items-center justify-between gap-y-10">
+        <div className="w-2/3 hyphens-auto">
+          <div className="line-clamp-2 text-lg font-bold text-white">{entry.label}</div>
+          {entry.prefix !== entry.label && (
+            <div className="text-primary-2 text-sm font-light">{entry.prefix}</div>
+          )}
+        </div>
+        <div
+          className={classNames(
+            'flex flex-row items-center gap-x-3 font-light',
+            disabled ? 'text-gray-400' : 'text-primary-2'
+          )}
+        >
+          <Tooltip title="Uncompressed total. The downloaded .tar.gz archive will be smaller.">
+            <div className="cursor-help">
+              {entry.totalSize ? `~${formatBytes(entry.totalSize)}` : renderEmptyOrValue(null)}
+            </div>
+          </Tooltip>
+          <div>{renderEmptyOrValue(mimeType)}</div>
+          <Button
+            onClick={onClick}
+            type="text"
+            htmlType="button"
+            disabled={disabled}
+            className={classNames(
+              'flex items-center justify-center rounded-none border border-solid',
+              'hover:text-primary-6!',
+              disabled
+                ? 'pointer-events-none cursor-not-allowed border-gray-300 bg-transparent text-gray-400!'
+                : 'border-primary-6 text-white'
+            )}
+            aria-label={`Download ${entry.label}`}
+            title={`Download ${entry.label}`}
+            icon={<DownloadIcon className="text-current!" />}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type FolderConfigGroupProps = {
+  name: string;
+  description: ReactNode;
+  mimeType: string;
+  entries: FolderEntry[];
+  archiveBaseName: (entry: FolderEntry) => string;
+  emptyMessage?: string;
+  downloadConfig: FolderDownloadConfig;
+};
+
+export function FolderConfigGroup({
+  name,
+  description,
+  mimeType,
+  entries,
+  archiveBaseName,
+  emptyMessage,
+  downloadConfig,
+}: FolderConfigGroupProps) {
+  const totalFiles = entries.reduce((acc, e) => acc + e.fileCount, 0);
+  return (
+    <div className="w-full">
+      <div className="mb-6 flex flex-row justify-between">
+        <div className="flex flex-col">
+          <div className="flex flex-row items-center text-xl font-bold tracking-wider text-white uppercase before:mr-2 before:block before:h-3 before:w-3 before:rounded-full before:bg-white before:content-['']">
+            {name}
+          </div>
+          {description}
+        </div>
+        <div className="text-primary-1 flex flex-row flex-nowrap gap-x-3 text-base font-bold">
+          <div className="whitespace-nowrap">
+            {totalFiles} File{totalFiles === 1 ? '' : 's'}
+          </div>
+          <div>{mimeType}</div>
+        </div>
+      </div>
+      <div className="border-primary-7 flex flex-col gap-y-6 border-l border-solid pl-8">
+        {entries.length === 0 ? (
+          <div className="text-primary-4 w-full p-8 text-base font-light">
+            {emptyMessage ?? 'No files available for this type.'}
+          </div>
+        ) : (
+          entries.map((entry) => (
+            <FolderRow
+              key={entry.prefix}
+              entry={entry}
+              archiveBaseName={archiveBaseName(entry)}
+              mimeType={mimeType}
+              downloadConfig={downloadConfig}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/segments/explore/circuit/elements/download-panel/folder-config-item.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/folder-config-item.tsx
@@ -64,10 +64,10 @@ function FolderRow({ entry, archiveBaseName, mimeType, downloadConfig }: FolderR
   return (
     <div className="flex w-full flex-row items-center justify-between gap-y-10">
       <div className="w-2/3 hyphens-auto">
-        <div className="line-clamp-2 text-lg font-bold text-white">{entry.label}</div>
-        {entry.prefix !== entry.label && (
-          <div className="text-primary-2 text-sm font-light">{entry.prefix}</div>
-        )}
+        <div className="line-clamp-2 text-lg font-bold text-white">
+          {entry.label}.{mimeType}
+        </div>
+        <div className="text-primary-2 text-sm font-light">{entry.prefix}</div>
       </div>
       <div
         className={classNames(
@@ -124,8 +124,8 @@ export function FolderConfigGroup({
   const totalFiles = entries.reduce((acc, e) => acc + e.fileCount, 0);
   return (
     <div className="w-full">
-      <div className="mb-6 flex flex-row justify-between">
-        <div className="flex flex-col">
+      <div className="mb-6 flex flex-row justify-between gap-x-6">
+        <div className="flex min-w-0 flex-1 flex-col">
           <div className="flex flex-row items-center text-xl font-bold tracking-wider text-white uppercase before:mr-2 before:block before:h-3 before:w-3 before:rounded-full before:bg-white before:content-['']">
             {name}
           </div>

--- a/src/ui/segments/explore/circuit/elements/download-panel/folder-config-item.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/folder-config-item.tsx
@@ -23,14 +23,14 @@ export type FolderDownloadConfig = {
   context: { virtualLabId: string; projectId: string };
 };
 
-type FolderGroupItemProps = {
+type FolderRowProps = {
   entry: FolderEntry;
   archiveBaseName: string;
   mimeType: string;
   downloadConfig: FolderDownloadConfig;
 };
 
-function FolderRow({ entry, archiveBaseName, mimeType, downloadConfig }: FolderGroupItemProps) {
+function FolderRow({ entry, archiveBaseName, mimeType, downloadConfig }: FolderRowProps) {
   const notify = useAppNotification();
   const disabled = entry.fileCount === 0;
 
@@ -62,43 +62,41 @@ function FolderRow({ entry, archiveBaseName, mimeType, downloadConfig }: FolderG
   };
 
   return (
-    <div className="flex w-full flex-col">
-      <div className="flex w-full flex-row items-center justify-between gap-y-10">
-        <div className="w-2/3 hyphens-auto">
-          <div className="line-clamp-2 text-lg font-bold text-white">{entry.label}</div>
-          {entry.prefix !== entry.label && (
-            <div className="text-primary-2 text-sm font-light">{entry.prefix}</div>
-          )}
-        </div>
-        <div
+    <div className="flex w-full flex-row items-center justify-between gap-y-10">
+      <div className="w-2/3 hyphens-auto">
+        <div className="line-clamp-2 text-lg font-bold text-white">{entry.label}</div>
+        {entry.prefix !== entry.label && (
+          <div className="text-primary-2 text-sm font-light">{entry.prefix}</div>
+        )}
+      </div>
+      <div
+        className={classNames(
+          'flex flex-row items-center gap-x-3 font-light',
+          disabled ? 'text-gray-400' : 'text-primary-2'
+        )}
+      >
+        <Tooltip title="Uncompressed total. The downloaded .tar.gz archive will be smaller.">
+          <div className="cursor-help">
+            {entry.totalSize ? `~${formatBytes(entry.totalSize)}` : renderEmptyOrValue(null)}
+          </div>
+        </Tooltip>
+        <div>{renderEmptyOrValue(mimeType)}</div>
+        <Button
+          onClick={onClick}
+          type="text"
+          htmlType="button"
+          disabled={disabled}
           className={classNames(
-            'flex flex-row items-center gap-x-3 font-light',
-            disabled ? 'text-gray-400' : 'text-primary-2'
+            'flex items-center justify-center rounded-none border border-solid',
+            'hover:text-primary-6!',
+            disabled
+              ? 'pointer-events-none cursor-not-allowed border-gray-300 bg-transparent text-gray-400!'
+              : 'border-primary-6 text-white'
           )}
-        >
-          <Tooltip title="Uncompressed total. The downloaded .tar.gz archive will be smaller.">
-            <div className="cursor-help">
-              {entry.totalSize ? `~${formatBytes(entry.totalSize)}` : renderEmptyOrValue(null)}
-            </div>
-          </Tooltip>
-          <div>{renderEmptyOrValue(mimeType)}</div>
-          <Button
-            onClick={onClick}
-            type="text"
-            htmlType="button"
-            disabled={disabled}
-            className={classNames(
-              'flex items-center justify-center rounded-none border border-solid',
-              'hover:text-primary-6!',
-              disabled
-                ? 'pointer-events-none cursor-not-allowed border-gray-300 bg-transparent text-gray-400!'
-                : 'border-primary-6 text-white'
-            )}
-            aria-label={`Download ${entry.label}`}
-            title={`Download ${entry.label}`}
-            icon={<DownloadIcon className="text-current!" />}
-          />
-        </div>
+          aria-label={`Download ${entry.label}`}
+          title={`Download ${entry.label}`}
+          icon={<DownloadIcon className="text-current!" />}
+        />
       </div>
     </div>
   );

--- a/src/ui/segments/explore/circuit/elements/download-panel/helpers.ts
+++ b/src/ui/segments/explore/circuit/elements/download-panel/helpers.ts
@@ -288,8 +288,7 @@ export function buildMechanismsEntry(
   config: { components?: { mechanisms_dir?: string }; manifest?: Record<string, string> },
   directory: DirectoryListContent['files']
 ): FolderEntry | null {
-  // Per ticket: the spec field is `components.mechanisms_dir`, but in practice it's not yet
-  // populated by circuit builders and mod files are hard-coded to `/mod`.
+  // The spec field is `components.mechanisms_dir`, with fallback to `/mod` for older circuits.
   // See https://github.com/openbraininstitute/prod-build-circuit/issues/32
   const raw = config.components?.mechanisms_dir || DEFAULT_MECHANISMS_DIR;
   const entry = buildFolderEntry(raw, config.manifest, directory);

--- a/src/ui/segments/explore/circuit/elements/download-panel/helpers.ts
+++ b/src/ui/segments/explore/circuit/elements/download-panel/helpers.ts
@@ -41,7 +41,9 @@ export const updateFileCounterAtom = atomFamily((key: string) => {
       morphologies: 0,
       nodes: 0,
       edges: 0,
-      configuration_files: 0,
+      configuration_file: 0,
+      node_sets_file: 0,
+      id_mapping: 0,
       electrical_models: 0,
       mechanisms: 0,
     };
@@ -181,6 +183,12 @@ export type ConfigurationFileItem = {
   size: number | null;
 };
 
+export type ConfigurationFiles = {
+  circuitConfig: ConfigurationFileItem;
+  nodeSetsFile: ConfigurationFileItem | null;
+  idMapping: ConfigurationFileItem | null;
+};
+
 export type FolderEntry = {
   prefix: string;
   label: string;
@@ -224,16 +232,19 @@ export function buildConfigurationFiles(
     manifest?: Record<string, string>;
   },
   directory: DirectoryListContent['files']
-): ConfigurationFileItem[] {
-  const items: Array<{ path: string; title: string }> = [
-    { path: CIRCUIT_CONFIG_PATH, title: 'Circuit config' },
-  ];
-  if (config.node_sets_file) {
-    items.push({
-      path: getAssetPath(config.node_sets_file, config.manifest),
-      title: 'Node sets',
-    });
-  }
+): ConfigurationFiles {
+  const toItem = (path: string, title: string): ConfigurationFileItem => ({
+    path,
+    title,
+    size: directory[path]?.size ?? null,
+  });
+
+  const circuitConfig = toItem(CIRCUIT_CONFIG_PATH, 'Configuration file');
+
+  const nodeSetsFile = config.node_sets_file
+    ? toItem(getAssetPath(config.node_sets_file, config.manifest), 'Node sets file')
+    : null;
+
   // Spec field is optional and often not set in older circuits - fall back to the
   // legacy hardcoded path only if it actually exists.
   const idMappingFromConfig = config.components?.provenance?.id_mapping;
@@ -242,14 +253,9 @@ export function buildConfigurationFiles(
     : directory[DEFAULT_ID_MAPPING_PATH]
       ? DEFAULT_ID_MAPPING_PATH
       : null;
-  if (idMappingPath) {
-    items.push({ path: idMappingPath, title: 'ID mapping' });
-  }
-  return items.map(({ path, title }) => ({
-    path,
-    title,
-    size: directory[path]?.size ?? null,
-  }));
+  const idMapping = idMappingPath ? toItem(idMappingPath, 'ID mapping') : null;
+
+  return { circuitConfig, nodeSetsFile, idMapping };
 }
 
 export function buildElectricalModelsEntries(

--- a/src/ui/segments/explore/circuit/elements/download-panel/helpers.ts
+++ b/src/ui/segments/explore/circuit/elements/download-panel/helpers.ts
@@ -189,6 +189,7 @@ export type FolderEntry = {
 };
 
 const CIRCUIT_CONFIG_PATH = 'circuit_config.json';
+const DEFAULT_ID_MAPPING_PATH = 'id_mapping.json';
 
 function filterDirectoryByPrefix(
   directory: DirectoryListContent['files'],
@@ -233,12 +234,16 @@ export function buildConfigurationFiles(
       title: 'Node sets',
     });
   }
-  const idMapping = config.components?.provenance?.id_mapping;
-  if (idMapping) {
-    items.push({
-      path: getAssetPath(idMapping, config.manifest),
-      title: 'ID mapping',
-    });
+  // Use `components.provenance.id_mapping` from the config,
+  // fall back to `id_mapping.json` if the file exists.
+  const idMappingFromConfig = config.components?.provenance?.id_mapping;
+  const idMappingPath = idMappingFromConfig
+    ? getAssetPath(idMappingFromConfig, config.manifest)
+    : directory[DEFAULT_ID_MAPPING_PATH]
+      ? DEFAULT_ID_MAPPING_PATH
+      : null;
+  if (idMappingPath) {
+    items.push({ path: idMappingPath, title: 'ID mapping' });
   }
   return items.map(({ path, title }) => ({
     path,

--- a/src/ui/segments/explore/circuit/elements/download-panel/helpers.ts
+++ b/src/ui/segments/explore/circuit/elements/download-panel/helpers.ts
@@ -41,6 +41,9 @@ export const updateFileCounterAtom = atomFamily((key: string) => {
       morphologies: 0,
       nodes: 0,
       edges: 0,
+      configuration_files: 0,
+      electrical_models: 0,
+      mechanisms: 0,
     };
     if (update) {
       set(fileCounter, {
@@ -170,6 +173,123 @@ function sanitizePath(path: string): string {
   let sanitized = path.replace(/^\.\//, ''); // Remove leading ./
   sanitized = sanitized.replace(/^\/+/, ''); // Remove leading slashes
   return sanitized;
+}
+
+export type ConfigurationFileItem = {
+  path: string;
+  title: string;
+  size: number | null;
+};
+
+export type FolderEntry = {
+  prefix: string;
+  label: string;
+  fileCount: number;
+  totalSize: number;
+};
+
+const CIRCUIT_CONFIG_PATH = 'circuit_config.json';
+
+function filterDirectoryByPrefix(
+  directory: DirectoryListContent['files'],
+  prefix: string
+): Array<{ path: string; size: number }> {
+  const normalized = prefix.endsWith('/') ? prefix : `${prefix}/`;
+  return Object.entries(directory)
+    .filter(([path]) => path.startsWith(normalized))
+    .map(([path, meta]) => ({ path, size: meta.size }));
+}
+
+function buildFolderEntry(
+  rawPath: string,
+  manifest: Record<string, string> | undefined,
+  directory: DirectoryListContent['files']
+): FolderEntry | null {
+  const resolved = getAssetPath(rawPath, manifest);
+  if (!resolved) return null;
+  const files = filterDirectoryByPrefix(directory, resolved);
+  return {
+    prefix: resolved,
+    label: resolved.split('/').filter(Boolean).pop() ?? resolved,
+    fileCount: files.length,
+    totalSize: files.reduce((acc, f) => acc + (f.size ?? 0), 0),
+  };
+}
+
+export function buildConfigurationFiles(
+  config: {
+    node_sets_file?: string;
+    components?: { provenance?: { id_mapping?: string } };
+    manifest?: Record<string, string>;
+  },
+  directory: DirectoryListContent['files']
+): ConfigurationFileItem[] {
+  const items: Array<{ path: string; title: string }> = [
+    { path: CIRCUIT_CONFIG_PATH, title: 'Circuit config' },
+  ];
+  if (config.node_sets_file) {
+    items.push({
+      path: getAssetPath(config.node_sets_file, config.manifest),
+      title: 'Node sets',
+    });
+  }
+  const idMapping = config.components?.provenance?.id_mapping;
+  if (idMapping) {
+    items.push({
+      path: getAssetPath(idMapping, config.manifest),
+      title: 'ID mapping',
+    });
+  }
+  return items.map(({ path, title }) => ({
+    path,
+    title,
+    size: directory[path]?.size ?? null,
+  }));
+}
+
+export function buildElectricalModelsEntries(
+  config: {
+    components?: { biophysical_neuron_models_dir?: string };
+    networks?: { nodes?: Array<SonataCircuitNetworkNodeConfigItem> };
+    manifest?: Record<string, string>;
+  },
+  directory: DirectoryListContent['files']
+): FolderEntry[] {
+  const candidates = new Set<string>();
+  const topLevel = config.components?.biophysical_neuron_models_dir;
+  if (topLevel) candidates.add(topLevel);
+  for (const node of config.networks?.nodes ?? []) {
+    for (const pop of Object.values(node.populations ?? {})) {
+      if (pop.biophysical_neuron_models_dir) {
+        candidates.add(pop.biophysical_neuron_models_dir);
+      }
+    }
+  }
+  const entries: FolderEntry[] = [];
+  const seenPrefixes = new Set<string>();
+  for (const raw of candidates) {
+    const entry = buildFolderEntry(raw, config.manifest, directory);
+    if (entry && !seenPrefixes.has(entry.prefix)) {
+      seenPrefixes.add(entry.prefix);
+      entries.push(entry);
+    }
+  }
+  return entries;
+}
+
+const DEFAULT_MECHANISMS_DIR = 'mod';
+
+export function buildMechanismsEntry(
+  config: { components?: { mechanisms_dir?: string }; manifest?: Record<string, string> },
+  directory: DirectoryListContent['files']
+): FolderEntry | null {
+  // Per ticket: the spec field is `components.mechanisms_dir`, but in practice it's not yet
+  // populated by circuit builders and mod files are hard-coded to `/mod`.
+  // See https://github.com/openbraininstitute/prod-build-circuit/issues/32
+  const raw = config.components?.mechanisms_dir || DEFAULT_MECHANISMS_DIR;
+  const entry = buildFolderEntry(raw, config.manifest, directory);
+  if (!entry || entry.fileCount === 0) return null;
+  return entry;
 }
 
 export function countConnectivityPaths(

--- a/src/ui/segments/explore/circuit/elements/download-panel/helpers.ts
+++ b/src/ui/segments/explore/circuit/elements/download-panel/helpers.ts
@@ -234,8 +234,8 @@ export function buildConfigurationFiles(
       title: 'Node sets',
     });
   }
-  // Use `components.provenance.id_mapping` from the config,
-  // fall back to `id_mapping.json` if the file exists.
+  // Spec field is optional and often unset by builders — fall back to the
+  // legacy hardcoded path only if it actually exists.
   const idMappingFromConfig = config.components?.provenance?.id_mapping;
   const idMappingPath = idMappingFromConfig
     ? getAssetPath(idMappingFromConfig, config.manifest)

--- a/src/ui/segments/explore/circuit/elements/download-panel/helpers.ts
+++ b/src/ui/segments/explore/circuit/elements/download-panel/helpers.ts
@@ -234,7 +234,7 @@ export function buildConfigurationFiles(
       title: 'Node sets',
     });
   }
-  // Spec field is optional and often unset by builders — fall back to the
+  // Spec field is optional and often not set in older circuits - fall back to the
   // legacy hardcoded path only if it actually exists.
   const idMappingFromConfig = config.components?.provenance?.id_mapping;
   const idMappingPath = idMappingFromConfig

--- a/src/ui/segments/explore/circuit/elements/download-panel/index.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/index.tsx
@@ -1,10 +1,15 @@
 'use client';
 
 import { CloseOutlined } from '@ant-design/icons';
+import { Button } from 'antd';
+import kebabCase from 'es-toolkit/compat/kebabCase';
 import sum from 'es-toolkit/compat/sum';
+import { saveAs } from 'file-saver';
 import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useHotkeys } from 'react-hotkeys-hook';
 
+import { DownloadIcon } from '@/components/icons';
+import ComponentsConfig from '@/ui/segments/explore/circuit/elements/download-panel/components-config';
 import ConnectivityMatrices from '@/ui/segments/explore/circuit/elements/download-panel/connectivity-matrices';
 import EntireCircuitExport from '@/ui/segments/explore/circuit/elements/download-panel/entire-circuit-export';
 import {
@@ -30,6 +35,12 @@ export function DownloadPanel() {
   };
 
   useHotkeys('Escape', onClose);
+
+  const onDownloadMetadata = () => {
+    if (!circuit) return;
+    const blob = new Blob([JSON.stringify(circuit, null, 2)], { type: 'application/json' });
+    saveAs(blob, `${kebabCase(circuit.name) || circuit.id}-metadata.json`);
+  };
 
   if (!circuit) return null;
   return (
@@ -70,12 +81,33 @@ export function DownloadPanel() {
           </button>
         </div>
         <EntireCircuitExport circuit={circuit} />
+        <div className="bg-primary-8 mx-8 mt-4 flex flex-row items-start justify-between gap-3 rounded-md p-8 shadow-xs">
+          <div className="w-3/4 hyphens-auto">
+            <div className="text-xl font-bold tracking-wide text-white uppercase">
+              JSON metadata
+            </div>
+            <p className="text-primary-2 text-sm leading-normal font-light hyphens-auto">
+              Stand-alone JSON file with the circuit&apos;s metadata. Not bundled into the archive
+              downloads.
+            </p>
+          </div>
+          <Button
+            type="link"
+            htmlType="button"
+            className="border-primary-6 flex items-center justify-center rounded-none border border-solid"
+            aria-label="Download JSON metadata"
+            title="Download JSON metadata"
+            icon={<DownloadIcon className="text-white!" />}
+            onClick={onDownloadMetadata}
+          />
+        </div>
         <div className="border-primary-7 text-primary-4 mx-8 my-8 border-y border-solid py-4 text-xl font-bold tracking-wide uppercase">
           Download components only
         </div>
         <div className="flex w-full flex-col gap-y-12 px-8 pb-10">
           <ConnectivityMatrices key="connectivity-metrics-content" circuit={circuit} />
           <NetworkAndMorphologyConfig key="network-and-morphology-content" circuit={circuit} />
+          <ComponentsConfig key="components-content" circuit={circuit} />
         </div>
       </div>
     </div>

--- a/src/ui/segments/explore/circuit/elements/download-panel/index.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/index.tsx
@@ -83,23 +83,23 @@ export function DownloadPanel() {
         <EntireCircuitExport circuit={circuit} />
         <div className="bg-primary-8 mx-8 mt-4 flex flex-row items-start justify-between gap-3 rounded-md p-8 shadow-xs">
           <div className="w-3/4 hyphens-auto">
-            <div className="text-xl font-bold tracking-wide text-white uppercase">
-              JSON metadata
-            </div>
+            <div className="text-xl font-bold tracking-wide text-white uppercase">Metadata</div>
             <p className="text-primary-2 text-sm leading-normal font-light hyphens-auto">
-              Stand-alone JSON file with the circuit&apos;s metadata. Not bundled into the archive
-              downloads.
+              Stand-alone JSON file with the circuit&apos;s metadata.
             </p>
           </div>
-          <Button
-            type="link"
-            htmlType="button"
-            className="border-primary-6 flex items-center justify-center rounded-none border border-solid"
-            aria-label="Download JSON metadata"
-            title="Download JSON metadata"
-            icon={<DownloadIcon className="text-white!" />}
-            onClick={onDownloadMetadata}
-          />
+          <div className="text-primary-1 flex flex-row items-center gap-x-3 font-semibold">
+            <div>json</div>
+            <Button
+              type="link"
+              htmlType="button"
+              className="border-primary-6 flex items-center justify-center rounded-none border border-solid"
+              aria-label="Download metadata"
+              title="Download metadata"
+              icon={<DownloadIcon className="text-white!" />}
+              onClick={onDownloadMetadata}
+            />
+          </div>
         </div>
         <div className="border-primary-7 text-primary-4 mx-8 my-8 border-y border-solid py-4 text-xl font-bold tracking-wide uppercase">
           Download components only

--- a/src/ui/segments/explore/circuit/elements/download-panel/network-morphology-config.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/network-morphology-config.tsx
@@ -43,22 +43,23 @@ export default function NetworkAndMorphologyConfig({ circuit }: { circuit: ICirc
     assets,
     filter: (asset) => asset.label === AssetLabel.sonata_circuit,
   });
+  const configAssetId = configAsset?.id ?? '';
 
   const networksConfig = useQuery({
     queryKey: keyBuilder.asset({
       entityId: circuit.id,
-      assetId: configAsset!.id,
+      assetId: configAssetId,
       assetPath: AssetDefaultPath,
       context: { virtualLabId, projectId },
     }),
     queryFn: () =>
       resolveCircuitConfigAndDirectory<ICircuitSonataConfiguration>({
         entityId: circuit.id,
-        assetId: configAsset!.id,
+        assetId: configAssetId,
         assetPath: AssetDefaultPath,
         context: { virtualLabId, projectId },
       }),
-    enabled: !!circuit && !!configAsset!.id,
+    enabled: !!circuit && !!configAssetId,
     select: (result) => {
       return {
         directory: result.directory,


### PR DESCRIPTION
## Summary

Extends the Circuit Download panel so users can pull individual circuit artifacts instead of always grabbing the full circuit tarball.

## What's new

- **Configuration files** — `circuit_config.json`, node sets, ID mapping as single-file downloads via the existing presigned-URL path. JSON/text MIME types are routed through a fetch-blob shim so the browser saves them instead of rendering inline.
- **Electrical models & mechanisms** — on-the-fly `tar.gz` archives streamed by a new `asset-folder` ticket flow that shares the ticket store, auth, and gzip wiring with the existing entity-batch pipeline.
- **JSON metadata** — stand-alone client-side dump of the `ICircuit` payload.

## Backend changes

- `DownloadTicket` becomes a discriminated union (`entity-batch` | `asset-folder`); existing entity-batch routes unchanged.
- New routes: `POST /api/entity-download/asset-folder/ticket`, `GET /api/entity-download/asset-folder/ticket/[ticketId]`.
- New generator `getAssetFolderFiles` lists assets under one folder prefix and streams them through the shared `tar-stream + createGzip` pipeline.
- `GET /api/entity-download/presigned-url` now validates its query params with Zod (entity type enum, UUIDs, non-empty asset path) instead of trusting raw search params.

## UI changes

- New `ComponentsConfig` section in the download panel, plus a `FolderConfigItem` row visual aligned with the existing network/morphology rows.
- React Query dedupes the new `resolveCircuitConfigAndDirectory` call with the one already issued by `NetworkAndMorphologyConfig` (same key), so no extra network round-trips.

## Notable fallbacks

- ID mapping: falls back to root `id_mapping.json` when `components.provenance.id_mapping` isn't set but the file exists in the directory listing.
- Mechanisms: falls back to `/mod` when `components.mechanisms_dir` is missing (per prod-build-circuit#32).

## Tooling

- Adds a `:NODE:` import group to `biome.json` so `node:`-prefixed built-ins sort above external packages.

## Test plan

- [x] Open a circuit's Download panel: Configuration files (3 rows), Electrical models (≥1), Mechanisms (1), and Metadata button render
- [x] Single-file rows download via presigned URL (verify JSON/text save, not render)
- [x] Folder rows produce a valid `.tar.gz`; `tar -tzf <file> | wc -l` matches the directory listing under the prefix
- [x] Metadata button downloads `<circuit-name>-metadata.json` with the full circuit payload
- [x] Regression: existing Nodes / Edges / Morphologies / Connectivity rows and entity-batch tarball downloads still work