### PR TITLE
fix(circuit-download): consistent empty-state for electrical models / mechanisms

### DIFF
--- a/src/ui/segments/explore/circuit/elements/download-panel/components-config.tsx
+++ b/src/ui/segments/explore/circuit/elements/download-panel/components-config.tsx
@@ -179,7 +179,7 @@ export default function ComponentsConfig({ circuit }: { circuit: ICircuit }) {
             mimeType={electricalModelsContentConfiguration.mimeType}
             entries={electricalEntries}
             archiveBaseName={(e) => e.label || 'electrical-models'}
-            emptyMessage="No electrical models directory in this circuit."
+            emptyMessage="No electrical models in this circuit."
             downloadConfig={{
               entityId: circuit.id,
               assetConfigId: configAssetId,
@@ -192,7 +192,7 @@ export default function ComponentsConfig({ circuit }: { circuit: ICircuit }) {
             mimeType={mechanismsContentConfiguration.mimeType}
             entries={mechanismsEntry ? [mechanismsEntry] : []}
             archiveBaseName={() => 'mechanisms'}
-            emptyMessage="No mechanisms directory in this circuit."
+            emptyMessage="No mechanisms in this circuit."
             downloadConfig={{
               entityId: circuit.id,
               assetConfigId: configAssetId,

--- a/src/ui/segments/explore/circuit/elements/download-panel/helpers.ts
+++ b/src/ui/segments/explore/circuit/elements/download-panel/helpers.ts
@@ -280,7 +280,7 @@ export function buildElectricalModelsEntries(
   const seenPrefixes = new Set<string>();
   for (const raw of candidates) {
     const entry = buildFolderEntry(raw, config.manifest, directory);
-    if (entry && !seenPrefixes.has(entry.prefix)) {
+    if (entry && entry.fileCount > 0 && !seenPrefixes.has(entry.prefix)) {
       seenPrefixes.add(entry.prefix);
       entries.push(entry);
     }


### PR DESCRIPTION
## Problem

Anatomical circuits (e.g. MICrONS, H01) have no `.hoc`/`.mod` files, but the **Electrical models** and **Mechanisms** download sections rendered their empty state differently:

- **Electrical models** kept a `FolderEntry` with `fileCount: 0` → greyed-out `.tar.gz` row.
- **Mechanisms** dropped empty directories → "No … in this circuit." message.

Reported in [prod-explore-functionality#495 (comment)](https://github.com/openbraininstitute/prod-explore-functionality/issues/495#issuecomment-4668008244).

## Fix

- `buildElectricalModelsEntries` now drops directories with no files (`fileCount > 0` guard), mirroring `buildMechanismsEntry`, so both sections fall through to the empty message.
- Reworded both empty messages to omit "directory" (the directory may exist but be empty): `"No electrical models in this circuit."` / `"No mechanisms in this circuit."`

## Changes

- `download-panel/helpers.ts`
- `download-panel/components-config.tsx`
