### PR TITLE
feat(circuit-nodes-table): download progress bar

### DIFF
--- a/src/features/circuit-nodes/circuit-nodes-table.tsx
+++ b/src/features/circuit-nodes/circuit-nodes-table.tsx
@@ -174,7 +174,7 @@ function renderBody({
 function CenteredSpin({ label }: { label: string }) {
   return (
     <div className={styles.centered}>
-      <Spin tip={label} size="large">
+      <Spin tip={label} size="large" className="[&_.ant-spin-dot-item]:bg-primary-6!">
         <div className={styles.spinBox} />
       </Spin>
     </div>
@@ -196,7 +196,7 @@ function DownloadProgress({
   return (
     <div className={styles.centered}>
       <div style={{ width: 280 }} className="text-center">
-        <div className="mb-1 text-sm text-primary-8">
+        <div className="mb-1 text-sm text-primary-9">
           Downloading nodes…{' '}
           <span className="tabular-nums">
             {formatBytes(progress.received, 0)} / {formatBytes(progress.total, 0)}
@@ -206,7 +206,7 @@ function DownloadProgress({
           type="line"
           percent={percent}
           strokeColor="var(--color-primary-6)"
-          className="[&_.ant-progress-text]:text-primary-8!"
+          className="[&_.ant-progress-text]:text-primary-9!"
         />
       </div>
     </div>

--- a/src/features/circuit-nodes/circuit-nodes-table.tsx
+++ b/src/features/circuit-nodes/circuit-nodes-table.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Empty, Spin } from 'antd';
+import { Empty, Progress, Spin } from 'antd';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { defaultVisibleColumnSet, NodesGrid } from '@/features/circuit-nodes/components/nodes-grid';
@@ -47,6 +47,7 @@ export default function CircuitNodesTable({ circuit, className }: Props) {
     columns,
     datasource,
     isLoading: workerLoading,
+    progress: downloadProgress,
     error: workerError,
   } = useNodesWorker({
     enabled,
@@ -81,6 +82,7 @@ export default function CircuitNodesTable({ circuit, className }: Props) {
           configLoading,
           workerError,
           workerLoading,
+          downloadProgress,
           hasPopulation: !!population,
           columns,
           rowCount,
@@ -99,6 +101,7 @@ function renderBody({
   configLoading,
   workerError,
   workerLoading,
+  downloadProgress,
   hasPopulation,
   columns,
   rowCount,
@@ -111,6 +114,7 @@ function renderBody({
   configLoading: boolean;
   workerError: Error | null;
   workerLoading: boolean;
+  downloadProgress: ReturnType<typeof useNodesWorker>['progress'];
   hasPopulation: boolean;
   columns: ReturnType<typeof useNodesWorker>['columns'];
   rowCount: number;
@@ -152,7 +156,7 @@ function renderBody({
     );
   }
   if (workerLoading || !columns || !datasource) {
-    return <CenteredSpin label="Loading nodes…" />;
+    return <DownloadProgress progress={downloadProgress} />;
   }
   return (
     <NodesGrid
@@ -172,6 +176,42 @@ function CenteredSpin({ label }: { label: string }) {
       <Spin tip={label} size="large">
         <div className={styles.spinBox} />
       </Spin>
+    </div>
+  );
+}
+
+function bytesToMb(n: number): string {
+  return (n / 1024 / 1024).toFixed(0);
+}
+
+function DownloadProgress({
+  progress,
+}: {
+  progress: ReturnType<typeof useNodesWorker>['progress'];
+}) {
+  // No bytes yet (or no Content-Length to compute a percent): fall back to the indeterminate spinner.
+  if (!progress) return <CenteredSpin label="Loading nodes…" />;
+  if (!progress.total) {
+    return <CenteredSpin label={`Downloading nodes… ${bytesToMb(progress.received)} MB`} />;
+  }
+
+  const percent = Math.round((progress.received / progress.total) * 100);
+  return (
+    <div className={styles.centered}>
+      <div style={{ width: 280 }} className="text-center">
+        <div className="mb-1 text-sm text-primary-8">
+          Downloading nodes…{' '}
+          <span className="tabular-nums">
+            {bytesToMb(progress.received)} / {bytesToMb(progress.total)} MB
+          </span>
+        </div>
+        <Progress
+          type="line"
+          percent={percent}
+          strokeColor="var(--color-primary-6)"
+          className="[&_.ant-progress-text]:text-primary-8!"
+        />
+      </div>
     </div>
   );
 }

--- a/src/features/circuit-nodes/circuit-nodes-table.tsx
+++ b/src/features/circuit-nodes/circuit-nodes-table.tsx
@@ -9,6 +9,7 @@ import { useCircuitConfig } from '@/features/circuit-nodes/hooks/use-circuit-con
 import { useNodesWorker } from '@/features/circuit-nodes/hooks/use-nodes-worker';
 import { GenericError } from '@/ui/molecules/generic-error';
 import { cn } from '@/utils/css-class';
+import { formatBytes } from '@/utils/format';
 
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
 import type { NodePopulation, ViewMode } from '@/features/circuit-nodes/types';
@@ -180,10 +181,6 @@ function CenteredSpin({ label }: { label: string }) {
   );
 }
 
-function bytesToMb(n: number): string {
-  return (n / 1024 / 1024).toFixed(0);
-}
-
 function DownloadProgress({
   progress,
 }: {
@@ -192,7 +189,7 @@ function DownloadProgress({
   // No bytes yet (or no Content-Length to compute a percent): fall back to the indeterminate spinner.
   if (!progress) return <CenteredSpin label="Loading nodes…" />;
   if (!progress.total) {
-    return <CenteredSpin label={`Downloading nodes… ${bytesToMb(progress.received)} MB`} />;
+    return <CenteredSpin label={`Downloading nodes… ${formatBytes(progress.received, 0)}`} />;
   }
 
   const percent = Math.round((progress.received / progress.total) * 100);
@@ -202,7 +199,7 @@ function DownloadProgress({
         <div className="mb-1 text-sm text-primary-8">
           Downloading nodes…{' '}
           <span className="tabular-nums">
-            {bytesToMb(progress.received)} / {bytesToMb(progress.total)} MB
+            {formatBytes(progress.received, 0)} / {formatBytes(progress.total, 0)}
           </span>
         </div>
         <Progress

--- a/src/features/circuit-nodes/hooks/use-nodes-worker.ts
+++ b/src/features/circuit-nodes/hooks/use-nodes-worker.ts
@@ -33,6 +33,7 @@ export function useNodesWorker({ enabled, circuitId, circuitAssetId, population 
   const [openResult, setOpenResult] = useState<OpenResponse | null>(null);
   const [filteredCount, setFilteredCount] = useState<number | null>(null);
   const [error, setError] = useState<Error | null>(null);
+  const [progress, setProgress] = useState<{ received: number; total: number | null } | null>(null);
 
   useEffect(() => {
     if (!enabled || !population || !circuitAssetId || !circuitId) {
@@ -41,6 +42,7 @@ export function useNodesWorker({ enabled, circuitId, circuitAssetId, population 
       setOpenResult(null);
       setFilteredCount(null);
       setError(null);
+      setProgress(null);
       return;
     }
 
@@ -49,6 +51,7 @@ export function useNodesWorker({ enabled, circuitId, circuitAssetId, population 
 
     setStatus('loading');
     setError(null);
+    setProgress(null);
 
     (async () => {
       try {
@@ -71,16 +74,23 @@ export function useNodesWorker({ enabled, circuitId, circuitAssetId, population 
         workerRef.current = { worker, proxy, populationKey: population.name };
 
         const fileKey = `${circuitId}-${circuitAssetId}-${population.name}`;
-        const result = await proxy.open({
-          populationKey: population.name,
-          fileKey,
-          url,
-          headers,
-        });
+        const result = await proxy.open(
+          {
+            populationKey: population.name,
+            fileKey,
+            url,
+            headers,
+          },
+          Comlink.proxy((received: number, total: number | null) => {
+            if (cancelled || generationRef.current !== generation) return;
+            setProgress({ received, total });
+          })
+        );
         if (cancelled || generationRef.current !== generation) return;
 
         setOpenResult(result);
         setFilteredCount(null);
+        setProgress(null);
         setStatus('ready');
       } catch (e) {
         if (cancelled || generationRef.current !== generation) return;
@@ -88,6 +98,7 @@ export function useNodesWorker({ enabled, circuitId, circuitAssetId, population 
         setError(e instanceof Error ? e : new Error(String(e)));
         setStatus('error');
         setOpenResult(null);
+        setProgress(null);
       }
     })();
 
@@ -141,6 +152,7 @@ export function useNodesWorker({ enabled, circuitId, circuitAssetId, population 
     columns: openResult?.columns,
     datasource,
     isLoading: status === 'loading',
+    progress,
     error,
   };
 }

--- a/src/features/circuit-nodes/hooks/use-nodes-worker.ts
+++ b/src/features/circuit-nodes/hooks/use-nodes-worker.ts
@@ -6,7 +6,12 @@ import { EntityTypeDict } from '@/api/entitycore/types';
 import { useWorkspace } from '@/ui/hooks/use-workspace';
 
 import type { IDatasource } from 'ag-grid-community';
-import type { ColumnMeta, NodePopulation, OpenResponse } from '@/features/circuit-nodes/types';
+import type {
+  ColumnMeta,
+  DownloadProgress,
+  NodePopulation,
+  OpenResponse,
+} from '@/features/circuit-nodes/types';
 import type { NodesWorkerApi } from '@/features/circuit-nodes/worker/nodes.worker';
 
 type Args = {
@@ -33,7 +38,7 @@ export function useNodesWorker({ enabled, circuitId, circuitAssetId, population 
   const [openResult, setOpenResult] = useState<OpenResponse | null>(null);
   const [filteredCount, setFilteredCount] = useState<number | null>(null);
   const [error, setError] = useState<Error | null>(null);
-  const [progress, setProgress] = useState<{ received: number; total: number | null } | null>(null);
+  const [progress, setProgress] = useState<DownloadProgress | null>(null);
 
   useEffect(() => {
     if (!enabled || !population || !circuitAssetId || !circuitId) {
@@ -81,9 +86,9 @@ export function useNodesWorker({ enabled, circuitId, circuitAssetId, population 
             url,
             headers,
           },
-          Comlink.proxy((received: number, total: number | null) => {
+          Comlink.proxy((next: DownloadProgress) => {
             if (cancelled || generationRef.current !== generation) return;
-            setProgress({ received, total });
+            setProgress(next);
           })
         );
         if (cancelled || generationRef.current !== generation) return;

--- a/src/features/circuit-nodes/types.ts
+++ b/src/features/circuit-nodes/types.ts
@@ -91,6 +91,13 @@ export type OpenResponse = {
   columns: ColumnMeta[];
 };
 
+/** Download progress reported from the worker's fetch loop. `total` is null when the response
+ * carries no Content-Length. */
+export type DownloadProgress = {
+  received: number;
+  total: number | null;
+};
+
 export type NodePopulation = {
   name: string;
   type: string;

--- a/src/features/circuit-nodes/worker/fetch-and-cache.ts
+++ b/src/features/circuit-nodes/worker/fetch-and-cache.ts
@@ -22,10 +22,12 @@ export async function fetchToFS({
   url,
   headers,
   fileKey,
+  onProgress,
 }: {
   url: string;
   headers: Record<string, string>;
   fileKey: string;
+  onProgress?: (received: number, total: number | null) => void;
 }): Promise<{ filename: string }> {
   const { FS } = await ready;
   if (!FS) throw new Error('h5wasm FS not initialized');
@@ -39,26 +41,50 @@ export async function fetchToFS({
   }
 
   const cache = await caches.open(CIRCUIT_H5_CACHE);
-  let response = await cache.match(url);
+  const cached = await cache.match(url);
 
-  if (!response) {
+  // Stream the *live network response* into the FS while tee-ing a second branch into CacheStorage,
+  // so progress reflects the actual download (not a fast local cache read). The network is the
+  // bottleneck, so the tee's buffers stay near-empty and memory stays at ~chunk + final file size.
+  let body: ReadableStream<Uint8Array> | null;
+  let total: number | null;
+  let cachePut: Promise<void> | null = null;
+
+  if (cached) {
+    body = cached.body;
+    total = Number(cached.headers.get('content-length')) || null;
+  } else {
     const fresh = await fetch(url, { headers });
     if (!fresh.ok) {
       throw new AssetFetchError(fresh.status, `Asset fetch failed (${fresh.status})`);
     }
-    await cache.put(url, fresh);
-    response = await cache.match(url);
-    if (!response) {
-      throw new AssetFetchError(0, 'CacheStorage match failed immediately after put');
+    if (!fresh.body) {
+      throw new AssetFetchError(0, 'Asset response has no body stream');
     }
+    total = Number(fresh.headers.get('content-length')) || null;
+    const [toFs, toCache] = fresh.body.tee();
+    // Best-effort cross-session cache. The .catch keeps this from becoming an unhandled rejection if
+    // the FS-write loop below throws and we bail before awaiting it; a failed write just re-downloads.
+    cachePut = cache
+      .put(url, new Response(toCache, { headers: fresh.headers, status: 200 }))
+      .catch(() => {});
+    body = toFs;
   }
 
-  if (!response.body) {
+  if (!body) {
     throw new AssetFetchError(0, 'Asset response has no body stream');
   }
 
-  const reader = response.body.getReader();
+  const reader = body.getReader();
   const stream = FS.open(filename, 'w+');
+  // Only surface progress for genuine network downloads. A cache hit reads from disk fast enough that
+  // the bar would just flicker, so we leave `progress` null and the UI shows the quick spinner.
+  const reportProgress = cached ? undefined : onProgress;
+  // Throttle progress emits so a 1 GB file doesn't flood the Comlink channel: when the total is
+  // known, emit on each whole-percent change; otherwise emit roughly every 2 MB.
+  let lastPercent = -1;
+  let lastEmittedBytes = 0;
+  const PROGRESS_BYTE_STEP = 2 * 1024 * 1024;
   try {
     let offset = 0;
     for (;;) {
@@ -66,7 +92,20 @@ export async function fetchToFS({
       if (done) break;
       FS.write(stream, value, 0, value.byteLength, offset);
       offset += value.byteLength;
+      if (reportProgress) {
+        if (total) {
+          const percent = Math.floor((offset / total) * 100);
+          if (percent !== lastPercent) {
+            lastPercent = percent;
+            reportProgress(offset, total);
+          }
+        } else if (offset - lastEmittedBytes >= PROGRESS_BYTE_STEP) {
+          lastEmittedBytes = offset;
+          reportProgress(offset, total);
+        }
+      }
     }
+    reportProgress?.(offset, total);
   } catch (err) {
     try {
       FS.unlink(filename);
@@ -77,6 +116,9 @@ export async function fetchToFS({
   } finally {
     FS.close(stream);
   }
+
+  // Ensure the cross-session cache entry is fully written before returning.
+  if (cachePut) await cachePut;
 
   return { filename };
 }

--- a/src/features/circuit-nodes/worker/fetch-and-cache.ts
+++ b/src/features/circuit-nodes/worker/fetch-and-cache.ts
@@ -2,6 +2,8 @@ import { ready } from 'h5wasm';
 
 import { CIRCUIT_H5_CACHE } from '@/features/circuit-nodes/types';
 
+import type { DownloadProgress } from '@/features/circuit-nodes/types';
+
 class AssetFetchError extends Error {
   status: number;
   constructor(status: number, message: string) {
@@ -27,7 +29,7 @@ export async function fetchToFS({
   url: string;
   headers: Record<string, string>;
   fileKey: string;
-  onProgress?: (received: number, total: number | null) => void;
+  onProgress?: (progress: DownloadProgress) => void;
 }): Promise<{ filename: string }> {
   const { FS } = await ready;
   if (!FS) throw new Error('h5wasm FS not initialized');
@@ -51,6 +53,9 @@ export async function fetchToFS({
   let cachePut: Promise<void> | null = null;
 
   if (cached) {
+    if (!cached.body) {
+      throw new AssetFetchError(0, 'Asset response has no body stream');
+    }
     body = cached.body;
     total = Number(cached.headers.get('content-length')) || null;
   } else {
@@ -69,10 +74,6 @@ export async function fetchToFS({
       .put(url, new Response(toCache, { headers: fresh.headers, status: 200 }))
       .catch(() => {});
     body = toFs;
-  }
-
-  if (!body) {
-    throw new AssetFetchError(0, 'Asset response has no body stream');
   }
 
   const reader = body.getReader();
@@ -97,15 +98,15 @@ export async function fetchToFS({
           const percent = Math.floor((offset / total) * 100);
           if (percent !== lastPercent) {
             lastPercent = percent;
-            reportProgress(offset, total);
+            reportProgress({ received: offset, total });
           }
         } else if (offset - lastEmittedBytes >= PROGRESS_BYTE_STEP) {
           lastEmittedBytes = offset;
-          reportProgress(offset, total);
+          reportProgress({ received: offset, total });
         }
       }
     }
-    reportProgress?.(offset, total);
+    reportProgress?.({ received: offset, total });
   } catch (err) {
     try {
       FS.unlink(filename);

--- a/src/features/circuit-nodes/worker/nodes.worker.ts
+++ b/src/features/circuit-nodes/worker/nodes.worker.ts
@@ -4,6 +4,7 @@ import { fetchToFS, unlinkFromFS } from '@/features/circuit-nodes/worker/fetch-a
 import { NodesSession } from '@/features/circuit-nodes/worker/nodes-h5';
 
 import type {
+  DownloadProgress,
   GetRowsRequest,
   GetRowsResponse,
   OpenRequest,
@@ -15,7 +16,7 @@ let session: NodesSession | null = null;
 const api = {
   async open(
     opts: OpenRequest,
-    onProgress?: (received: number, total: number | null) => void
+    onProgress?: (progress: DownloadProgress) => void
   ): Promise<OpenResponse> {
     if (session) {
       session.close();

--- a/src/features/circuit-nodes/worker/nodes.worker.ts
+++ b/src/features/circuit-nodes/worker/nodes.worker.ts
@@ -13,7 +13,10 @@ import type {
 let session: NodesSession | null = null;
 
 const api = {
-  async open(opts: OpenRequest): Promise<OpenResponse> {
+  async open(
+    opts: OpenRequest,
+    onProgress?: (received: number, total: number | null) => void
+  ): Promise<OpenResponse> {
     if (session) {
       session.close();
       await unlinkFromFS(session.filename);
@@ -23,6 +26,7 @@ const api = {
       url: opts.url,
       headers: opts.headers,
       fileKey: opts.fileKey,
+      onProgress,
     });
     session = new NodesSession(filename, opts.populationKey);
     return { rowCount: session.rowCount, columns: session.columns };


### PR DESCRIPTION
## Summary

The circuit nodes table downloads a `nodes.h5` file (up to ~1 GB) into a web worker before rendering. Today it shows only an indeterminate spinner, so during a ~minute-long download users can't tell whether it's working or stuck. This replaces the spinner with a real horizontal progress bar showing percentage and downloaded/total MB.

## Changes

- **`worker/fetch-and-cache.ts`** — stream the live network response into the Emscripten FS while `tee()`-ing a second branch into CacheStorage, so progress reflects the actual download instead of a fast local cache read. Emits are throttled (per-percent, or ~2 MB when `Content-Length` is absent). Caching is best-effort (a failed write just re-downloads next session). **Progress is reported only on a genuine network fetch** — cache hits read fast enough that a bar would just flicker.
- **`worker/nodes.worker.ts`** — `open()` forwards an optional `onProgress` callback.
- **`hooks/use-nodes-worker.ts`** — passes a Comlink-proxied progress callback; exposes `{ received, total }` state guarded by the existing generation/cancel checks; resets on load/ready/error/teardown.
- **`circuit-nodes-table.tsx`** — `DownloadProgress` renders an antd `Progress` line bar (`var(--color-primary-6)`) with live MB counts, falling back to the spinner before the first byte or when no `Content-Length` is available.

## Verification

- [x] First load (network throttled): bar fills 0→100% with live MB counts
- [x] Reload same population: cache hit → quick spinner, no flicker
- [ ] Switch populations mid-download: progress resets cleanly
- [x] `obi-circuit-h5-v1` cache still populated after a fresh download

## Notes

- Live percentage depends on the asset response including `Content-Length` (presigned S3 GETs normally do; it's CORS-safelisted). Without it, the UI shows a MB-downloaded spinner fallback.