### PR TITLE
ci(release): allow dispatch from hotfix/* branches

### DIFF
--- a/.github/workflows/release-aws.yml
+++ b/.github/workflows/release-aws.yml
@@ -13,10 +13,13 @@ jobs:
     env:
       IMAGE_NAME: ${{ vars.PUBLICECR_URI }}
     steps:
-      - name: Fail if branch is not main
-        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+      - name: Fail if branch is not main or a hotfix/* branch
+        if: >-
+          github.event_name == 'workflow_dispatch'
+          && github.ref != 'refs/heads/main'
+          && !startsWith(github.ref, 'refs/heads/hotfix/')
         run: |
-          echo "This workflow should not be triggered with workflow_dispatch on a branch other than main"
+          echo "This workflow must be dispatched from main or a hotfix/* branch."
           exit 1
 
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Relax the branch guard in `release-aws.yml` so the release workflow can be dispatched on a `hotfix/*` branch in addition to `main`. Enables shipping a targeted fix without pulling in newer commits from `main`.

## How it works

`actions/checkout` already follows `github.ref`, so dispatching the workflow on a `hotfix/*` branch means the tag, image, and GitHub Release all land on the hotfix commit. No other workflow logic changes.

## Hotfix flow after this lands

1. `git checkout -b hotfix/<name> <last-released-tag>` and push the fix.
2. (Optional) Open a PR to get a preview deploy and validate.
3. Actions → **Make release** → **Run workflow** → select the `hotfix/<name>` branch.
4. Workflow tags that commit `YYYY.MM.DD.N`, builds, pushes to ECR, creates the GitHub Release.
5. Merge the hotfix PR back to `main` as a follow-up so the fix lands on the trunk.