### PR TITLE
fix(simulate): resolve 404 when launching Simulate from Circuit detail

### DIFF
--- a/src/features/scan-config/workflow/definitions/index.ts
+++ b/src/features/scan-config/workflow/definitions/index.ts
@@ -33,6 +33,7 @@ export { buildEmSynapseMappingWorkflow } from '@/features/scan-config/workflow/d
 export { extractCircuitWorkflow } from '@/features/scan-config/workflow/definitions/extract-circuit';
 export { processEmCellMeshWorkflow } from '@/features/scan-config/workflow/definitions/process-em-cell-mesh';
 export { simulateIonChannelWorkflow } from '@/features/scan-config/workflow/definitions/simulate-ion-channel';
+export { simulateMEModelWithSynapsesCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-me-model-with-synapses-circuit';
 export { simulateMemodelCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-memodel-circuit';
 export { simulateMicrocircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-microcircuit';
 export { simulatePairedNeuronCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-paired-neuron-circuit';

--- a/src/features/scan-config/workflow/definitions/simulate-me-model-with-synapses-circuit.ts
+++ b/src/features/scan-config/workflow/definitions/simulate-me-model-with-synapses-circuit.ts
@@ -1,0 +1,7 @@
+import { resolveSimulationByCampaignId } from '@/entity-configuration/domain/simulation/single-neuron-circuit-simulation';
+import { defineSimulateCircuitScanConfigWorkflow } from '@/features/scan-config/workflow/definitions';
+
+export const simulateMEModelWithSynapsesCircuitWorkflow = defineSimulateCircuitScanConfigWorkflow({
+  id: 'simulate-me-model-with-synapses-circuit',
+  resolve: resolveSimulationByCampaignId,
+});

--- a/src/features/scan-config/workflow/simulate-circuit-workflows.ts
+++ b/src/features/scan-config/workflow/simulate-circuit-workflows.ts
@@ -1,10 +1,13 @@
+import { CircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import { simulateMEModelWithSynapsesCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-me-model-with-synapses-circuit';
 import { simulateMicrocircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-microcircuit';
 import { simulatePairedNeuronCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-paired-neuron-circuit';
 import { simulateRegionCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-region-circuit';
 import { simulateSingleNeuronCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-single-neuron-circuit';
 import { simulateSmallMicrocircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-small-microcircuit';
 
+import type { TCircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit';
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { TScanConfigWorkflowDefinition } from '@/features/scan-config/workflow/types';
 
@@ -15,6 +18,7 @@ export const SIMULATE_CIRCUIT_SOURCE_TYPES = [
   ExtendedEntitiesTypeDict.SmallMicrocircuit,
   ExtendedEntitiesTypeDict.Microcircuit,
   ExtendedEntitiesTypeDict.BrainRegion,
+  ExtendedEntitiesTypeDict.MEModelWithSynapses,
 ] as const;
 
 export type TSimulateCircuitSourceType = (typeof SIMULATE_CIRCUIT_SOURCE_TYPES)[number];
@@ -25,6 +29,7 @@ export const simulateCircuitWorkflowBySourceType = {
   [ExtendedEntitiesTypeDict.SmallMicrocircuit]: simulateSmallMicrocircuitWorkflow,
   [ExtendedEntitiesTypeDict.Microcircuit]: simulateMicrocircuitWorkflow,
   [ExtendedEntitiesTypeDict.BrainRegion]: simulateRegionCircuitWorkflow,
+  [ExtendedEntitiesTypeDict.MEModelWithSynapses]: simulateMEModelWithSynapsesCircuitWorkflow,
 } as const satisfies Record<TSimulateCircuitSourceType, TScanConfigWorkflowDefinition>;
 
 export function isSimulateCircuitSourceType(
@@ -41,4 +46,28 @@ export function getSimulateCircuitWorkflow(
   }
 
   return simulateCircuitWorkflowBySourceType[sourceType];
+}
+
+/**
+ * Maps a base `Circuit` entity's `scale` to its simulate-workflow `dataType`. Used when the user
+ * lands on the base `/data/view/circuit/{id}` detail page (which doesn't carry a scale-specific
+ * extended type) and triggers Simulate.
+ */
+export function getSimulateCircuitSourceTypeByScale(
+  scale: TCircuitScaleDictionary
+): TSimulateCircuitSourceType | null {
+  switch (scale) {
+    case CircuitScaleDictionary.Single:
+      return ExtendedEntitiesTypeDict.MEModelWithSynapses;
+    case CircuitScaleDictionary.PairNeuron:
+      return ExtendedEntitiesTypeDict.PairedNeuronCircuit;
+    case CircuitScaleDictionary.SmallMicrocircuit:
+      return ExtendedEntitiesTypeDict.SmallMicrocircuit;
+    case CircuitScaleDictionary.Microcircuit:
+      return ExtendedEntitiesTypeDict.Microcircuit;
+    case CircuitScaleDictionary.Region:
+      return ExtendedEntitiesTypeDict.BrainRegion;
+    default:
+      return null;
+  }
 }

--- a/src/ui/segments/action-menu.tsx
+++ b/src/ui/segments/action-menu.tsx
@@ -22,8 +22,13 @@ import {
 } from '@/api/entitycore/types/extended-entity-type';
 import { useAppNotification } from '@/components/notification';
 import { config } from '@/config';
-import { WorkspaceScope, WorkspaceSection } from '@/constants';
+import { WorkflowActivityDictValue, WorkspaceScope, WorkspaceSection } from '@/constants';
 import { getEntityByExtendedType } from '@/entity-configuration/domain/helpers';
+import { resolveSimulateConfigureSegment } from '@/features/scan-config/workflow/resolve-configure-segment';
+import {
+  getSimulateCircuitSourceTypeByScale,
+  isSimulateCircuitSourceType,
+} from '@/features/scan-config/workflow/simulate-circuit-workflows';
 import { useCopyToClipboard } from '@/hooks/useCopyClipboard';
 import { downloadArchive } from '@/services/entity-download';
 import Action from '@/ui/molecules/side-menu-action';
@@ -132,6 +137,12 @@ export default function ActionMenu({
       ? entityType.isSimulatable
       : (entityType.isSimulatable as (e: typeof entity) => boolean)(entity);
 
+  const simulateDataType = isSimulateCircuitSourceType(type)
+    ? type
+    : 'scale' in entity
+      ? (getSimulateCircuitSourceTypeByScale((entity as ICircuit).scale) ?? undefined)
+      : undefined;
+
   return (
     <div className="text-primary-9 mt-10 flex flex-col gap-5 px-5 text-base font-bold">
       <Action
@@ -151,10 +162,17 @@ export default function ActionMenu({
           icon={
             <NextLink
               href={{
-                pathname: `${config.ROOT_ROUTE}/${ctx.virtualLabId}/${ctx.projectId}/workflows/simulate/configure/${entityType.type.replaceAll('_', '-')}/${entity.id}`,
+                pathname: `${config.ROOT_ROUTE}/${ctx.virtualLabId}/${ctx.projectId}/workflows/simulate/configure/${resolveSimulateConfigureSegment(
+                  {
+                    section: WorkflowActivityDictValue.simulate,
+                    recordType: entityType.type,
+                    dataType: simulateDataType ?? type,
+                  }
+                )}/${entity.id}`,
                 query: {
                   sessionId: crypto.randomUUID(),
                   [PanelQueryParam]: WorkflowSimulatePanels.Configuration,
+                  ...(simulateDataType ? { dataType: simulateDataType } : {}),
                 },
               }}
             >


### PR DESCRIPTION
## Summary

Clicking **Simulate** on a Circuit detail page (`/app/.../data/view/circuit/{id}`) 404'd because `ActionMenu` built `/workflows/simulate/configure/circuit/{id}` with no `dataType` query — the shared scan-config page factory requires it and otherwise calls `notFound()`. The single-scale "Synaptome (beta)" (MEModelWithSynapses) view 404'd for the same reason plus a missing source-type entry.

## Changes

- **`action-menu.tsx`** — replace the hard-coded `${entityType.type.replaceAll('_','-')}` segment with `resolveSimulateConfigureSegment`, and derive a `dataType` query:
  - If `type` is already a `SIMULATE_CIRCUIT_SOURCE_TYPES` member, use it.
  - Else if the entity has a `scale`, map via the new `getSimulateCircuitSourceTypeByScale` helper.
- **`simulate-circuit-workflows.ts`** — add `MEModelWithSynapses` to `SIMULATE_CIRCUIT_SOURCE_TYPES` and `simulateCircuitWorkflowBySourceType`; add `getSimulateCircuitSourceTypeByScale(scale)` mapping CircuitScale → source type.
- **`definitions/simulate-me-model-with-synapses-circuit.ts`** (new) — workflow definition reusing `resolveSimulationByCampaignId`.
- **`definitions/index.ts`** — re-export the new workflow.

Entity-driven schema resolution (`getSupportedEntityTypesForScanConfiguration` + `useGenericSchemaName`) already maps a single-scale Circuit to the MEModelWithSynapses schema, so no editor changes were needed.

## Test plan

- [x] Click **Simulate** on circuits of each scale (Small, Microcircuit, Pair, Region) — configure page renders, URL has the matching `dataType`.
- [x] Click **Simulate** on a single-scale Circuit detail — lands on configure page with `dataType=me_model_with_synapses` and renders the synaptome schema.
- [x] Click **Simulate** on the SingleNeuronCircuit view of the same entity — renders the same schema (entity-driven).
- [x] Smoke-test Memodel / SingleNeuronSynaptome Simulate — URLs unchanged, still load.

***

## TODO
We have redundant definitions: `MEModelWithSynapses` and `SingleNeuronCircuit` which are backed by Circuit entity of scale `single`. These have to be merged - I'll submit a separate PR for that.