### PR TITLE
fix(circuit-nodes): resolve all SONATA manifest variables in config paths

### DIFF
--- a/src/features/circuit-nodes/hooks/use-circuit-config.ts
+++ b/src/features/circuit-nodes/hooks/use-circuit-config.ts
@@ -5,6 +5,7 @@ import { downloadAsset } from '@/api/entitycore/queries/assets';
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { AssetLabel } from '@/api/entitycore/types/shared/global';
 import { useWorkspace } from '@/ui/hooks/use-workspace';
+import { resolveManifestPath } from '@/utils/circuit-manifest';
 
 import type {
   ICircuit,
@@ -18,34 +19,21 @@ import type {
 
 const CIRCUIT_CONFIG_PATH = 'circuit_config.json';
 
-function resolveBase(manifest: Record<string, string> | undefined): string {
-  const base = manifest?.$BASE_DIR ?? './';
-  return base === './' || base === '.' ? '' : base.replace(/\/$/, '');
-}
-
-function stripBase(file: string, base: string): string {
-  if (!file) return file;
-  if (file.startsWith('$BASE_DIR/')) return file.slice('$BASE_DIR/'.length);
-  if (base && file.startsWith(`${base}/`)) return file.slice(base.length + 1);
-  return file;
-}
-
 function parseSonataConfig(
   raw: ICircuitSonataConfiguration,
   circuitAssetId: string
 ): ParsedCircuitConfig {
-  const base = resolveBase(raw.manifest);
   const nodes: NodePopulation[] = [];
   const edges: EdgePopulation[] = [];
 
   for (const entry of raw.networks?.nodes ?? []) {
-    const file = stripBase(entry.nodes_file ?? '', base);
+    const file = resolveManifestPath(entry.nodes_file ?? '', raw.manifest);
     for (const [name, pop] of Object.entries(entry.populations ?? {})) {
       nodes.push({ name, type: pop.type, file });
     }
   }
   for (const entry of raw.networks?.edges ?? []) {
-    const file = stripBase(entry.edges_file ?? '', base);
+    const file = resolveManifestPath(entry.edges_file ?? '', raw.manifest);
     for (const [name, pop] of Object.entries(entry.populations ?? {})) {
       edges.push({ name, type: pop.type, file });
     }

--- a/src/features/scan-config/components/model-preview/viewer-layout/circuit-loader/circuit-config.ts
+++ b/src/features/scan-config/components/model-preview/viewer-layout/circuit-loader/circuit-config.ts
@@ -1,4 +1,5 @@
 import { assertType } from '@/util/type-guards';
+import { normalizeRelativePath, resolveManifestPath } from '@/utils/circuit-manifest';
 
 import type { ICircuitSonataConfiguration } from '@/api/entitycore/types/entities/circuit';
 
@@ -25,30 +26,7 @@ export class CircuitConfig {
   }
 
   private resolvePath(path: string) {
-    const manifest = this.config.manifest ?? {};
-    const parts = (path ?? '')
-      .split('/')
-      .map((part) => {
-        const value = manifest[part];
-        return value ? value : part;
-      })
-      .join('/')
-      .split('/')
-      .filter((item) => !!item);
-    const result: string[] = [];
-    for (const part of parts) {
-      if (typeof part !== 'string' || part.trim().length === 0 || part === '.') continue;
-
-      if (part === '..') {
-        if (result.length > 0) {
-          result.pop();
-        }
-        continue;
-      }
-
-      result.push(part);
-    }
-    return result.join('/');
+    return normalizeRelativePath(resolveManifestPath(path ?? '', this.config.manifest));
   }
 }
 

--- a/src/ui/segments/explore/circuit/elements/download-panel/helpers.ts
+++ b/src/ui/segments/explore/circuit/elements/download-panel/helpers.ts
@@ -1,9 +1,6 @@
-import escapeRegExp from 'es-toolkit/compat/escapeRegExp';
 import get from 'es-toolkit/compat/get';
 import has from 'es-toolkit/compat/has';
-import isEmpty from 'es-toolkit/compat/isEmpty';
 import map from 'es-toolkit/compat/map';
-import reduce from 'es-toolkit/compat/reduce';
 import sumBy from 'es-toolkit/compat/sumBy';
 import toPairs from 'es-toolkit/compat/toPairs';
 import values from 'es-toolkit/compat/values';
@@ -13,6 +10,7 @@ import { atomFamily } from 'jotai-family';
 import { downloadAsset, listDirectoryOfAssets } from '@/api/entitycore/queries/assets';
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { EmptyValue } from '@/entity-configuration/definitions/renderer';
+import { resolveManifestPath as getAssetPath } from '@/utils/circuit-manifest';
 
 import type {
   CircuitConnectivityMatricesConfiguration,
@@ -137,45 +135,8 @@ export function buildNetworksConfig(
   };
 }
 
-export function getAssetPath(path: string, manifest?: Record<string, string>): string {
-  if (!manifest || isEmpty(manifest)) {
-    return sanitizePath(path);
-  }
-
-  let resolvedPath = path;
-  const maxIterations = 50; // Prevent infinite loops
-  let iteration = 0;
-
-  // Keep replacing variables until no more variables exist or max iterations reached
-  while (resolvedPath.includes('$') && iteration < maxIterations) {
-    const previousPath = resolvedPath;
-
-    // Use  es-toolkit's reduce for efficient variable replacement
-    resolvedPath = reduce(
-      manifest,
-      (currentPath, value, key) => {
-        // Use global regex replace for all occurrences
-        return currentPath.replace(new RegExp(escapeRegExp(key), 'g'), value);
-      },
-      resolvedPath
-    );
-
-    // Break if no changes were made (no more replacements possible)
-    if (previousPath === resolvedPath) {
-      break;
-    }
-
-    iteration++;
-  }
-
-  return sanitizePath(resolvedPath);
-}
-
-function sanitizePath(path: string): string {
-  let sanitized = path.replace(/^\.\//, ''); // Remove leading ./
-  sanitized = sanitized.replace(/^\/+/, ''); // Remove leading slashes
-  return sanitized;
-}
+// Re-exported from the shared resolver so existing call sites keep importing `getAssetPath`.
+export { getAssetPath };
 
 export type ConfigurationFileItem = {
   path: string;

--- a/src/utils/circuit-manifest.nodetest.ts
+++ b/src/utils/circuit-manifest.nodetest.ts
@@ -1,0 +1,75 @@
+// Block-scoped so the `require`-based bindings don't collide with other
+// global-script *.nodetest.ts files (e.g. assets.nodetest.ts). Uses `require`
+// (not ESM import) because node --experimental-strip-types runs this as
+// CommonJS and resolves the explicit `.ts` extension.
+{
+  const assert: typeof import('node:assert/strict') = require('node:assert/strict');
+  const test: typeof import('node:test') = require('node:test');
+  const { resolveManifestPath, normalizeRelativePath }: typeof import('./circuit-manifest') =
+    require('./circuit-manifest.ts');
+
+  const { describe, it } = test;
+
+  const MANIFEST = {
+    $BASE_DIR: '.',
+    $COMPONENTS_DIR: '$BASE_DIR/components',
+    $NETWORK_NODES_DIR: '$BASE_DIR/networks/nodes',
+    $NETWORK_EDGES_DIR: '$BASE_DIR/networks/edges/functional',
+  } as const;
+
+  describe('resolveManifestPath', () => {
+    it('resolves a nested node variable to a clean relative path', () => {
+      assert.equal(
+        resolveManifestPath('$NETWORK_NODES_DIR/hippocampus_neurons/nodes.h5', MANIFEST),
+        'networks/nodes/hippocampus_neurons/nodes.h5'
+      );
+    });
+
+    it('resolves a nested edge variable', () => {
+      assert.equal(
+        resolveManifestPath(
+          '$NETWORK_EDGES_DIR/CA3_projections__hippocampus_neurons__chemical_synapse/edges.h5',
+          MANIFEST
+        ),
+        'networks/edges/functional/CA3_projections__hippocampus_neurons__chemical_synapse/edges.h5'
+      );
+    });
+
+    it('resolves $BASE_DIR = "." away to an empty prefix', () => {
+      assert.equal(resolveManifestPath('$COMPONENTS_DIR/x.h5', MANIFEST), 'components/x.h5');
+    });
+
+    it('sanitizes only when the manifest is empty', () => {
+      assert.equal(resolveManifestPath('./a/b.h5', {}), 'a/b.h5');
+    });
+
+    it('sanitizes only when the manifest is undefined', () => {
+      assert.equal(resolveManifestPath('/a/b.h5'), 'a/b.h5');
+    });
+
+    it('strips a leading ./ and leading slashes', () => {
+      assert.equal(resolveManifestPath('.//a/b.h5', MANIFEST), 'a/b.h5');
+    });
+
+    it('terminates on a cyclic manifest without hanging', () => {
+      const cyclic = { $A: '$B/a', $B: '$A/b' };
+      // Should not throw or loop forever; exact output is unspecified but bounded.
+      const result = resolveManifestPath('$A/file.h5', cyclic);
+      assert.equal(typeof result, 'string');
+    });
+  });
+
+  describe('normalizeRelativePath', () => {
+    it('collapses . and .. segments', () => {
+      assert.equal(normalizeRelativePath('a/./b/../c'), 'a/c');
+    });
+
+    it('drops leading ./ and empty segments', () => {
+      assert.equal(normalizeRelativePath('.//a//b'), 'a/b');
+    });
+
+    it('treats a leading .. with nothing to pop as a no-op', () => {
+      assert.equal(normalizeRelativePath('../a/b'), 'a/b');
+    });
+  });
+}

--- a/src/utils/circuit-manifest.nodetest.ts
+++ b/src/utils/circuit-manifest.nodetest.ts
@@ -57,6 +57,36 @@
       const result = resolveManifestPath('$A/file.h5', cyclic);
       assert.equal(typeof result, 'string');
     });
+
+    // Manifests where one variable's value references another variable, and
+    // where a short key (`$NETWORK`) is a prefix of a longer one
+    // (`$NETWORK_NODES_DIR`). Matching whole `$VAR` tokens must resolve these
+    // without the prefix corrupting the longer key.
+    const NESTED_MANIFEST = {
+      $BASE_DIR: '.',
+      $COMPONENTS_DIR: '$BASE_DIR/components',
+      $NETWORK: '$BASE_DIR/networks',
+      $NETWORK_NODES_DIR: '$NETWORK/nodes',
+      $NETWORK_EDGES_DIR: '$NETWORK/edges/functional',
+    } as const;
+
+    it('resolves transitive variable references (nodes)', () => {
+      assert.equal(
+        resolveManifestPath('$NETWORK_NODES_DIR/hippocampus_neurons/nodes.h5', NESTED_MANIFEST),
+        'networks/nodes/hippocampus_neurons/nodes.h5'
+      );
+    });
+
+    it('resolves transitive variable references (edges)', () => {
+      assert.equal(
+        resolveManifestPath('$NETWORK_EDGES_DIR/foo/edges.h5', NESTED_MANIFEST),
+        'networks/edges/functional/foo/edges.h5'
+      );
+    });
+
+    it('does not let a prefix key collide with a sibling', () => {
+      assert.equal(resolveManifestPath('$COMPONENTS_DIR/x.h5', NESTED_MANIFEST), 'components/x.h5');
+    });
   });
 
   describe('normalizeRelativePath', () => {

--- a/src/utils/circuit-manifest.ts
+++ b/src/utils/circuit-manifest.ts
@@ -1,0 +1,73 @@
+import escapeRegExp from 'es-toolkit/compat/escapeRegExp';
+import isEmpty from 'es-toolkit/compat/isEmpty';
+import reduce from 'es-toolkit/compat/reduce';
+
+function sanitizePath(path: string): string {
+  let sanitized = path.replace(/^\.\//, ''); // Remove leading ./
+  sanitized = sanitized.replace(/^\/+/, ''); // Remove leading slashes
+  return sanitized;
+}
+
+/**
+ * Resolves SONATA `circuit_config.json` manifest variables in a path.
+ *
+ * Manifest entries are `$VAR` keys that may reference one another, e.g.
+ * `$NETWORK_NODES_DIR` -> `$BASE_DIR/networks/nodes` -> `.`. We iterate
+ * (up to `maxIterations`) replacing every key globally until the path is
+ * stable, then strip a leading `./` or `/`.
+ *
+ * Note: replacement order follows manifest insertion order and is not sorted
+ * longest-key-first, so overlapping keys (e.g. `$NET` vs `$NETWORK`) could
+ * collide. Real circuit manifests don't define such keys; this matches the
+ * behavior previously shipped by the circuit download panel.
+ */
+export function resolveManifestPath(path: string, manifest?: Record<string, string>): string {
+  if (!manifest || isEmpty(manifest)) {
+    return sanitizePath(path);
+  }
+
+  let resolvedPath = path;
+  const maxIterations = 50; // Prevent infinite loops
+  let iteration = 0;
+
+  // Keep replacing variables until no more variables exist or max iterations reached
+  while (resolvedPath.includes('$') && iteration < maxIterations) {
+    const previousPath = resolvedPath;
+
+    // Use es-toolkit's reduce for efficient variable replacement
+    resolvedPath = reduce(
+      manifest,
+      (currentPath, value, key) => {
+        // Use global regex replace for all occurrences
+        return currentPath.replace(new RegExp(escapeRegExp(key), 'g'), value);
+      },
+      resolvedPath
+    );
+
+    // Break if no changes were made (no more replacements possible)
+    if (previousPath === resolvedPath) {
+      break;
+    }
+
+    iteration++;
+  }
+
+  return sanitizePath(resolvedPath);
+}
+
+/**
+ * Collapses `.` and `..` segments (and empty segments) in a relative path.
+ * `a/./b/../c` -> `a/c`. A leading `..` with nothing to pop is a no-op.
+ */
+export function normalizeRelativePath(path: string): string {
+  const result: string[] = [];
+  for (const part of path.split('/')) {
+    if (typeof part !== 'string' || part.trim().length === 0 || part === '.') continue;
+    if (part === '..') {
+      result.pop();
+      continue;
+    }
+    result.push(part);
+  }
+  return result.join('/');
+}

--- a/src/utils/circuit-manifest.ts
+++ b/src/utils/circuit-manifest.ts
@@ -1,6 +1,4 @@
-import escapeRegExp from 'es-toolkit/compat/escapeRegExp';
 import isEmpty from 'es-toolkit/compat/isEmpty';
-import reduce from 'es-toolkit/compat/reduce';
 
 function sanitizePath(path: string): string {
   let sanitized = path.replace(/^\.\//, ''); // Remove leading ./
@@ -11,15 +9,17 @@ function sanitizePath(path: string): string {
 /**
  * Resolves SONATA `circuit_config.json` manifest variables in a path.
  *
- * Manifest entries are `$VAR` keys that may reference one another, e.g.
- * `$NETWORK_NODES_DIR` -> `$BASE_DIR/networks/nodes` -> `.`. We iterate
- * (up to `maxIterations`) replacing every key globally until the path is
- * stable, then strip a leading `./` or `/`.
+ * Manifest entries are `$VAR` keys that may reference one another, possibly
+ * transitively, e.g. `$NETWORK_NODES_DIR` -> `$NETWORK/nodes` ->
+ * `$BASE_DIR/networks/nodes` -> `.`. We iterate (up to `maxIterations`)
+ * replacing every `$VAR` token until the path is stable, then strip a leading
+ * `./` or `/`.
  *
- * Note: replacement order follows manifest insertion order and is not sorted
- * longest-key-first, so overlapping keys (e.g. `$NET` vs `$NETWORK`) could
- * collide. Real circuit manifests don't define such keys; this matches the
- * behavior previously shipped by the circuit download panel.
+ * Each pass matches whole `$VAR` tokens (greedy `\$[A-Za-z_][A-Za-z0-9_]*`) and
+ * looks each up in the manifest, so prefix-overlapping keys (e.g. `$NETWORK` vs
+ * `$NETWORK_NODES_DIR`) never collide. Unknown tokens are left intact, which
+ * makes the next pass a no-op and terminates the loop. Cyclic manifests stop at
+ * `maxIterations`.
  */
 export function resolveManifestPath(path: string, manifest?: Record<string, string>): string {
   if (!manifest || isEmpty(manifest)) {
@@ -34,14 +34,10 @@ export function resolveManifestPath(path: string, manifest?: Record<string, stri
   while (resolvedPath.includes('$') && iteration < maxIterations) {
     const previousPath = resolvedPath;
 
-    // Use es-toolkit's reduce for efficient variable replacement
-    resolvedPath = reduce(
-      manifest,
-      (currentPath, value, key) => {
-        // Use global regex replace for all occurrences
-        return currentPath.replace(new RegExp(escapeRegExp(key), 'g'), value);
-      },
-      resolvedPath
+    // Match whole `$VAR` tokens and look each up; unknown tokens pass through
+    // unchanged. Matching whole tokens avoids prefix-overlap collisions.
+    resolvedPath = resolvedPath.replace(/\$[A-Za-z_][A-Za-z0-9_]*/g, (token) =>
+      token in manifest ? manifest[token] : token
     );
 
     // Break if no changes were made (no more replacements possible)


### PR DESCRIPTION
## Problem

A SONATA `circuit_config.json` `manifest` declares path variables that can reference one another (e.g. `$NETWORK_NODES_DIR` → `$BASE_DIR/networks/nodes` → `.`). The circuit-nodes parser only stripped `$BASE_DIR` and left every other variable intact. The unresolved path reached `buildAssetDownloadRequest`, where `URLSearchParams` percent-encoded the literal `$` to `%24`, producing a broken S3 URL:

```
.../Circuits/rCA1/%24NETWORK_NODES_DIR/hippocampus_neurons/nodes.h5
```

## Fix

Extract the download panel's proven iterative resolver into a shared `src/utils/circuit-manifest.ts` and reuse it across all three manifest resolvers:

| File | Change |
|------|--------|
| `src/utils/circuit-manifest.ts` *(new)* | `resolveManifestPath` (substitute all `$VAR`s until stable, strip leading `./`/`/`) + `normalizeRelativePath` (collapse `.`/`..`) |
| `features/circuit-nodes/hooks/use-circuit-config.ts` | the bug fix — replace `resolveBase`/`stripBase` with `resolveManifestPath` |
| `download-panel/helpers.ts` | move resolver out, re-export `getAssetPath` (behavior unchanged) |
| `scan-config/.../circuit-config.ts` | gains full nested-variable resolution while keeping its `.`/`..` normalization |

The example now resolves to `networks/nodes/hippocampus_neurons/nodes.h5` → request `?asset_path=networks%2Fnodes%2F…%2Fnodes.h5` (no `%24`).

## Testing

- New `circuit-manifest.nodetest.ts` (10 cases: nested vars, empty/missing manifest, leading-`./` stripping, cycle termination, `.`/`..` collapse) — all pass via `pnpm test:node`.
- `biome check` and `tsc` clean on all changed files; `knip` reports no new dead exports.
- Manual DevTools check against a live circuit still pending.