### PR TITLE
feat(simulations): support LearningEngine (INAIT) circuit simulations

### DIFF
--- a/src/api/entitycore/types/entities/circuit.ts
+++ b/src/api/entitycore/types/entities/circuit.ts
@@ -74,7 +74,7 @@ export type TCircuitScaleDictionary =
 export type TCircuitBuildCategoryDictionary =
   (typeof CircuitBuildCategory)[keyof typeof CircuitBuildCategory]['key'];
 
-export type TCircuitTargetSimulator = 'NEURON' | 'Brian2';
+export type TCircuitTargetSimulator = 'NEURON' | 'Brian2' | 'LearningEngine';
 
 interface CircuitBase {
   description: string;

--- a/src/entity-configuration/domain/model/circuit.ts
+++ b/src/entity-configuration/domain/model/circuit.ts
@@ -70,16 +70,18 @@ export const Circuit: EntityCoreTypeConfig<ICircuit> = {
   isDownloadable: true,
   isCopyable: true,
   isSimulatable: (entity: ICircuit) =>
-    entity.has_electrical_cell_models &&
-    includes(
-      [
-        CircuitScaleDictionary.Single,
-        CircuitScaleDictionary.PairNeuron,
-        CircuitScaleDictionary.SmallMicrocircuit,
-        CircuitScaleDictionary.Microcircuit,
-        CircuitScaleDictionary.Region,
-        CircuitScaleDictionary.WholeBrain,
-      ],
-      entity.scale
-    ),
+    // LearningEngine (INAIT) circuits are simulatable regardless of biophysical models.
+    entity.target_simulator === 'LearningEngine' ||
+    (entity.has_electrical_cell_models &&
+      includes(
+        [
+          CircuitScaleDictionary.Single,
+          CircuitScaleDictionary.PairNeuron,
+          CircuitScaleDictionary.SmallMicrocircuit,
+          CircuitScaleDictionary.Microcircuit,
+          CircuitScaleDictionary.Region,
+          CircuitScaleDictionary.WholeBrain,
+        ],
+        entity.scale
+      )),
 } as const;

--- a/src/features/feature-flags/flags.ts
+++ b/src/features/feature-flags/flags.ts
@@ -32,7 +32,7 @@ export const wholeBrainSimulationFlag = defineFlag<boolean>({
   key: 'whole-brain-simulation',
   defaultValue: false,
   values: [true, false],
-  description: 'Whole brain / Brian2 FlyWire simulations',
+  description: 'Whole brain simulations',
   visible: () => ['local', 'preview'].includes(config.DEPLOYMENT_ENV),
 });
 

--- a/src/features/scan-config/components/hooks/use-scan-configuration.ts
+++ b/src/features/scan-config/components/hooks/use-scan-configuration.ts
@@ -35,7 +35,9 @@ import {
 } from '@/features/scan-config/types';
 import { resolvePrimaryEntityIdFromConfigForm } from '@/features/scan-config/workflow/workflow-schema-selection';
 import {
+  buildGeneratedApiUrl,
   resolveScanConfigFromRegistry,
+  resolveSimulatorScanConfigOverride,
   type TScanConfigRegistryConfig,
 } from '@/ui/segments/workflows/config/scan-config-binding';
 
@@ -107,16 +109,20 @@ export function useScanConfiguration({
 }: TUseScanConfigurationParams): TUseScanConfigurationResult {
   const registryResolved = useMemo(() => resolveScanConfigFromRegistry(scanConfig), [scanConfig]);
 
-  const { schema, isLoading: loadingSchema } = useObioneJsonSchema({
-    schemaName: registryResolved.schemaName,
+  // When the entity id must be extracted from a saved config form, we need a schema to do so.
+  // Use the descriptor's default schema for that extraction — the circuit reference shape is the
+  // same across circuit-simulation schemas, so it resolves the primary entity id regardless.
+  const needsFormEntityId = !entityFromProps && !entityId && !!initialConfig;
+  const { schema: formSchema } = useObioneJsonSchema({
+    schemaName: needsFormEntityId ? registryResolved.schemaName : undefined,
   });
 
   const entityIdFromForm = useMemo(
     () =>
-      schema && initialConfig
-        ? resolvePrimaryEntityIdFromConfigForm(schema, initialConfig)
+      formSchema && initialConfig
+        ? resolvePrimaryEntityIdFromConfigForm(formSchema, initialConfig)
         : undefined,
-    [initialConfig, schema]
+    [initialConfig, formSchema]
   );
 
   const effectiveEntityId = entityId ?? entityIdFromForm;
@@ -134,6 +140,22 @@ export function useScanConfiguration({
   const entity = entityFromProps ?? fetchedEntity;
   const isEntityLoading = shouldFetchEntity && loadingEntity;
 
+  // Select the circuit-simulation generation endpoint + schema from the circuit's
+  // `target_simulator` (Brian2 / LearningEngine), falling back to the descriptor default.
+  const simulatorOverride = useMemo(() => {
+    const targetSimulator = entity && 'target_simulator' in entity ? entity.target_simulator : null;
+    return resolveSimulatorScanConfigOverride(targetSimulator);
+  }, [entity]);
+
+  const effectiveSchemaName = simulatorOverride?.schemaName ?? registryResolved.schemaName;
+  const effectiveEndpoint = simulatorOverride
+    ? buildGeneratedApiUrl(simulatorOverride.generatedApiPath)
+    : registryResolved.generatedEndpoint;
+
+  const { schema, isLoading: loadingSchema } = useObioneJsonSchema({
+    schemaName: effectiveSchemaName,
+  });
+
   const resolved = useMemo(() => {
     if (isEntityLoading && !entity) {
       return null;
@@ -144,11 +166,11 @@ export function useScanConfiguration({
     return {
       usedType: registryResolved.entityType,
       entityConfig,
-      endpoint: registryResolved.generatedEndpoint,
-      schemaName: registryResolved.schemaName,
+      endpoint: effectiveEndpoint,
+      schemaName: effectiveSchemaName,
       effectiveSchemaMappingKey: registryResolved.schemaMappingKey,
     };
-  }, [entity, isEntityLoading, registryResolved]);
+  }, [entity, isEntityLoading, registryResolved, effectiveEndpoint, effectiveSchemaName]);
 
   const property_endpoints = resolved?.effectiveSchemaMappingKey
     ? get(schema?.property_endpoints, resolved.effectiveSchemaMappingKey, '')

--- a/src/features/scan-config/types.ts
+++ b/src/features/scan-config/types.ts
@@ -109,6 +109,7 @@ export const SchemaNameDict = {
   // simulation
   CircuitSimulationScanConfig: 'CircuitSimulationScanConfig',
   Brian2CircuitSimulationScanConfig: 'Brian2CircuitSimulationScanConfig',
+  LearningEngineCircuitSimulationScanConfig: 'LearningEngineCircuitSimulationScanConfig',
   MEModelSimulationScanConfig: 'MEModelSimulationScanConfig',
   MEModelWithSynapsesCircuitSimulationScanConfig: 'MEModelWithSynapsesCircuitSimulationScanConfig',
   IonChannelModelSimulationScanConfig: 'IonChannelModelSimulationScanConfig',

--- a/src/features/scan-config/use-cases/simulations/results.tsx
+++ b/src/features/scan-config/use-cases/simulations/results.tsx
@@ -308,7 +308,12 @@ export default function SimulationsTab({
   };
 
   const scale = get(model, 'scale', null);
-  const shouldTreatSimulationAsTask = scale !== null && TASK_LAUNCH_SCALES.has(scale);
+  const targetSimulator = get(model, 'target_simulator', null);
+  // Circuits targeting an external simulator (Brian2 / LearningEngine) always launch through the
+  // task system (obi-one `/declared/task/launch`), independent of scale.
+  const isExternalSimulator = targetSimulator === 'Brian2' || targetSimulator === 'LearningEngine';
+  const shouldTreatSimulationAsTask =
+    isExternalSimulator || (scale !== null && TASK_LAUNCH_SCALES.has(scale));
 
   // TODO Refactor
   const run = async (simIds: string[]) => {

--- a/src/ui/segments/workflows/config/activities/simulate.ts
+++ b/src/ui/segments/workflows/config/activities/simulate.ts
@@ -14,7 +14,7 @@ import {
   circuitSimulationConfigureBinding,
   ionChannelSimulationConfigureBinding,
   memodelCircuitSimulationConfigureBinding,
-  wholeBrainBrian2SimulationConfigureBinding,
+  wholeBrainCircuitSimulationConfigureBinding,
 } from '../scan-config-binding';
 import { WorkflowBrowseDefaults, WorkflowStagePresets } from '../types';
 
@@ -246,8 +246,9 @@ export const SimulateWorkflows: readonly IWorkflowDescriptor[] = [
     },
     scanConfig: {
       definition: simulateWholeBrainCircuitWorkflow,
-      schemaName: SchemaNameDict.Brian2CircuitSimulationScanConfig,
-      configureBinding: wholeBrainBrian2SimulationConfigureBinding(),
+      // Default schema/endpoint; Brian2 is selected from `target_simulator` at configure time.
+      schemaName: SchemaNameDict.CircuitSimulationScanConfig,
+      configureBinding: wholeBrainCircuitSimulationConfigureBinding(),
     },
     configurationInputs: [{ type: ExtendedEntitiesTypeDict.WholeBrain }],
     requiredFeatures: [wholeBrainSimulationFlag.key],

--- a/src/ui/segments/workflows/config/scan-config-binding.ts
+++ b/src/ui/segments/workflows/config/scan-config-binding.ts
@@ -1,7 +1,8 @@
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { config as appConfig } from '@/config';
-import { SchemaMappingKeyDict } from '@/features/scan-config/types';
+import { SchemaMappingKeyDict, SchemaNameDict } from '@/features/scan-config/types';
 
+import type { TCircuitTargetSimulator } from '@/api/entitycore/types/entities/circuit';
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type {
   SchemaName,
@@ -24,6 +25,7 @@ export type TScanConfigFromIdType =
 export const ScanConfigGeneratedApiPath = {
   CircuitSimulation: 'circuit-simulation-scan-config-generate-grid',
   Brian2CircuitSimulation: 'brian-2-circuit-simulation-scan-config-generate-grid',
+  LearningEngineCircuitSimulation: 'learning-engine-circuit-simulation-scan-config-generate-grid',
   MEModelWithSynapsesCircuitSimulation:
     'me-model-with-synapses-circuit-simulation-scan-config-generate-grid',
   MEModelSimulation: 'me-model-simulation-scan-config-generate-grid',
@@ -61,8 +63,37 @@ export function resolveScanConfigFromIdType(
   return binding.fromIdTypeByBrowseType[browseType];
 }
 
+export function buildGeneratedApiUrl(generatedApiPath: string): string {
+  return `${appConfig.OBI_ONE_URL}/generated/${generatedApiPath}`;
+}
+
 export function resolveScanConfigGeneratedApiUrl(binding: TScanConfigConfigureBinding): string {
-  return `${appConfig.OBI_ONE_URL}/generated/${binding.generatedApiPath}`;
+  return buildGeneratedApiUrl(binding.generatedApiPath);
+}
+
+/**
+ * Data-driven selection of the circuit-simulation generation endpoint + schema by the
+ * circuit's `target_simulator`. Returns `null` for `NEURON`/`null` (use the descriptor default).
+ * This is what lets a single scale-based simulate workflow target the Brian2 or
+ * LearningEngine (INAIT) obi-one endpoint without scale-pinned descriptors.
+ */
+export function resolveSimulatorScanConfigOverride(
+  targetSimulator: TCircuitTargetSimulator | null | undefined
+): { generatedApiPath: string; schemaName: SchemaName } | null {
+  switch (targetSimulator) {
+    case 'Brian2':
+      return {
+        generatedApiPath: ScanConfigGeneratedApiPath.Brian2CircuitSimulation,
+        schemaName: SchemaNameDict.Brian2CircuitSimulationScanConfig,
+      };
+    case 'LearningEngine':
+      return {
+        generatedApiPath: ScanConfigGeneratedApiPath.LearningEngineCircuitSimulation,
+        schemaName: SchemaNameDict.LearningEngineCircuitSimulationScanConfig,
+      };
+    default:
+      return null;
+  }
 }
 
 /** Workflow registry scan-config entry — single source for configure resolution. */
@@ -166,14 +197,17 @@ export function buildEmSynapseMappingConfigureBinding(): TScanConfigConfigureBin
   };
 }
 
-export function wholeBrainBrian2SimulationConfigureBinding(): TScanConfigConfigureBinding {
+export function wholeBrainCircuitSimulationConfigureBinding(): TScanConfigConfigureBinding {
   return {
     browseType: ExtendedEntitiesTypeDict.WholeBrain,
     scanConfigEntityType: ExtendedEntitiesTypeDict.WholeBrain,
     fromIdTypeByBrowseType: {
       [ExtendedEntitiesTypeDict.WholeBrain]: ScanConfigFromIdType.CircuitFromID,
     },
-    generatedApiPath: ScanConfigGeneratedApiPath.Brian2CircuitSimulation,
+    // Generic circuit-simulation endpoint/schema by default; the actual endpoint
+    // (e.g. Brian2) is selected from the circuit's `target_simulator` at configure time
+    // via `resolveSimulatorScanConfigOverride`.
+    generatedApiPath: ScanConfigGeneratedApiPath.CircuitSimulation,
     schemaMappingKey: SchemaMappingKeyDict.Circuit,
   };
 }


### PR DESCRIPTION
## What

Adds frontend support for simulating circuits with `target_simulator === 'LearningEngine'` (INAIT), and refactors the FlyWire Brian2 routing so the generation endpoint/schema is chosen by **`target_simulator`** rather than by circuit **scale**.

Ref: openbraininstitute/prod-circuit-simulation#201

## How

- **Data-driven endpoint selection.** New `resolveSimulatorScanConfigOverride(target_simulator)` maps `Brian2` and `LearningEngine` to their obi-one generated endpoint + scan-config schema, falling back to the descriptor default for `NEURON`/`null`. Applied in `useScanConfiguration` once the circuit entity loads.
- **Whole-brain descriptor reverted to the generic circuit binding/schema** — Brian2 is now supplied by the override, not pinned to the `WholeBrain` scale.
- **LearningEngine circuits are simulatable** regardless of biophysical cell models.
- **Launch:** external simulators (Brian2/LearningEngine) route through the task system regardless of scale, via the generic `circuit_simulation` task type.
- **Flag:** `wholeBrainSimulationFlag` kept; description renamed to `'Whole brain simulations'`.

## Changes

| File | Change |
|------|--------|
| `api/entitycore/types/entities/circuit.ts` | widen `TCircuitTargetSimulator` with `'LearningEngine'` |
| `features/scan-config/types.ts` | add `LearningEngineCircuitSimulationScanConfig` schema name |
| `ui/segments/workflows/config/scan-config-binding.ts` | LE generated API path + `resolveSimulatorScanConfigOverride`; generic whole-brain binding |
| `features/scan-config/components/hooks/use-scan-configuration.ts` | apply override → effective schema + endpoint |
| `entity-configuration/domain/model/circuit.ts` | LE circuits simulatable regardless of cell models |
| `ui/segments/workflows/config/activities/simulate.ts` | whole-brain descriptor → generic circuit binding/schema |
| `features/scan-config/use-cases/simulations/results.tsx` | launch external simulators via task system at any scale |
| `features/feature-flags/flags.ts` | rename flag description |

## Verification

- [x] Open a `LearningEngine` circuit → Simulate button appears, form renders `LearningEngineCircuitSimulationScanConfig`, Generate POSTs to `/generated/learning-engine-circuit-simulation-scan-config-generate-grid`.
- [x] Launch posts to `/declared/task/launch` with `task_type: 'circuit_simulation'`; spike raster renders; campaign appears in Data + Workflows table.
- [x] **Regression:** Brian2 whole-brain circuit still resolves to the Brian2 endpoint/schema via the override; NEURON circuits still use the generic endpoint.
