### PR TITLE
fix(circuit-download): make assetPath optional in presigned-url schema

### DIFF
--- a/src/app/api/entity-download/presigned-url/route.ts
+++ b/src/app/api/entity-download/presigned-url/route.ts
@@ -13,7 +13,7 @@ const querySchema = z.object({
   virtualLabId: z.uuid(),
   projectId: z.uuid(),
   configAssetId: z.uuid(),
-  assetPath: z.string().min(1),
+  assetPath: z.string().min(1).optional(),
 });
 
 export async function GET(request: NextRequest) {


### PR DESCRIPTION
## Summary
- Regression introduced in #1691: the new zod schema on `/api/entity-download/presigned-url` required `assetPath` as a non-empty string, breaking every caller that downloads a whole asset (no sub-path).
- Mark `assetPath` as `.optional()` so whole-asset downloads pass; `.min(1)` still rejects empty strings from path-based callers.

## Root cause
`src/app/api/entity-download/presigned-url/route.ts` — `assetPath: z.string().min(1)`. Client (`pre-singed-url.ts`) and downstream `downloadAsset` both treat the field as optional, and several call sites omit it intentionally:
- `entire-circuit-export.tsx` (reported)
- `ion-channel-build/sections/file-viewer.tsx`, `output.tsx`
- `scan-config/components/model-preview/ion-channel-figure-viewer.tsx`

## Fix
```diff
- assetPath: z.string().min(1),
+ assetPath: z.string().min(1).optional(),
```

## Test plan
- [x] Explore → open a circuit → Download panel → "Download full circuit" opens the presigned URL without a 400.
- [x] Same panel → download a single config file (e.g. `circuit_config.json`) still works (path-based branch).
- [x] Ion-channel build output / figure viewer pages load without 400s on `/api/entity-download/presigned-url`.