### PR TITLE
fix: refresh stripe session expiration

### DIFF
--- a/src/features/credits/credits-amount-input.tsx
+++ b/src/features/credits/credits-amount-input.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { LoadingOutlined } from '@ant-design/icons';
-
 import { CoinsIcon } from '@/components/icons';
 import { Input } from '@/ui/molecules/input';
+import { Skeleton } from '@/ui/molecules/skeleton';
 import { cn } from '@/utils/css-class';
 
 const integerFormatter = new Intl.NumberFormat('en-US', {
@@ -27,6 +26,7 @@ export function parseCreditsAmount(value: string) {
 export function CreditsAmountInput({
   className,
   disabled,
+  error,
   hint,
   inputClassName,
   loadingHint = false,
@@ -35,6 +35,7 @@ export function CreditsAmountInput({
 }: {
   className?: string;
   disabled?: boolean;
+  error?: string;
   hint: string;
   inputClassName?: string;
   loadingHint?: boolean;
@@ -56,6 +57,7 @@ export function CreditsAmountInput({
               className={cn(
                 'h-12 w-full rounded-full border-white/20 bg-[#052f66] pr-28 text-xl! font-bold text-white placeholder:text-white/50',
                 '[appearance:textfield] border px-4 py-1 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none',
+                { 'border-red-400': error },
                 inputClassName
               )}
               disabled={disabled}
@@ -64,10 +66,15 @@ export function CreditsAmountInput({
               Credits
             </div>
           </div>
+          {error && <p className="mt-2 ml-2 text-xs text-red-400">{error}</p>}
           <div className="mt-2 ml-2 flex items-center gap-2 text-current">
             <CoinsIcon className="size-5" />
             <span className="text-sm">
-              {loadingHint ? <LoadingOutlined spin className="ml-2 text-current" /> : hint}
+              {loadingHint ? (
+                <Skeleton className="h-4 w-12 rounded-full animate-pulse bg-gray-50/30!" />
+              ) : (
+                hint
+              )}
             </span>
           </div>
         </div>

--- a/src/features/payments/standalone/payment-method-section.tsx
+++ b/src/features/payments/standalone/payment-method-section.tsx
@@ -6,12 +6,14 @@ import { BillingAddressElement, BillingCardElement } from '@/features/stripe/pay
 import { Button as UiButton } from '@/ui/molecules/button';
 import { cn } from '@/utils/css-class';
 
+import type { StripePaymentElementChangeEvent } from '@stripe/stripe-js';
 import type { TBillingAddress } from '@/api/virtual-lab-svc/queries/types';
 
 export function StandalonePaymentMethodSection({
   billingAddress,
   disabled,
   onCancel,
+  onCardChange,
   onPay,
   onPaymentReady,
   onBillingAddressChange,
@@ -23,6 +25,7 @@ export function StandalonePaymentMethodSection({
   billingAddress: TBillingAddress | null;
   disabled: boolean;
   onCancel: () => void;
+  onCardChange: (event: StripePaymentElementChangeEvent) => void;
   onPay: () => void;
   onPaymentReady: () => void;
   onBillingAddressChange: (address: TBillingAddress | null) => void;
@@ -46,6 +49,7 @@ export function StandalonePaymentMethodSection({
         <BillingCardElement
           disabled={disabled}
           framed={false}
+          onChange={onCardChange}
           onReady={onPaymentReady}
           paymentElementId="credits-form"
         />

--- a/src/features/payments/standalone/standalone-payment-form.tsx
+++ b/src/features/payments/standalone/standalone-payment-form.tsx
@@ -5,7 +5,15 @@ import { useQueryClient } from '@tanstack/react-query';
 import { NotificationPlacements } from 'antd/es/notification/interface';
 import { get } from 'es-toolkit/compat';
 import { useSession } from 'next-auth/react';
-import { useDeferredValue, useEffect, useMemo, useReducer, useState } from 'react';
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'react';
 
 import {
   BillingQuoteRequestFlowDict,
@@ -18,14 +26,17 @@ import { useBillingQuoteQuery } from '@/features/payments/hooks';
 import { useCreateStandalonePaymentMutation } from '@/features/payments/standalone/hooks';
 import { StandalonePaymentMethodSection } from '@/features/payments/standalone/payment-method-section';
 import {
-  confirmStripeSetupPaymentMethod,
-  StripeSetupConfirmationError,
-} from '@/features/stripe/confirm-setup';
+  getBackendPaymentErrorDescription,
+  getStripeSetupErrorDescription,
+  isSetupIntentConsumedError,
+} from '@/features/stripe/errors';
+import { resolvePaymentMethodId } from '@/features/stripe/hooks';
 import { formatMinorCurrency } from '@/features/stripe/utils';
 import { messages } from '@/i18n/en/payment';
 import { keyBuilder as userKeyBuilder } from '@/ui/use-query-keys/user';
 import { keyBuilder } from '@/ui/use-query-keys/workspace';
 
+import type { StripePaymentElementChangeEvent } from '@stripe/stripe-js';
 import type { User } from 'next-auth';
 
 const MAX_CONVERSIONS_PER_TRANSACTION = 10;
@@ -38,9 +49,11 @@ const notificationConfig = {
 export function StandalonePaymentForm({
   virtualLabId,
   onCancel,
+  onSetupIntentRefreshNeeded,
 }: {
   virtualLabId: string;
   onCancel: () => void;
+  onSetupIntentRefreshNeeded: () => Promise<void>;
 }) {
   const queryClient = useQueryClient();
   const elements = useElements();
@@ -53,6 +66,8 @@ export function StandalonePaymentForm({
   const [isPaying, setIsPaying] = useState(false);
   const [saveBillingAddressToProfile, setSaveBillingAddressToProfile] = useState<boolean>(false);
   const [stripeElementsReady, setStripeElementsReady] = useState(false);
+  const [cachedPaymentMethodId, setCachedPaymentMethodId] = useState<string | null>(null);
+  const cachedPaymentMethodIdRef = useRef<string | null>(null);
   const [conversionKeys, addConversionKey] = useReducer((keys: Set<string>, key: string) => {
     if (keys.has(key)) {
       return keys;
@@ -113,6 +128,7 @@ export function StandalonePaymentForm({
   const limitReached = Boolean(conversionKey) && !conversionAllowed;
   const currentBillingAddress = billingAddress?.country ? billingAddress : null;
   const user = session?.user as User;
+  const creditsError = !credits ? messages.creditsAmountRequired : undefined;
 
   const disablePaying =
     !stripe ||
@@ -125,29 +141,52 @@ export function StandalonePaymentForm({
     quote.isFetching ||
     isPaying;
 
+  const cachePaymentMethodId = useCallback((paymentMethodId: string) => {
+    cachedPaymentMethodIdRef.current = paymentMethodId;
+    setCachedPaymentMethodId(paymentMethodId);
+  }, []);
+
+  const clearCachedPaymentMethodId = useCallback(() => {
+    cachedPaymentMethodIdRef.current = null;
+    setCachedPaymentMethodId(null);
+  }, []);
+
+  const handleCardChange = useCallback(
+    (event: StripePaymentElementChangeEvent) => {
+      if (isPaying || !cachedPaymentMethodIdRef.current || event.empty) {
+        return;
+      }
+
+      clearCachedPaymentMethodId();
+      void onSetupIntentRefreshNeeded();
+    },
+    [clearCachedPaymentMethodId, isPaying, onSetupIntentRefreshNeeded]
+  );
+
   const onPay = async () => {
     if (disablePaying) return;
     setIsPaying(true);
 
     let paymentMethodId: string;
     try {
-      paymentMethodId = await confirmStripeSetupPaymentMethod({
+      paymentMethodId = await resolvePaymentMethodId({
         billingAddress: currentBillingAddress,
+        cachedPaymentMethodId,
         elements,
         returnUrl: window.location.href,
         stripe,
         user,
       });
+      cachePaymentMethodId(paymentMethodId);
     } catch (error) {
-      const description =
-        error instanceof StripeSetupConfirmationError && error.reason === 'missing_payment_method'
-          ? messages.paymentMethodSaveError
-          : error instanceof Error
-            ? (error.message ?? messages.paymentProcessingErrorFallback)
-            : messages.paymentProcessingErrorFallback;
+      if (isSetupIntentConsumedError(error)) {
+        clearCachedPaymentMethodId();
+        await onSetupIntentRefreshNeeded();
+      }
+
       errorNotify({
         message: messages.paymentProcessingErrorTitle,
-        description,
+        description: getStripeSetupErrorDescription(error),
         ...notificationConfig,
       });
       setIsPaying(false);
@@ -173,6 +212,7 @@ export function StandalonePaymentForm({
           .replace('$$price', formatMinorCurrency(data.amount_total, data.currency)),
         ...notificationConfig,
       });
+      clearCachedPaymentMethodId();
       const accountingKey = keyBuilder.accounting({ virtualLabId });
       onCancel();
       window.setTimeout(() => {
@@ -183,17 +223,9 @@ export function StandalonePaymentForm({
       setIsPaying(false);
     } catch (error) {
       const code = get(error, 'cause.code', 'DEFAULT');
-      const errors = {
-        ENTITY_ALREADY_EXISTS: messages.paymentProcessingErrorEntityAlreadyExists,
-        ENTITY_NOT_CREATED: messages.paymentProcessingErrorEntityNotCreated,
-        ENTITY_NOT_FOUND: messages.paymentProcessingErrorEntityNotFound,
-        PAYMENT_ERROR: `We couldn’t process your payment because the billing country does not match the country associated with your payment method. Please verify your billing details and try again.`,
-        DEFAULT: messages.paymentProcessingError,
-      };
-      const description = get(errors, code, messages.paymentProcessingError);
       errorNotify({
         message: messages.paymentProcessingErrorTitle,
-        description,
+        description: getBackendPaymentErrorDescription(code, 'standalone'),
         ...notificationConfig,
       });
       setIsPaying(false);
@@ -206,6 +238,7 @@ export function StandalonePaymentForm({
         hint={limitReached ? 'Calculation of order full amount limit reached' : conversionText}
         value={credits}
         disabled={isPaying}
+        error={creditsError}
         loadingHint={conversion.isFetching}
         onValueChange={setCredits}
       />
@@ -219,6 +252,7 @@ export function StandalonePaymentForm({
         disabled={isPaying}
         onBillingAddressChange={setBillingAddress}
         onCancel={onCancel}
+        onCardChange={handleCardChange}
         onPay={onPay}
         onPaymentReady={() => setStripeElementsReady(true)}
         onSaveBillingAddressChange={setSaveBillingAddressToProfile}

--- a/src/features/payments/standalone/stripe-payment.tsx
+++ b/src/features/payments/standalone/stripe-payment.tsx
@@ -3,6 +3,7 @@
 import { LoadingOutlined } from '@ant-design/icons';
 import { Elements } from '@stripe/react-stripe-js';
 import { Spin } from 'antd';
+import { useCallback, useState } from 'react';
 
 import { StandalonePaymentForm } from '@/features/payments/standalone/standalone-payment-form';
 import { useSetupIntentQuery, useStripeInstanceQuery } from '@/features/stripe/hooks';
@@ -15,9 +16,19 @@ export function StandaloneStripePayment({
   virtualLabId: string;
   onCancel: () => void;
 }) {
-  const setupIntent = useSetupIntentQuery({ virtualLabId });
+  const [elementsKey, setElementsKey] = useState(0);
+  const {
+    data: setupIntentData,
+    isLoading: isSetupIntentLoading,
+    refetch: refetchSetupIntent,
+  } = useSetupIntentQuery({ virtualLabId });
   const stripe = useStripeInstanceQuery();
-  const loadingStripe = setupIntent.isLoading || stripe.isLoading;
+  const loadingStripe = isSetupIntentLoading || stripe.isLoading;
+
+  const refreshSetupIntent = useCallback(async () => {
+    await refetchSetupIntent();
+    setElementsKey((currentKey) => currentKey + 1);
+  }, [refetchSetupIntent]);
 
   if (loadingStripe) {
     return (
@@ -27,16 +38,21 @@ export function StandaloneStripePayment({
     );
   }
 
-  if (!stripe.data || !setupIntent.data?.data) {
+  if (!stripe.data || !setupIntentData?.data) {
     return null;
   }
 
   return (
     <Elements
+      key={elementsKey}
       stripe={stripe.data}
-      options={buildStripeFormOptions(setupIntent.data.data.client_secret)}
+      options={buildStripeFormOptions(setupIntentData.data.client_secret)}
     >
-      <StandalonePaymentForm virtualLabId={virtualLabId} onCancel={onCancel} />
+      <StandalonePaymentForm
+        virtualLabId={virtualLabId}
+        onCancel={onCancel}
+        onSetupIntentRefreshNeeded={refreshSetupIntent}
+      />
     </Elements>
   );
 }

--- a/src/features/payments/subscription/payment-form.tsx
+++ b/src/features/payments/subscription/payment-form.tsx
@@ -6,7 +6,7 @@ import { NotificationPlacements } from 'antd/es/notification/interface';
 import { get } from 'es-toolkit/compat';
 import { useAtomValue } from 'jotai';
 import { useSession } from 'next-auth/react';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import {
   BillingQuoteRequestFlowDict,
@@ -16,12 +16,17 @@ import { useAppNotification } from '@/components/notification';
 import { BillingSummary } from '@/features/payments/billing-summary';
 import { useBillingQuoteQuery } from '@/features/payments/hooks';
 import PricingToggleCards from '@/features/payments/subscription/pricing-toggle-cards';
-import { DefaultCurrency, flowAtom } from '@/features/payments/subscription/shared';
+import { DefaultCurrency, FlowStepDict, flowAtom } from '@/features/payments/subscription/shared';
 import {
-  confirmStripeSetupPaymentMethod,
-  StripeSetupConfirmationError,
-} from '@/features/stripe/confirm-setup';
-import { useSetupIntentQuery, useStripeInstanceQuery } from '@/features/stripe/hooks';
+  getBackendPaymentErrorDescription,
+  getStripeSetupErrorDescription,
+  isSetupIntentConsumedError,
+} from '@/features/stripe/errors';
+import {
+  resolvePaymentMethodId,
+  useSetupIntentQuery,
+  useStripeInstanceQuery,
+} from '@/features/stripe/hooks';
 import {
   BillingAddressElement,
   BillingCardElement,
@@ -36,6 +41,7 @@ import { cn } from '@/utils/css-class';
 
 import { useCreateSubscriptionMutation } from './hooks';
 
+import type { StripePaymentElementChangeEvent } from '@stripe/stripe-js';
 import type { User } from 'next-auth';
 import type {
   CreditConversionResponse,
@@ -44,6 +50,7 @@ import type {
 
 type Props = {
   onPrevious: () => void;
+  onSetupIntentRefreshNeeded: () => Promise<void>;
 };
 
 const notificationConfig = {
@@ -51,7 +58,7 @@ const notificationConfig = {
   key: 'subscription-payment-error',
 };
 
-function Form({ onPrevious }: Props) {
+function Form({ onPrevious, onSetupIntentRefreshNeeded }: Props) {
   const { virtualLabId } = useWorkspace();
   const queryClient = useQueryClient();
   const elements = useElements();
@@ -62,6 +69,8 @@ function Form({ onPrevious }: Props) {
   const [stripeElementsReady, setElementsReady] = useState(false);
   const [isSubscribing, setSubscribing] = useState(false);
   const [saveBillingAddressToProfile, setSaveBillingAddressToProfile] = useState<boolean>(false);
+  const [cachedPaymentMethodId, setCachedPaymentMethodId] = useState<string | null>(null);
+  const cachedPaymentMethodIdRef = useRef<string | null>(null);
   const { success: successNotify, error: errorNotify } = useAppNotification();
   const createSubscription = useCreateSubscriptionMutation();
 
@@ -117,6 +126,28 @@ function Form({ onPrevious }: Props) {
     quote.isFetching ||
     isSubscribing;
 
+  const cachePaymentMethodId = useCallback((paymentMethodId: string) => {
+    cachedPaymentMethodIdRef.current = paymentMethodId;
+    setCachedPaymentMethodId(paymentMethodId);
+  }, []);
+
+  const clearCachedPaymentMethodId = useCallback(() => {
+    cachedPaymentMethodIdRef.current = null;
+    setCachedPaymentMethodId(null);
+  }, []);
+
+  const handleCardChange = useCallback(
+    (event: StripePaymentElementChangeEvent) => {
+      if (isSubscribing || !cachedPaymentMethodIdRef.current || event.empty) {
+        return;
+      }
+
+      clearCachedPaymentMethodId();
+      void onSetupIntentRefreshNeeded();
+    },
+    [clearCachedPaymentMethodId, isSubscribing, onSetupIntentRefreshNeeded]
+  );
+
   const onSubmit = async (event: React.SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
     event.stopPropagation();
@@ -127,23 +158,24 @@ function Form({ onPrevious }: Props) {
 
     let paymentMethodId: string;
     try {
-      paymentMethodId = await confirmStripeSetupPaymentMethod({
+      paymentMethodId = await resolvePaymentMethodId({
         billingAddress: currentBillingAddress,
+        cachedPaymentMethodId,
         elements,
         returnUrl: window.location.href,
         stripe,
         user,
       });
+      cachePaymentMethodId(paymentMethodId);
     } catch (error) {
-      const description =
-        error instanceof StripeSetupConfirmationError && error.reason === 'missing_payment_method'
-          ? messages.paymentMethodSaveError
-          : error instanceof Error
-            ? (error.message ?? messages.paymentProcessingError)
-            : messages.paymentProcessingError;
+      if (isSetupIntentConsumedError(error)) {
+        clearCachedPaymentMethodId();
+        await onSetupIntentRefreshNeeded();
+      }
+
       errorNotify({
         message: messages.paymentProcessingErrorTitle,
-        description,
+        description: getStripeSetupErrorDescription(error),
         ...notificationConfig,
       });
       setSubscribing(false);
@@ -172,20 +204,13 @@ function Form({ onPrevious }: Props) {
         });
         makeTriggerWorkspaceConfigurationClickEvent<null>({ on: false, data: null, type: null });
       }
+      clearCachedPaymentMethodId();
       setSubscribing(false);
     } catch (error) {
       const code = get(error, 'cause.code', 'DEFAULT');
-      const errors = {
-        ENTITY_ALREADY_EXISTS: messages.subscriptionPaymentErrorEntityAlreadyExists,
-        ENTITY_NOT_CREATED: messages.subscriptionPaymentErrorEntityNotCreated,
-        ENTITY_NOT_FOUND: messages.subscriptionPaymentErrorEntityNotFound,
-        PAYMENT_ERROR: `We couldn’t process your payment because the billing country does not match the country associated with your payment method. Please verify your billing details and try again.`,
-        DEFAULT: messages.paymentProcessingError,
-      };
-      const description = get(errors, code, messages.paymentProcessingError);
       errorNotify({
         message: messages.paymentProcessingErrorTitle,
-        description,
+        description: getBackendPaymentErrorDescription(code, 'subscription'),
         ...notificationConfig,
       });
       setSubscribing(false);
@@ -220,6 +245,7 @@ function Form({ onPrevious }: Props) {
             <BillingCardElement
               disabled={isSubscribing}
               framed={false}
+              onChange={handleCardChange}
               onReady={() => setElementsReady(true)}
               paymentElementId="subscription-form"
             />
@@ -262,15 +288,25 @@ function Form({ onPrevious }: Props) {
   );
 }
 
-export default function PaymentForm({ onPrevious }: Props) {
+export default function PaymentForm({ onPrevious }: { onPrevious: () => void }) {
   const { step } = useAtomValue(flowAtom);
-  const setupIntent = useSetupIntentQuery({
-    enabled: step === 'pay',
+  const [elementsKey, setElementsKey] = useState(0);
+  const {
+    data: setupIntentData,
+    isLoading: isSetupIntentLoading,
+    refetch: refetchSetupIntent,
+  } = useSetupIntentQuery({
+    enabled: step === FlowStepDict.Pay,
     virtualLabId: 'subscription',
   });
-  const stripe = useStripeInstanceQuery({ enabled: step === 'pay' });
+  const stripe = useStripeInstanceQuery({ enabled: step === FlowStepDict.Pay });
 
-  if (setupIntent.isLoading || stripe.isLoading) {
+  const refreshSetupIntent = useCallback(async () => {
+    await refetchSetupIntent();
+    setElementsKey((currentKey) => currentKey + 1);
+  }, [refetchSetupIntent]);
+
+  if (isSetupIntentLoading || stripe.isLoading) {
     return (
       <div className="flex h-full grow items-center justify-center py-7">
         <Spin size="large" indicator={<LoadingOutlined className="text-white" />} />
@@ -278,17 +314,18 @@ export default function PaymentForm({ onPrevious }: Props) {
     );
   }
 
-  if (!setupIntent.data?.data?.client_secret || !stripe.data) {
+  if (!setupIntentData?.data?.client_secret || !stripe.data) {
     return null;
   }
 
   return (
     <div className="flex h-full min-h-0 grow flex-col">
       <Elements
+        key={elementsKey}
         stripe={stripe.data}
-        options={buildStripeFormOptions(setupIntent.data.data.client_secret)}
+        options={buildStripeFormOptions(setupIntentData.data.client_secret)}
       >
-        <Form onPrevious={onPrevious} />
+        <Form onPrevious={onPrevious} onSetupIntentRefreshNeeded={refreshSetupIntent} />
       </Elements>
     </div>
   );

--- a/src/features/stripe/errors.ts
+++ b/src/features/stripe/errors.ts
@@ -1,0 +1,65 @@
+import { StripeSetupConfirmationError } from '@/features/stripe/confirm-setup';
+import { messages } from '@/i18n/en/payment';
+
+export function isSetupIntentConsumedError(error: unknown): boolean {
+  if (!(error instanceof StripeSetupConfirmationError)) {
+    return false;
+  }
+
+  if (error.reason === 'missing_payment_method') {
+    return true;
+  }
+
+  if (error.reason !== 'stripe_error' || !error.message) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+
+  return (
+    message.includes('already succeeded') ||
+    message.includes('already been confirmed') ||
+    message.includes('invalid status') ||
+    message.includes('unexpected_state')
+  );
+}
+
+export function getStripeSetupErrorDescription(error: unknown): string {
+  if (error instanceof StripeSetupConfirmationError && error.reason === 'missing_payment_method') {
+    return messages.paymentMethodSaveError;
+  }
+
+  if (isSetupIntentConsumedError(error)) {
+    return messages.setupIntentSessionExpired;
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return messages.paymentProcessingErrorFallback;
+}
+
+export function getBackendPaymentErrorDescription(
+  code: string,
+  flow: 'standalone' | 'subscription' = 'standalone'
+): string {
+  const errors =
+    flow === 'subscription'
+      ? {
+          ENTITY_ALREADY_EXISTS: messages.subscriptionPaymentErrorEntityAlreadyExists,
+          ENTITY_NOT_CREATED: messages.subscriptionPaymentErrorEntityNotCreated,
+          ENTITY_NOT_FOUND: messages.subscriptionPaymentErrorEntityNotFound,
+          PAYMENT_ERROR: messages.paymentProcessingErrorBillingCountryMismatch,
+          DEFAULT: messages.paymentProcessingError,
+        }
+      : {
+          ENTITY_ALREADY_EXISTS: messages.paymentProcessingErrorEntityAlreadyExists,
+          ENTITY_NOT_CREATED: messages.paymentProcessingErrorEntityNotCreated,
+          ENTITY_NOT_FOUND: messages.paymentProcessingErrorEntityNotFound,
+          PAYMENT_ERROR: messages.paymentProcessingErrorBillingCountryMismatch,
+          DEFAULT: messages.paymentProcessingError,
+        };
+
+  return errors[code as keyof typeof errors] ?? messages.paymentProcessingError;
+}

--- a/src/features/stripe/hooks.ts
+++ b/src/features/stripe/hooks.ts
@@ -1,9 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { getSetupIntent } from '@/api/virtual-lab-svc/queries/payment';
+import { getStripe } from '@/features/stripe/client';
+import { confirmStripeSetupPaymentMethod } from '@/features/stripe/confirm-setup';
 import { keyBuilder as externalKeyBuilder } from '@/ui/use-query-keys/third-parties';
 
-import { getStripe } from './client';
+import type { Stripe, StripeElements } from '@stripe/stripe-js';
+import type { User } from 'next-auth';
+import type { TBillingAddress } from '@/api/virtual-lab-svc/queries/types';
 
 export function useSetupIntentQuery({
   enabled = true,
@@ -26,5 +30,33 @@ export function useStripeInstanceQuery({ enabled = true }: { enabled?: boolean }
     queryKey: externalKeyBuilder.stripeInstance(),
     queryFn: getStripe,
     enabled,
+  });
+}
+
+export async function resolvePaymentMethodId({
+  billingAddress,
+  cachedPaymentMethodId,
+  elements,
+  returnUrl,
+  stripe,
+  user,
+}: {
+  billingAddress: TBillingAddress;
+  cachedPaymentMethodId: string | null;
+  elements: StripeElements;
+  returnUrl: string;
+  stripe: Stripe;
+  user: User;
+}): Promise<string> {
+  if (cachedPaymentMethodId) {
+    return cachedPaymentMethodId;
+  }
+
+  return confirmStripeSetupPaymentMethod({
+    billingAddress,
+    elements,
+    returnUrl,
+    stripe,
+    user,
   });
 }

--- a/src/features/stripe/payment-elements.tsx
+++ b/src/features/stripe/payment-elements.tsx
@@ -11,7 +11,7 @@ import { keyBuilder } from '@/ui/use-query-keys/third-parties';
 import { keyBuilder as userKeyBuilder } from '@/ui/use-query-keys/user';
 import { cn } from '@/utils/css-class';
 
-import type { StripeElementsOptions } from '@stripe/stripe-js';
+import type { StripeElementsOptions, StripePaymentElementChangeEvent } from '@stripe/stripe-js';
 import type { TBillingAddress } from '@/api/virtual-lab-svc/queries/types';
 
 export const buildStripeFormOptions = (clientSecret: string): StripeElementsOptions => ({
@@ -149,11 +149,13 @@ export function BillingAddressElement({
 export function BillingCardElement({
   disabled = false,
   framed = true,
+  onChange,
   onReady,
   paymentElementId,
 }: {
   disabled?: boolean;
   framed?: boolean;
+  onChange?: (event: StripePaymentElementChangeEvent) => void;
   onReady: () => void;
   paymentElementId: string;
 }) {
@@ -168,6 +170,7 @@ export function BillingCardElement({
       <PaymentElement
         id={paymentElementId}
         onReady={onReady}
+        onChange={(event) => onChange?.(event)}
         options={{
           fields: {
             billingDetails: 'never',

--- a/src/i18n/en/payment.ts
+++ b/src/i18n/en/payment.ts
@@ -2,6 +2,11 @@ export const messages = {
   paymentProcessingErrorTitle: 'Payment processing error',
   paymentMethodSaveError:
     'We couldn’t save your payment method. Please try again, or use a different card.',
+  paymentProcessingErrorBillingCountryMismatch:
+    'The billing country must match your card’s country. Update your billing address to match your card, then click Pay again.',
+  setupIntentSessionExpired:
+    'This payment session has expired. Please close this window and start the payment process again.',
+  creditsAmountRequired: 'Enter the number of credits you want to purchase.',
   paymentProcessingErrorFallback:
     "We couldn't process your payment. Please check your card details and try again.",
   paymentSuccess: `Successfully purchased $$credits credits for $$price`,


### PR DESCRIPTION
- allow re-using the form even the setup intent is already used
- add error message when the credits input is empty

Related to: https://github.com/openbraininstitute/prod-virtual-lab/issues/354