### PR TITLE
fix(circuit-nodes): avoid h5wasm slice() on variable-length string columns

### DIFF
--- a/src/features/circuit-nodes/worker/nodes-h5.ts
+++ b/src/features/circuit-nodes/worker/nodes-h5.ts
@@ -409,7 +409,7 @@ export class NodesSession {
       return out;
     }
 
-    if (!useGather && !this.loaded.has(name)) {
+    if (!useGather && !this.loaded.has(name) && !isVariableLengthString(handle)) {
       const sliced = handle.dataset.slice([[sliceStart, sliceEnd]]);
       return decodeSliceForPage(handle, sliced);
     }
@@ -439,6 +439,13 @@ export class NodesSession {
     }
     return out;
   }
+}
+
+function isVariableLengthString(handle: ColumnHandle): boolean {
+  // h5wasm reports variable-length strings as "S" (no size suffix) and
+  // fixed-length strings as "S<n>". Dataset.slice() aborts on vlen strings,
+  // so route them through the full-column path (Dataset.value), which works.
+  return handle.kind === 'string' && handle.dtype === 'S';
 }
 
 function range(start: number, end: number): number[] {


### PR DESCRIPTION
## Problem
For circuits whose virtual populations store `morphology` / `me_combo` as variable-length UTF-8 strings (HDF5 `H5T_STRING { STRSIZE H5T_VARIABLE }`), every cell in the nodes table was empty even though the row count was correct.

## Root cause
`h5wasm@0.7.9` (and current `0.10.2`) aborts with `RuntimeError: memory access out of bounds` when `Dataset.slice()` is called on a vlen string column. The nodes worker takes the narrow-slice fast path on cold cache, so the failure rejected `getRows` and ag-grid kept rendering placeholder rows.

There is no issue corresponding to this bug in the h5was repo. To be investigated later.

Reproduces standalone:

\`\`\`js
const ds = file.get('nodes/external_S1nonbarrel_neurons/0/morphology'); // dtype "S"
ds.value;          // all strings
ds.slice([[0,3]]); // aborts
\`\`\`

## Fix
`src/features/circuit-nodes/worker/nodes-h5.ts` — skip the narrow-slice fast path for vlen string columns (`kind === 'string' && dtype === 'S'`) and fall through to the existing `loadColumn` path (`Dataset.value` + LRU cache). Non-string and fixed-length string columns are unchanged.

## Verified
- `external_S1nonbarrel_neurons (virtual)` — 1,203 rows, all columns populated (Region, Layer, Mtype, Etype, Morphology, Me combo, X/Y/Z, dynamics_params/*).
- `POm (virtual)` — 21 rows, X/Y/Z and Model type populated.
- `S1nonbarrel_neurons (biophysical)` — still renders correctly.
- Repro: paired-neuron-circuit-simulation workflow → Table view → Population dropdown.

## Performance
First request per vlen string column reads the full column instead of a 200-row slice (cached afterwards). For the failing population (1,203 rows × 2 vlen columns) ≈ a few hundred KB — imperceptible. Worst-case scaling (~1M-row populations with long string fields) would be a couple of hundred MB resident; not a regression because `slice()` does not work for these columns in any tested h5wasm version, so the trade-off is "full column read" vs "no data shown".