### PR TITLE
feat(scan-config): circuit neuronal manipulation support

### DIFF
--- a/src/__tests__/scan-config/circuit-manipulation-state.test.ts
+++ b/src/__tests__/scan-config/circuit-manipulation-state.test.ts
@@ -1,72 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  clearDeletedBlockReferences,
+  resolveNeuronSet,
+} from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/state';
+import { ScanConfigUIElementDict } from '@/features/scan-config/types';
+
 import type { Config } from '@/features/scan-config/types';
-
-const assert: typeof import('node:assert/strict') = require('node:assert/strict');
-const fs: typeof import('node:fs') = require('node:fs');
-const Module: typeof import('node:module') = require('node:module');
-const path: typeof import('node:path') = require('node:path');
-const test: typeof import('node:test') = require('node:test');
-const ts: typeof import('typescript') = require('typescript');
-const { describe, it } = test;
-
-type NodeModuleConstructor = typeof Module & {
-  _nodeModulePaths(from: string): string[];
-};
-type TranspiledModule = InstanceType<typeof Module> & {
-  _compile(code: string, filename: string): void;
-};
-
-const ScanConfigUIElementDict = {
-  BlockSingle: 'block_single',
-  BlockDictionary: 'block_dictionary',
-  BlockUnion: 'block_union',
-  Reference: 'reference',
-  IonChannelVariableModificationByNeuron: 'ion_channel_variable_modification_by_neuron',
-  ionChannelVariableModificationBySectionList: 'ion_channel_variable_modification_by_section_list',
-} as const;
-
-function loadStateHelpers(): typeof import('./state') {
-  const statePath = path.join(__dirname, 'state.ts');
-  const source = fs.readFileSync(statePath, 'utf8');
-  const output = ts.transpileModule(source, {
-    compilerOptions: {
-      module: ts.ModuleKind.CommonJS,
-      target: ts.ScriptTarget.ES2022,
-    },
-  }).outputText;
-  const NodeModule = Module as NodeModuleConstructor;
-  const stateModule = new NodeModule(statePath, module) as TranspiledModule;
-
-  stateModule.filename = statePath;
-  stateModule.paths = NodeModule._nodeModulePaths(path.dirname(statePath));
-  stateModule.require = ((id: string) => {
-    if (id === '../../../utils') {
-      return {
-        isPlainObject: (value: unknown) =>
-          typeof value === 'object' && value !== null && !Array.isArray(value),
-      };
-    }
-
-    if (id === '../../../../types') {
-      return {
-        isType: (value: unknown) =>
-          typeof value === 'object' &&
-          value !== null &&
-          !Array.isArray(value) &&
-          'const' in value &&
-          !('ui_element' in value),
-        ScanConfigUIElementDict,
-      };
-    }
-
-    return require(id);
-  }) as NodeJS.Require;
-
-  stateModule._compile(output, statePath);
-  return stateModule.exports;
-}
-
-const stateHelpers = loadStateHelpers();
-const { clearDeletedBlockReferences, resolveNeuronSet } = stateHelpers;
 
 describe('circuit ion-channel manipulation state', () => {
   it('changes the target signature when the referenced neuron-set content changes', () => {
@@ -93,8 +33,7 @@ describe('circuit ion-channel manipulation state', () => {
       block_dict_name: 'neuron_sets',
     };
 
-    assert.notEqual(
-      resolveNeuronSet(firstConfig, reference).signature,
+    expect(resolveNeuronSet(firstConfig, reference).signature).not.toBe(
       resolveNeuronSet(secondConfig, reference).signature
     );
   });
@@ -163,7 +102,7 @@ describe('circuit ion-channel manipulation state', () => {
 
     const next = clearDeletedBlockReferences(config, schema, 'neuron_sets', 'target-set');
 
-    assert.deepEqual(next.initialize, {
+    expect(next.initialize).toEqual({
       type: 'Initialize',
       neuron_set: null,
       manipulation: null,

--- a/src/__tests__/scan-config/ion-channel-modification-base.spec.tsx
+++ b/src/__tests__/scan-config/ion-channel-modification-base.spec.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GlobalModificationBase } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/global-base';
+import { RangeModificationBase } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/range-base';
+
+import type { MechanismVariablesRoot } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/mapping';
+import type { ConfigValue } from '@/features/scan-config/types';
+
+const DATA: MechanismVariablesRoot = {
+  NaTg: {
+    section_lists: ['somatic', 'axonal'],
+    entity_id: 'ic-natg',
+    variables: {
+      gbar: {
+        units: 'S/cm2',
+        limits: [0, 1],
+        variable_type: 'RANGE',
+        section_lists_original_values: { somatic: 0.1, axonal: 0.2 },
+      },
+    },
+  },
+};
+
+describe('GlobalModificationBase', () => {
+  const baseProps = {
+    data: DATA,
+    disabled: false,
+    setState: vi.fn(),
+    fieldKey: 'modification',
+    modificationType: 'GlobalModification',
+  };
+
+  it('shows the loading note while circuit variables are being fetched', () => {
+    render(<GlobalModificationBase {...baseProps} state={{}} loading reason={null} />);
+
+    expect(screen.getByText(/Loading variables/)).toBeInTheDocument();
+    expect(screen.queryByText('Select a variable…')).not.toBeInTheDocument();
+  });
+
+  it('shows the reason note instead of the picker when one is provided', () => {
+    render(
+      <GlobalModificationBase
+        {...baseProps}
+        state={{}}
+        loading={false}
+        reason={<span>Could not load variables for the selected neuron set.</span>}
+      />
+    );
+
+    expect(
+      screen.getByText('Could not load variables for the selected neuron set.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Select a variable…')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty picker (placeholder) when data is available but nothing is selected', () => {
+    render(<GlobalModificationBase {...baseProps} state={{}} />);
+
+    expect(screen.getByText('Select a variable…')).toBeInTheDocument();
+  });
+
+  it('reflects an existing selection in the trigger and links to the ion-channel entity', () => {
+    const state: Record<string, ConfigValue> = {
+      modification: {
+        type: 'GlobalModification',
+        ion_channel_id: 'ic-natg',
+        channel_name: 'NaTg',
+        variable_name: 'gbar',
+        new_value: 0.05,
+      },
+    };
+    render(<GlobalModificationBase {...baseProps} state={state} />);
+
+    expect(screen.getByText('NaTg')).toBeInTheDocument();
+    expect(screen.getByText('gbar')).toBeInTheDocument();
+    expect(screen.getByLabelText('View ion channel NaTg')).toBeInTheDocument();
+  });
+});
+
+describe('RangeModificationBase', () => {
+  const baseProps = {
+    data: DATA,
+    disabled: false,
+    setState: vi.fn(),
+    fieldKey: 'modification',
+    modificationType: 'RangeModification',
+  };
+
+  it('renders the empty picker when nothing is selected yet', () => {
+    render(<RangeModificationBase {...baseProps} state={{}} />);
+
+    expect(screen.getByText('Select a variable…')).toBeInTheDocument();
+  });
+
+  it('resolves the channel from ion_channel_id and shows the section-list editor', () => {
+    const state: Record<string, ConfigValue> = {
+      modification: {
+        type: 'RangeModification',
+        ion_channel_id: 'ic-natg',
+        variable_name: 'gbar',
+        section_list_modifications: { somatic: 0.05 },
+      },
+    };
+    render(<RangeModificationBase {...baseProps} state={state} />);
+
+    expect(screen.getByText('NaTg')).toBeInTheDocument();
+    expect(screen.getByText('gbar')).toBeInTheDocument();
+    // both section lists from the resolved variable become editable rows. `somatic`
+    // also appears in the trigger's section-list badge, hence getAllByText.
+    expect(screen.getAllByText('somatic').length).toBeGreaterThan(0);
+    expect(screen.getByText('axonal')).toBeInTheDocument();
+  });
+
+  it('honours the gating reason over the picker', () => {
+    render(
+      <RangeModificationBase
+        {...baseProps}
+        state={{}}
+        reason={<span>No ion-channel variables are available for the selected neuron set.</span>}
+      />
+    );
+
+    expect(
+      screen.getByText('No ion-channel variables are available for the selected neuron set.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Select a variable…')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/scan-config/modification-shell.spec.tsx
+++ b/src/__tests__/scan-config/modification-shell.spec.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ModificationShell } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/modification-shell';
+import { ScanConfigUIElementDict } from '@/features/scan-config/types';
+
+import type { MechanismVariablesRoot } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/mapping';
+
+const UI_ELEMENT = ScanConfigUIElementDict.IonChannelVariableModificationByNeuron;
+const SOME_DATA: MechanismVariablesRoot = {
+  NaTg: { section_lists: ['somatic'], entity_id: 'ic-natg', variables: {} },
+};
+
+function renderShell(props: Partial<React.ComponentProps<typeof ModificationShell>> = {}) {
+  return render(
+    <ModificationShell uiElement={UI_ELEMENT} data={null} loading={false} reason={null} {...props}>
+      <div data-testid="picker">picker</div>
+    </ModificationShell>
+  );
+}
+
+describe('ModificationShell', () => {
+  it('renders nothing when there is no data, loading, or reason (me-model idle state)', () => {
+    const { container } = renderShell();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the loading note instead of the picker while fetching', () => {
+    renderShell({ loading: true });
+
+    expect(screen.getByText(/Loading variables/)).toBeInTheDocument();
+    expect(screen.queryByTestId('picker')).not.toBeInTheDocument();
+  });
+
+  it('renders the picker once usable data is available', () => {
+    const { container } = renderShell({ data: SOME_DATA });
+
+    expect(screen.getByTestId('picker')).toBeInTheDocument();
+    expect(
+      container.querySelector(`[data-scan-config-block-element="${UI_ELEMENT}"]`)
+    ).not.toBeNull();
+  });
+
+  it('renders a plain-string reason note in place of the picker', () => {
+    renderShell({ reason: 'No ion-channel variables are available.', data: SOME_DATA });
+
+    expect(screen.getByText('No ion-channel variables are available.')).toBeInTheDocument();
+    expect(screen.queryByTestId('picker')).not.toBeInTheDocument();
+  });
+
+  it('renders a rich ReactNode reason (error headline + endpoint detail)', () => {
+    renderShell({
+      data: SOME_DATA,
+      reason: (
+        <div className="flex flex-col gap-1">
+          <span className="text-error font-medium">Could not load variables.</span>
+          <span className="text-gray-400">Neuron set &quot;exc&quot; not found.</span>
+        </div>
+      ),
+    });
+
+    expect(screen.getByText('Could not load variables.')).toBeInTheDocument();
+    expect(screen.getByText('Neuron set "exc" not found.')).toBeInTheDocument();
+    expect(screen.queryByTestId('picker')).not.toBeInTheDocument();
+  });
+
+  it('prefers the loading note over a reason when both are set', () => {
+    renderShell({ loading: true, reason: 'should not show', data: SOME_DATA });
+
+    expect(screen.getByText(/Loading variables/)).toBeInTheDocument();
+    expect(screen.queryByText('should not show')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/scan-config/neuronal-manipulation-properties-api.test.ts
+++ b/src/__tests__/scan-config/neuronal-manipulation-properties-api.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const post = vi.fn();
+
+vi.mock('@/api/one/utils', () => ({
+  obioneApi: async () => ({ post }),
+}));
+
+vi.mock('@/api/entitycore/utils', () => ({
+  getEntityCoreContext: () => ({
+    headers: { 'virtual-lab-id': 'vl-1', 'project-id': 'pj-1' },
+  }),
+}));
+
+import { fetchNeuronalManipulationProperties } from '@/api/one/neuronal-manipulation-properties';
+
+describe('fetchNeuronalManipulationProperties', () => {
+  beforeEach(() => {
+    post.mockReset();
+    post.mockResolvedValue({ MechanismVariablesByIonChannel: {} });
+  });
+
+  it('POSTs MEModel properties with entity_id only', async () => {
+    await fetchNeuronalManipulationProperties({
+      ctx: { virtualLabId: 'vl-1', projectId: 'pj-1' },
+      endpoint: '/memodel-neuronal-manipulation-properties',
+      entityId: 'memodel-1',
+    });
+
+    expect(post).toHaveBeenCalledWith('/declared/memodel-neuronal-manipulation-properties', {
+      headers: expect.objectContaining({
+        accept: 'application/json',
+        'Content-Type': 'application/json',
+      }),
+      body: { entity_id: 'memodel-1' },
+      signal: undefined,
+    });
+  });
+
+  it('POSTs Circuit properties with entity_id and neuron_set when includeNeuronSet is true', async () => {
+    const neuronSet = { type: 'AllNeurons' };
+
+    await fetchNeuronalManipulationProperties({
+      ctx: { virtualLabId: 'vl-1', projectId: 'pj-1' },
+      endpoint: '/circuit-neuronal-manipulation-properties-by-neuron-set',
+      entityId: 'circuit-1',
+      neuronSet,
+      includeNeuronSet: true,
+    });
+
+    expect(post).toHaveBeenCalledWith(
+      '/declared/circuit-neuronal-manipulation-properties-by-neuron-set',
+      {
+        headers: expect.objectContaining({
+          accept: 'application/json',
+          'Content-Type': 'application/json',
+        }),
+        body: { entity_id: 'circuit-1', neuron_set: neuronSet },
+        signal: undefined,
+      }
+    );
+  });
+
+  it('sends neuron_set null for the Circuit default-target fast path', async () => {
+    await fetchNeuronalManipulationProperties({
+      ctx: { virtualLabId: 'vl-1', projectId: 'pj-1' },
+      endpoint: '/circuit-neuronal-manipulation-properties-by-neuron-set',
+      entityId: 'circuit-1',
+      neuronSet: null,
+      includeNeuronSet: true,
+    });
+
+    expect(post).toHaveBeenCalledWith(
+      '/declared/circuit-neuronal-manipulation-properties-by-neuron-set',
+      expect.objectContaining({
+        body: { entity_id: 'circuit-1', neuron_set: null },
+      })
+    );
+  });
+});

--- a/src/__tests__/scan-config/schema-mapping-config.test.ts
+++ b/src/__tests__/scan-config/schema-mapping-config.test.ts
@@ -28,40 +28,24 @@ describe('parseSchemaMappingConfiguration', () => {
     });
 
     expect(parsed.NodePropertyUniqueValuesByPopulation?.L5.mtype).toEqual(['L5_PC', 'L5_NBC']);
-    expect(parsed.MechanismVariablesByIonChannel).toBeUndefined();
   });
 
-  it('accepts MEModel mapped-circuit-properties with MechanismVariablesByIonChannel only', () => {
+  it('accepts MEModel mapped-circuit-properties with usability only', () => {
     const parsed = parseSchemaMappingConfiguration({
-      MechanismVariablesByIonChannel: {
-        NaTg: {
-          section_lists: ['somatic', 'axonal'],
-          entity_id: '13c947c3-cb76-4a9a-91f4-146e95bd25f3',
-          variables: {
-            gNaTgbar_NaTg: {
-              units: '',
-              limits: [0, 10],
-              variable_type: 'RANGE',
-              section_lists_original_values: {
-                somatic: 0.21,
-                axonal: 0.42,
-              },
-            },
-          },
-        },
-      },
       usability: defaultUsability,
     });
 
-    expect(parsed.MechanismVariablesByIonChannel?.NaTg).toBeDefined();
+    expect(parsed.usability).toEqual(defaultUsability);
     expect(parsed.NodePropertyUniqueValuesByPopulation).toBeUndefined();
   });
 
-  it('accepts responses that include both circuit and memodel property groups', () => {
+  it('preserves unexpected keys via catchall without requiring MechanismVariablesByIonChannel', () => {
     const parsed = parseSchemaMappingConfiguration({
       NodePropertyUniqueValuesByPopulation: {
         L5: { mtype: ['L5_PC'] },
       },
+      // Legacy leftover: mechanism variables are no longer part of mapped-circuit-properties;
+      // neuronal manipulation uses dedicated POST endpoints instead.
       MechanismVariablesByIonChannel: {
         pas: {
           section_lists: ['somatic'],

--- a/src/__tests__/scan-config/use-circuit-manipulation-data.spec.tsx
+++ b/src/__tests__/scan-config/use-circuit-manipulation-data.spec.tsx
@@ -1,0 +1,167 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MechanismVariablesRoot } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/mapping';
+import type { Config, ConfigValue } from '@/features/scan-config/types';
+
+const queryResult = vi.hoisted(() => ({
+  value: {
+    data: undefined as MechanismVariablesRoot | undefined,
+    isLoading: false,
+    isError: false,
+    error: undefined as unknown,
+  },
+}));
+
+vi.mock('@/ui/hooks/use-workspace', () => ({
+  useWorkspace: () => ({ virtualLabId: 'vl-1', projectId: 'pj-1' }),
+}));
+vi.mock('@/features/scan-config/components/hooks/use-neuronal-manipulation-properties', () => ({
+  useNeuronalManipulationProperties: () => queryResult.value,
+}));
+
+import { useCircuitManipulationData } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/use-circuit-manipulation-data';
+
+type HarnessProps = {
+  config: Config;
+  state: Record<string, ConfigValue>;
+  setState: (next: Record<string, ConfigValue>) => void;
+};
+
+function Harness({ config, state, setState }: HarnessProps) {
+  const { data, loading, reason } = useCircuitManipulationData({
+    config,
+    state,
+    setState,
+    sourceField: 'neuron_set',
+    fieldKey: 'manipulation',
+    endpoint: '/neuronal-manipulation',
+    entityId: 'circuit-1',
+  });
+
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="hasData">{data ? 'yes' : 'no'}</span>
+      <div data-testid="reason">{reason}</div>
+    </div>
+  );
+}
+
+const REFERENCE: ConfigValue = { block_name: 'exc', block_dict_name: 'neuron_sets' };
+
+function makeConfig(nodeIds: number[]): Config {
+  return {
+    neuron_sets: {
+      exc: { type: 'NeuronSet', population: 'S1', node_id: nodeIds },
+    },
+  };
+}
+
+describe('useCircuitManipulationData', () => {
+  beforeEach(() => {
+    queryResult.value = { data: undefined, isLoading: false, isError: false, error: undefined };
+  });
+
+  it('reports loading and renders no reason while variables are being fetched', () => {
+    queryResult.value = { data: undefined, isLoading: true, isError: false, error: undefined };
+    render(
+      <Harness config={makeConfig([1])} state={{ neuron_set: REFERENCE }} setState={vi.fn()} />
+    );
+
+    expect(screen.getByTestId('loading')).toHaveTextContent('true');
+    expect(screen.getByTestId('reason')).toBeEmptyDOMElement();
+  });
+
+  it('surfaces the generic error headline plus the endpoint detail on failure', () => {
+    queryResult.value = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: { cause: { message: 'Neuron set "exc" has no biophysical neurons.' } },
+    };
+    render(
+      <Harness config={makeConfig([1])} state={{ neuron_set: REFERENCE }} setState={vi.fn()} />
+    );
+
+    expect(
+      screen.getByText('Could not load variables for the selected neuron set.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Neuron set "exc" has no biophysical neurons.')).toBeInTheDocument();
+  });
+
+  it('shows only the generic headline when the endpoint gives no usable detail', () => {
+    queryResult.value = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: { cause: {} },
+    };
+    const { container } = render(
+      <Harness config={makeConfig([1])} state={{ neuron_set: REFERENCE }} setState={vi.fn()} />
+    );
+
+    expect(
+      screen.getByText('Could not load variables for the selected neuron set.')
+    ).toBeInTheDocument();
+
+    const reason = container.querySelector('[data-testid="reason"] > div');
+    expect(reason?.children).toHaveLength(1);
+  });
+
+  it('shows the empty-state note when the endpoint returns no variables', () => {
+    queryResult.value = { data: {}, isLoading: false, isError: false, error: undefined };
+    render(
+      <Harness config={makeConfig([1])} state={{ neuron_set: REFERENCE }} setState={vi.fn()} />
+    );
+
+    expect(
+      screen.getByText('No ion-channel variables are available for the selected neuron set.')
+    ).toBeInTheDocument();
+  });
+
+  it('exposes data and no reason once variables resolve', () => {
+    queryResult.value = {
+      data: { NaTg: { section_lists: ['somatic'], entity_id: 'ic', variables: {} } },
+      isLoading: false,
+      isError: false,
+      error: undefined,
+    };
+    render(
+      <Harness config={makeConfig([1])} state={{ neuron_set: REFERENCE }} setState={vi.fn()} />
+    );
+
+    expect(screen.getByTestId('hasData')).toHaveTextContent('yes');
+    expect(screen.getByTestId('reason')).toBeEmptyDOMElement();
+  });
+
+  it('resets the modification when the targeted neuron set changes', () => {
+    const setState = vi.fn();
+    const state: Record<string, ConfigValue> = {
+      neuron_set: REFERENCE,
+      manipulation: { type: 'RangeModification', variable_name: 'gbar' },
+    };
+    const { rerender } = render(
+      <Harness config={makeConfig([1, 2])} state={state} setState={setState} />
+    );
+
+    expect(setState).not.toHaveBeenCalled();
+
+    // same selected block, different contents -> signature changes -> reset fires
+    rerender(<Harness config={makeConfig([1, 2, 3])} state={state} setState={setState} />);
+
+    expect(setState).toHaveBeenCalledWith({ ...state, manipulation: null });
+  });
+
+  it('does not reset when there is no modification to clear', () => {
+    const setState = vi.fn();
+    const state: Record<string, ConfigValue> = { neuron_set: REFERENCE };
+    const { rerender } = render(
+      <Harness config={makeConfig([1])} state={state} setState={setState} />
+    );
+
+    rerender(<Harness config={makeConfig([1, 2])} state={state} setState={setState} />);
+
+    expect(setState).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/scan-config/use-circuit-manipulation-data.test.tsx
+++ b/src/__tests__/scan-config/use-circuit-manipulation-data.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { ApiError } from '@/api/error';
+
 import type { MechanismVariablesRoot } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/mapping';
 import type { Config, ConfigValue } from '@/features/scan-config/types';
 
@@ -35,7 +37,7 @@ function Harness({ config, state, setState }: HarnessProps) {
     setState,
     sourceField: 'neuron_set',
     fieldKey: 'manipulation',
-    endpoint: '/neuronal-manipulation',
+    endpoint: '/circuit-neuronal-manipulation-properties-by-neuron-set',
     entityId: 'circuit-1',
   });
 
@@ -78,7 +80,9 @@ describe('useCircuitManipulationData', () => {
       data: undefined,
       isLoading: false,
       isError: true,
-      error: { cause: { message: 'Neuron set "exc" has no biophysical neurons.' } },
+      error: new ApiError('request failed', {
+        message: 'Neuron set "exc" has no biophysical neurons.',
+      }),
     };
     render(
       <Harness config={makeConfig([1])} state={{ neuron_set: REFERENCE }} setState={vi.fn()} />
@@ -95,7 +99,7 @@ describe('useCircuitManipulationData', () => {
       data: undefined,
       isLoading: false,
       isError: true,
-      error: { cause: {} },
+      error: new ApiError('request failed', {}),
     };
     const { container } = render(
       <Harness config={makeConfig([1])} state={{ neuron_set: REFERENCE }} setState={vi.fn()} />

--- a/src/__tests__/scan-config/use-memodel-manipulation-data.test.tsx
+++ b/src/__tests__/scan-config/use-memodel-manipulation-data.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiError } from '@/api/error';
+
+import type { MechanismVariablesRoot } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/mapping';
+
+const queryResult = vi.hoisted(() => ({
+  value: {
+    data: undefined as MechanismVariablesRoot | undefined,
+    isLoading: false,
+    isError: false,
+    error: undefined as unknown,
+  },
+  lastParams: undefined as unknown,
+}));
+
+vi.mock('@/ui/hooks/use-workspace', () => ({
+  useWorkspace: () => ({ virtualLabId: 'vl-1', projectId: 'pj-1' }),
+}));
+vi.mock('@/features/scan-config/components/hooks/use-neuronal-manipulation-properties', () => ({
+  useNeuronalManipulationProperties: (params: unknown) => {
+    queryResult.lastParams = params;
+    return queryResult.value;
+  },
+}));
+
+import { useMeModelManipulationData } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/me-model/use-memodel-manipulation-data';
+
+function Harness() {
+  const { data, loading, reason } = useMeModelManipulationData({
+    endpoint: '/memodel-neuronal-manipulation-properties',
+    entityId: 'memodel-1',
+  });
+
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="hasData">{data ? 'yes' : 'no'}</span>
+      <div data-testid="reason">{reason}</div>
+    </div>
+  );
+}
+
+describe('useMeModelManipulationData', () => {
+  beforeEach(() => {
+    queryResult.value = { data: undefined, isLoading: false, isError: false, error: undefined };
+    queryResult.lastParams = undefined;
+  });
+
+  it('calls the properties hook without includeNeuronSet / neuronSet', () => {
+    render(<Harness />);
+
+    expect(queryResult.lastParams).toEqual({
+      workspace: { virtualLabId: 'vl-1', projectId: 'pj-1' },
+      entityId: 'memodel-1',
+      endpoint: '/memodel-neuronal-manipulation-properties',
+    });
+  });
+
+  it('surfaces a model-scoped error note on failure', () => {
+    queryResult.value = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new ApiError('request failed', {
+        message: 'MEModel has no biophysical mechanisms.',
+      }),
+    };
+    render(<Harness />);
+
+    expect(
+      screen.getByText('Could not load ion-channel variables for this model.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('MEModel has no biophysical mechanisms.')).toBeInTheDocument();
+  });
+
+  it('shows the empty-state note when the endpoint returns no variables', () => {
+    queryResult.value = { data: {}, isLoading: false, isError: false, error: undefined };
+    render(<Harness />);
+
+    expect(
+      screen.getByText('No ion-channel variables are available for this model.')
+    ).toBeInTheDocument();
+  });
+
+  it('exposes data and no reason once variables resolve', () => {
+    queryResult.value = {
+      data: { NaTg: { section_lists: ['somatic'], entity_id: 'ic', variables: {} } },
+      isLoading: false,
+      isError: false,
+      error: undefined,
+    };
+    render(<Harness />);
+
+    expect(screen.getByTestId('hasData')).toHaveTextContent('yes');
+    expect(screen.getByTestId('reason')).toBeEmptyDOMElement();
+  });
+});

--- a/src/__tests__/scan-config/use-neuronal-manipulation-properties.spec.ts
+++ b/src/__tests__/scan-config/use-neuronal-manipulation-properties.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { selectMechanismVariablesRoot } from '@/features/scan-config/components/hooks/use-neuronal-manipulation-properties';
+
+const SAMPLE_CHANNEL = {
+  section_lists: ['somatic'],
+  entity_id: null,
+  variables: {
+    g_pas: {
+      units: '',
+      limits: [0, 10] as [number, number],
+      variable_type: 'RANGE' as const,
+      section_lists_original_values: { somatic: null },
+    },
+  },
+};
+
+describe('selectMechanismVariablesRoot', () => {
+  it('reads PascalCase MechanismVariablesByIonChannel from the live API shape', () => {
+    const root = selectMechanismVariablesRoot({
+      entity_type: 'circuit',
+      populations: null,
+      MechanismVariablesByIonChannel: { pas: SAMPLE_CHANNEL },
+      warnings: null,
+    });
+
+    expect(root).toEqual({ pas: SAMPLE_CHANNEL });
+    expect(Object.keys(root)).toHaveLength(1);
+  });
+
+  it('falls back to legacy snake_case when PascalCase is absent', () => {
+    const root = selectMechanismVariablesRoot({
+      mechanism_variables_by_ion_channel: { pas: SAMPLE_CHANNEL },
+    });
+
+    expect(root).toEqual({ pas: SAMPLE_CHANNEL });
+  });
+
+  it('prefers PascalCase when both keys are present', () => {
+    const root = selectMechanismVariablesRoot({
+      MechanismVariablesByIonChannel: { pas: SAMPLE_CHANNEL },
+      mechanism_variables_by_ion_channel: { other: SAMPLE_CHANNEL },
+    });
+
+    expect(root).toEqual({ pas: SAMPLE_CHANNEL });
+  });
+
+  it('returns an empty object when neither key is present', () => {
+    expect(selectMechanismVariablesRoot({ entity_type: 'circuit' })).toEqual({});
+  });
+});

--- a/src/api/one/neuronal-manipulation-properties.ts
+++ b/src/api/one/neuronal-manipulation-properties.ts
@@ -6,14 +6,18 @@ import type { WorkspaceContext } from '@/types/common';
 /**
  * `POST /declared/neuronal-manipulation-properties`.
  *
- * the mechanism-variables payload is keyed `mechanism_variables_by_ion_channel`
- * (snake_case) — note this differs from the schema's `property` selector
- * (`MechanismVariablesByIonChannel`) callers should read this field directly
+ * the mechanism-variables payload is keyed `MechanismVariablesByIonChannel`
+ * (same as the schema `property` selector / `RootSelector`). Older backends
+ * may still emit snake_case; callers should prefer PascalCase and fall back.
  */
 export type TNeuronalManipulationPropertiesResponse = {
   entity_type?: string;
   population?: string;
+  populations?: string[] | null;
+  MechanismVariablesByIonChannel?: Record<string, unknown>;
+  /** @deprecated prefer `MechanismVariablesByIonChannel` */
   mechanism_variables_by_ion_channel?: Record<string, unknown>;
+  warnings?: unknown;
 };
 
 export type TFetchNeuronalManipulationPropertiesParams = {

--- a/src/api/one/neuronal-manipulation-properties.ts
+++ b/src/api/one/neuronal-manipulation-properties.ts
@@ -4,46 +4,72 @@ import { obioneApi } from '@/api/one/utils';
 import type { WorkspaceContext } from '@/types/common';
 
 /**
- * `POST /declared/neuronal-manipulation-properties`.
+ * Response body for MEModel and Circuit neuronal-manipulation property endpoints.
  *
- * the mechanism-variables payload is keyed `MechanismVariablesByIonChannel`
- * (same as the schema `property` selector / `RootSelector`). Older backends
- * may still emit snake_case; callers should prefer PascalCase and fall back.
+ * @property MechanismVariablesByIonChannel - Preferred mechanism-variables map key.
+ * @property mechanism_variables_by_ion_channel - Legacy snake_case key; prefer PascalCase.
  */
 export type TNeuronalManipulationPropertiesResponse = {
   entity_type?: string;
   population?: string;
   populations?: string[] | null;
   MechanismVariablesByIonChannel?: Record<string, unknown>;
-  /** @deprecated prefer `MechanismVariablesByIonChannel` */
+  /** @deprecated Prefer `MechanismVariablesByIonChannel`. */
   mechanism_variables_by_ion_channel?: Record<string, unknown>;
   warnings?: unknown;
 };
 
+/** Parameters for {@link fetchNeuronalManipulationProperties}. */
 export type TFetchNeuronalManipulationPropertiesParams = {
   ctx: WorkspaceContext;
-  /** schema `property_endpoints.NeuronalManipulation`  */
+  /**
+   * Schema `property_endpoints.NeuronalManipulation` path without the `/declared` prefix.
+   *
+   * @example `/memodel-neuronal-manipulation-properties`
+   * @example `/circuit-neuronal-manipulation-properties-by-neuron-set`
+   */
   endpoint: string;
-  /** circuit entity id the manipulation targets */
+  /** Target MEModel or Circuit entity id. */
   entityId: string;
-  /** resolved neuron-set block config (a `NeuronSetUnion`), not a reference */
-  neuronSet: unknown;
+  /**
+   * Resolved neuron-set config for Circuit requests (`null` = default target).
+   * Omitted from the POST body when `includeNeuronSet` is false.
+   */
+  neuronSet?: unknown;
+  /**
+   * When `true`, include `neuron_set` in the POST body (Circuit endpoint).
+   * Leave unset/false for MEModel requests.
+   */
+  includeNeuronSet?: boolean;
   signal?: AbortSignal;
 };
 
 /**
- * fetches the ion-channel mechanism variables available for a circuit neuronal
- * manipulation, scoped to the selected neuron set (intersection across the emodels
- * in that set, computed server-side).
+ * Fetches ion-channel mechanism variables for neuronal manipulation UI blocks.
+ *
+ * Posts to `/declared{endpoint}`:
+ * - MEModel: `{ entity_id }`
+ * - Circuit: `{ entity_id, neuron_set }` when `includeNeuronSet` is true
+ *
+ * @param params - Request context, endpoint, entity id, and optional neuron set.
+ * @returns Mechanism variables keyed by ion channel (`MechanismVariablesByIonChannel`).
  */
 export async function fetchNeuronalManipulationProperties({
   ctx,
   endpoint,
   entityId,
   neuronSet,
+  includeNeuronSet = false,
   signal,
 }: TFetchNeuronalManipulationPropertiesParams): Promise<TNeuronalManipulationPropertiesResponse> {
   const api = await obioneApi();
+
+  const body: { entity_id: string; neuron_set?: unknown } = {
+    entity_id: entityId,
+  };
+  if (includeNeuronSet) {
+    body.neuron_set = neuronSet ?? null;
+  }
 
   return api.post<TNeuronalManipulationPropertiesResponse>(`/declared${endpoint}`, {
     headers: {
@@ -51,10 +77,7 @@ export async function fetchNeuronalManipulationProperties({
       accept: 'application/json',
       'Content-Type': 'application/json',
     },
-    body: {
-      entity_id: entityId,
-      neuron_set: neuronSet ?? null,
-    },
+    body,
     signal,
   });
 }

--- a/src/api/one/neuronal-manipulation-properties.ts
+++ b/src/api/one/neuronal-manipulation-properties.ts
@@ -1,0 +1,56 @@
+import { getEntityCoreContext } from '@/api/entitycore/utils';
+import { obioneApi } from '@/api/one/utils';
+
+import type { WorkspaceContext } from '@/types/common';
+
+/**
+ * `POST /declared/neuronal-manipulation-properties`.
+ *
+ * the mechanism-variables payload is keyed `mechanism_variables_by_ion_channel`
+ * (snake_case) — note this differs from the schema's `property` selector
+ * (`MechanismVariablesByIonChannel`) callers should read this field directly
+ */
+export type TNeuronalManipulationPropertiesResponse = {
+  entity_type?: string;
+  population?: string;
+  mechanism_variables_by_ion_channel?: Record<string, unknown>;
+};
+
+export type TFetchNeuronalManipulationPropertiesParams = {
+  ctx: WorkspaceContext;
+  /** schema `property_endpoints.NeuronalManipulation`  */
+  endpoint: string;
+  /** circuit entity id the manipulation targets */
+  entityId: string;
+  /** resolved neuron-set block config (a `NeuronSetUnion`), not a reference */
+  neuronSet: unknown;
+  signal?: AbortSignal;
+};
+
+/**
+ * fetches the ion-channel mechanism variables available for a circuit neuronal
+ * manipulation, scoped to the selected neuron set (intersection across the emodels
+ * in that set, computed server-side).
+ */
+export async function fetchNeuronalManipulationProperties({
+  ctx,
+  endpoint,
+  entityId,
+  neuronSet,
+  signal,
+}: TFetchNeuronalManipulationPropertiesParams): Promise<TNeuronalManipulationPropertiesResponse> {
+  const api = await obioneApi();
+
+  return api.post<TNeuronalManipulationPropertiesResponse>(`/declared${endpoint}`, {
+    headers: {
+      ...getEntityCoreContext(ctx).headers,
+      accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: {
+      entity_id: entityId,
+      neuron_set: neuronSet ?? null,
+    },
+    signal,
+  });
+}

--- a/src/api/one/utils.ts
+++ b/src/api/one/utils.ts
@@ -10,6 +10,11 @@ export async function obioneApi(url?: string) {
   return api;
 }
 
+/**
+ * Normalized obi-one error payload.
+ *
+ * Supports FastAPI `{ detail }` and the envelope `{ error_code, message, details }`.
+ */
 export type TObiOneErrorBody = {
   detail?: unknown;
   error_code?: unknown;
@@ -18,13 +23,12 @@ export type TObiOneErrorBody = {
 } | null;
 
 /**
- * Pull the human-readable reason out of an obi-one error body.
+ * Returns a human-readable reason from an obi-one error body.
  *
- * The service answers in two different shapes. FastAPI's `HTTPException` gives `{ detail }`,
- * while its own error envelope — used for rejected configs and for request validation failures —
- * gives `{ error_code, message, details }`, where the specific reason is in `details[0].msg` and
- * `message` may just be a generic "Validation error". Reading only one of the two is why a
- * rejected config surfaced as a bare "Unknown error".
+ * Preference order: `detail`, `details[0].msg`, then `message`.
+ *
+ * @param body - Parsed error body, or `null`.
+ * @returns Resolved reason string, or `"Unknown error"` when none is present.
  */
 export function getObiOneErrorReason(body: TObiOneErrorBody): string {
   if (isString(body?.detail)) return body.detail;
@@ -33,7 +37,12 @@ export function getObiOneErrorReason(body: TObiOneErrorBody): string {
   return 'Unknown error';
 }
 
-/** Rebuild the obi-one error body from the fields `parseApiError` lifted into the cause. */
+/**
+ * Rebuilds an obi-one error body from fields lifted onto {@link ApiError.cause}.
+ *
+ * @param error - Caught value; only {@link ApiError} instances yield a body.
+ * @returns Normalized body, or `null` when `error` is not an {@link ApiError}.
+ */
 export function toObiOneErrorBody(error: unknown): TObiOneErrorBody {
   if (!(error instanceof ApiError)) return null;
   const { detail, code, message, details } = error.cause ?? {};
@@ -49,12 +58,21 @@ export const ScanConfigGenerationStep = {
 export type TScanConfigGenerationStep =
   (typeof ScanConfigGenerationStep)[keyof typeof ScanConfigGenerationStep];
 
-/** Carries which step of campaign generation failed and the raw obi-one error body. */
+/**
+ * Error raised when scan-config campaign generation fails.
+ *
+ * @property step - Failing generation step.
+ * @property body - Raw obi-one error body for the step, when available.
+ */
 export class ScanConfigGenerationError extends Error {
   readonly step: TScanConfigGenerationStep;
 
   readonly body: TObiOneErrorBody;
 
+  /**
+   * @param step - Failing generation step.
+   * @param body - Optional obi-one error body used to build `message`.
+   */
   constructor(step: TScanConfigGenerationStep, body: TObiOneErrorBody = null) {
     super(getObiOneErrorReason(body));
     this.name = 'ScanConfigGenerationError';

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -51,9 +51,21 @@ function findMappedEntry<T>(arr: any[], fn: (item: any) => any) {
   return undefined;
 }
 
-const API_ERROR_CODE_PATHS = ['error.code', 'error_code', 'code'];
-const API_ERROR_MESSAGE_PATHS = ['error.message', 'error_message', 'message'];
-const API_ERROR_DETAILS_PATHS = ['error.details', 'error_details', 'details', 'data'];
+const API_ERROR_CODE_PATHS = ['error.code', 'error_code', 'code', 'detail.code'];
+const API_ERROR_MESSAGE_PATHS = [
+  'error.message',
+  'error_message',
+  'message',
+  'detail.detail',
+  'detail',
+];
+const API_ERROR_DETAILS_PATHS = [
+  'error.details',
+  'error_details',
+  'details',
+  'detail.detail',
+  'data',
+];
 
 /*
  * Parse the error code from the API response.
@@ -74,9 +86,10 @@ export async function parseApiError(
         : apiClientResponseData;
 
     const code = findMappedEntry<string>(API_ERROR_CODE_PATHS, (path) => get(responseData, path));
-    const message = findMappedEntry<string>(API_ERROR_MESSAGE_PATHS, (path) =>
-      get(responseData, path)
-    );
+    const message = findMappedEntry<string>(API_ERROR_MESSAGE_PATHS, (path) => {
+      const value = get(responseData, path);
+      return typeof value === 'string' ? value : undefined;
+    });
     const details = findMappedEntry<string>(API_ERROR_DETAILS_PATHS, (path) =>
       get(responseData, path)
     );

--- a/src/features/scan-config/components/block-dictionary-entries.tsx
+++ b/src/features/scan-config/components/block-dictionary-entries.tsx
@@ -13,6 +13,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import { Fragment, memo, useMemo } from 'react';
 
 import { useFieldErrors } from '@/features/scan-config/components/hooks/field-errors';
+import { clearDeletedBlockReferences } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/state';
 import { useEntryDiff } from '@/features/scan-config/hooks/use-entry-diff';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/molecules/tooltip';
 import { cn } from '@/utils/css-class';
@@ -22,7 +23,7 @@ import { isPlainObject } from './utils';
 
 import type { ErrorObject } from 'ajv';
 import type React from 'react';
-import type { Config, IBlockDictionary, TBlock } from '@/features/scan-config/types';
+import type { Config, ConfigSchema, IBlockDictionary, TBlock } from '@/features/scan-config/types';
 import type { ConfigHighlight } from '@/state/config-highlights';
 
 import styles from './block-dictionary-entries.module.css';
@@ -51,9 +52,9 @@ function EntryTab({
       className={cn(
         'text-primary-8 flex h-12.5 min-h-12.5 min-w-37.5 items-center justify-between ',
         'rounded-full bg-gray-100 px-5 py-2 text-sm drop-shadow ',
-        'hover:bg-linear-to-r hover:from-[#003A8C] hover:to-[#001026] hover:text-white gap-1',
+        'hover:bg-linear-to-r hover:from-[#003A8C] hover:to-primary-10 hover:text-white gap-1',
         {
-          'bg-linear-to-r from-[#003A8C] to-[#001026] text-white shadow-bnb': isSelected,
+          'bg-linear-to-r from-[#003A8C] to-primary-10 text-white shadow-bnb': isSelected,
         },
         styles.entryButton,
         diffClass
@@ -101,9 +102,11 @@ export default function BlockDictionaryEntries({
   highlights = [],
   visible,
   rootElementSchema,
+  schema,
 }: {
   config: Config;
   setConfig: (newConfig: Config) => void;
+  schema: ConfigSchema;
   rootElementSchema: IBlockDictionary;
   rootElement: string;
   selectedEntry: string;
@@ -359,21 +362,19 @@ export default function BlockDictionaryEntries({
 
                                     delete targetSection[subkey];
 
-                                    const initConfig = newConfig.initialize;
-                                    if (
-                                      isPlainObject(initConfig) &&
-                                      isPlainObject(initConfig.node_set) &&
-                                      typeof initConfig.node_set.block_name === 'string' &&
-                                      initConfig.node_set.block_name === subkey
-                                    ) {
-                                      initConfig.node_set = null;
-                                    }
+                                    // Schema-aware cleanup: clear refs + dependent manipulation fields
+                                    const cleaned = clearDeletedBlockReferences(
+                                      newConfig,
+                                      schema,
+                                      rootElement,
+                                      subkey
+                                    );
 
-                                    Object.entries(newConfig).forEach(([configK, configV]) => {
+                                    // Also clear nested refs (e.g. combination tuples)
+                                    Object.entries(cleaned).forEach(([configK, configV]) => {
                                       if (configK === 'initialize' || !isPlainObject(configV))
                                         return;
 
-                                      // Clear refs in section entries (incl. nested combination tuples)
                                       Object.values(configV).forEach((entryV) => {
                                         rewriteBlockReferences(entryV, subkey, {
                                           type: RewriteBlockReferencesModeDict.Clear,
@@ -381,7 +382,7 @@ export default function BlockDictionaryEntries({
                                       });
                                     });
 
-                                    setConfig(newConfig);
+                                    setConfig(cleaned);
 
                                     setSelectedEntry('');
                                     allEntries.delete(subkey);

--- a/src/features/scan-config/components/hooks/schema.ts
+++ b/src/features/scan-config/components/hooks/schema.ts
@@ -91,7 +91,12 @@ type NodeProperties = z.infer<typeof nodePropertyUniqueValuesSchema>;
 
 export const usabilitySchema = z.record(z.string(), z.boolean());
 
-/** obi-one `/declared/mapped-circuit-properties/{id}` — Circuit entity (combined neuron sets). */
+/**
+ * Circuit fields from `GET /declared/mapped-circuit-properties/{id}`.
+ *
+ * Mechanism variables are loaded from dedicated neuronal-manipulation POST endpoints,
+ * not from this response.
+ */
 const circuitMappedPropertiesSchema = z.object({
   NodePropertyUniqueValuesByPopulation: nodePropertyUniqueValuesSchema,
   NodeSet: z.array(z.string()).optional(),
@@ -102,25 +107,22 @@ const circuitMappedPropertiesSchema = z.object({
   NeuronalPopulation: z.array(z.string()).optional(),
 });
 
-/** obi-one `/declared/mapped-circuit-properties/{id}` — MEModel entity (single neuron beta). */
-const memodelMappedPropertiesSchema = z.object({
-  MechanismVariablesByIonChannel: z.record(z.string(), z.unknown()),
-});
-
 /**
- * Validates mapped-circuit-properties from obi-one.
- *
- * Circuit and MEModel entities return different property sets from the same endpoint;
- * both shapes must be accepted so neuron property filters and ion-channel manipulations work.
+ * Zod schema for mapped-circuit-properties responses (usability + Circuit neuron-set data).
  */
 export const configSchema = z
   .object({
     usability: usabilitySchema,
   })
   .merge(circuitMappedPropertiesSchema.partial())
-  .merge(memodelMappedPropertiesSchema.partial())
   .catchall(z.unknown());
 
+/**
+ * Parses and validates a mapped-circuit-properties response.
+ *
+ * @param resp - Raw API response.
+ * @returns Validated usability and Circuit mapping properties.
+ */
 export function parseSchemaMappingConfiguration(resp: unknown) {
   return configSchema.parse(resp);
 }

--- a/src/features/scan-config/components/hooks/use-neuronal-manipulation-properties.ts
+++ b/src/features/scan-config/components/hooks/use-neuronal-manipulation-properties.ts
@@ -13,24 +13,31 @@ import {
 
 import type { WorkspaceContext } from '@/types/common';
 
-const STALE_TIME_MS = 60 * 60 * 1000; // 1 hour
+const STALE_TIME_MS = 60 * 60 * 1000;
 
+/** Parameters for {@link useNeuronalManipulationProperties}. */
 export type TUseNeuronalManipulationPropertiesParams = {
   workspace: WorkspaceContext;
-  /** circuit entity id the manipulation targets */
+  /** Target MEModel or Circuit entity id. */
   entityId: string | undefined;
-  /** schema `property_endpoints.NeuronalManipulation` */
+  /** Schema `property_endpoints.NeuronalManipulation` path. */
   endpoint: string | undefined;
-  /** resolved neuron-set block config; null (default target) when none is selected */
-  neuronSet: unknown;
-  /** extra gate */
+  /**
+   * Circuit-only resolved neuron-set config (`null` = default target).
+   * Omit for MEModel fetches.
+   */
+  neuronSet?: unknown;
+  /** When `true`, include `neuron_set` in the POST body (Circuit endpoint). */
+  includeNeuronSet?: boolean;
+  /** Additional enable gate for the query. */
   enabled?: boolean;
 };
 
 /**
- * picks the mechanism-variables map from the neuronal-manipulation-properties
- * response. prefers PascalCase (`MechanismVariablesByIonChannel`); falls back to
- * legacy snake_case for older backends.
+ * Selects the mechanism-variables map from a neuronal-manipulation properties response.
+ *
+ * @param resp - Raw endpoint response.
+ * @returns PascalCase `MechanismVariablesByIonChannel` when present; otherwise legacy snake_case; otherwise `{}`.
  */
 export function selectMechanismVariablesRoot(
   resp: TNeuronalManipulationPropertiesResponse
@@ -40,25 +47,34 @@ export function selectMechanismVariablesRoot(
 }
 
 /**
- * loads the mechanism variables available for a circuit neuronal manipulation,
- * scoped to the selected neuron set.
- * runs once an entity id and endpoint are known; an unselected neuron set is sent to the endpoint as null (the default target).
+ * Loads mechanism variables for neuronal manipulation blocks.
+ *
+ * Circuit callers should pass `includeNeuronSet: true` and a resolved `neuronSet`
+ * (including `null` for the default target). MEModel callers omit both.
+ *
+ * @param params - Workspace, entity, endpoint, and optional neuron-set scope.
+ * @returns React Query result with selected {@link MechanismVariablesRoot}.
  */
 export function useNeuronalManipulationProperties({
   workspace,
   entityId,
   endpoint,
   neuronSet,
+  includeNeuronSet = false,
   enabled = true,
 }: TUseNeuronalManipulationPropertiesParams) {
   return useQuery({
-    queryKey: ['neuronal-manipulation-properties', { workspace, entityId, endpoint, neuronSet }],
+    queryKey: [
+      'neuronal-manipulation-properties',
+      { workspace, entityId, endpoint, neuronSet, includeNeuronSet },
+    ],
     queryFn: ({ signal }) =>
       fetchNeuronalManipulationProperties({
         ctx: workspace,
         endpoint: endpoint as string,
         entityId: entityId as string,
         neuronSet,
+        includeNeuronSet,
         signal,
       }),
     enabled: enabled && !!entityId && !!endpoint,

--- a/src/features/scan-config/components/hooks/use-neuronal-manipulation-properties.ts
+++ b/src/features/scan-config/components/hooks/use-neuronal-manipulation-properties.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchNeuronalManipulationProperties } from '@/api/one/neuronal-manipulation-properties';
+
+import type { MechanismVariablesRoot } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/mapping';
+import type { WorkspaceContext } from '@/types/common';
+
+const STALE_TIME_MS = 60 * 60 * 1000; // 1 hour
+
+export type TUseNeuronalManipulationPropertiesParams = {
+  workspace: WorkspaceContext;
+  /** circuit entity id the manipulation targets */
+  entityId: string | undefined;
+  /** schema `property_endpoints.NeuronalManipulation` */
+  endpoint: string | undefined;
+  /** resolved neuron-set block config; null (default target) when none is selected */
+  neuronSet: unknown;
+  /** extra gate */
+  enabled?: boolean;
+};
+
+/**
+ * loads the mechanism variables available for a circuit neuronal manipulation,
+ * scoped to the selected neuron set.
+ * runs once an entity id and endpoint are known; an unselected neuron set is sent to the endpoint as null (the default target).
+ */
+export function useNeuronalManipulationProperties({
+  workspace,
+  entityId,
+  endpoint,
+  neuronSet,
+  enabled = true,
+}: TUseNeuronalManipulationPropertiesParams) {
+  return useQuery({
+    queryKey: ['neuronal-manipulation-properties', { workspace, entityId, endpoint, neuronSet }],
+    queryFn: ({ signal }) =>
+      fetchNeuronalManipulationProperties({
+        ctx: workspace,
+        endpoint: endpoint as string,
+        entityId: entityId as string,
+        neuronSet,
+        signal,
+      }),
+    enabled: enabled && !!entityId && !!endpoint,
+    refetchOnWindowFocus: false,
+    staleTime: STALE_TIME_MS,
+    select: (resp): MechanismVariablesRoot =>
+      (resp.mechanism_variables_by_ion_channel as MechanismVariablesRoot | undefined) ?? {},
+  });
+}

--- a/src/features/scan-config/components/hooks/use-neuronal-manipulation-properties.ts
+++ b/src/features/scan-config/components/hooks/use-neuronal-manipulation-properties.ts
@@ -2,9 +2,15 @@
 
 import { useQuery } from '@tanstack/react-query';
 
-import { fetchNeuronalManipulationProperties } from '@/api/one/neuronal-manipulation-properties';
+import {
+  fetchNeuronalManipulationProperties,
+  type TNeuronalManipulationPropertiesResponse,
+} from '@/api/one/neuronal-manipulation-properties';
+import {
+  type MechanismVariablesRoot,
+  RootSelector,
+} from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/mapping';
 
-import type { MechanismVariablesRoot } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/mapping';
 import type { WorkspaceContext } from '@/types/common';
 
 const STALE_TIME_MS = 60 * 60 * 1000; // 1 hour
@@ -20,6 +26,18 @@ export type TUseNeuronalManipulationPropertiesParams = {
   /** extra gate */
   enabled?: boolean;
 };
+
+/**
+ * picks the mechanism-variables map from the neuronal-manipulation-properties
+ * response. prefers PascalCase (`MechanismVariablesByIonChannel`); falls back to
+ * legacy snake_case for older backends.
+ */
+export function selectMechanismVariablesRoot(
+  resp: TNeuronalManipulationPropertiesResponse
+): MechanismVariablesRoot {
+  const root = resp[RootSelector] ?? resp.mechanism_variables_by_ion_channel ?? undefined;
+  return (root as MechanismVariablesRoot | undefined) ?? {};
+}
 
 /**
  * loads the mechanism variables available for a circuit neuronal manipulation,
@@ -46,7 +64,6 @@ export function useNeuronalManipulationProperties({
     enabled: enabled && !!entityId && !!endpoint,
     refetchOnWindowFocus: false,
     staleTime: STALE_TIME_MS,
-    select: (resp): MechanismVariablesRoot =>
-      (resp.mechanism_variables_by_ion_channel as MechanismVariablesRoot | undefined) ?? {},
+    select: selectMechanismVariablesRoot,
   });
 }

--- a/src/features/scan-config/components/root-element.tsx
+++ b/src/features/scan-config/components/root-element.tsx
@@ -74,7 +74,7 @@ export function RootElement({
   const { highlights, hasHighlights, isExpanded, diffClass } = useRootElementDiff(rootElement);
   const hasFieldErrors = useFieldErrorsForPath(rootElement);
 
-  if (!schema || !schema?.properties) return;
+  if (!schema?.properties) return;
 
   const handleEntryClick = (subkey: string) => {
     setSelectedRootElement(rootElement); // Select the parent block
@@ -191,6 +191,7 @@ export function RootElement({
       {rootElementSchema.ui_element === ScanConfigUIElementDict.BlockDictionary &&
         (config[rootElement] || hasHighlights) && (
           <BlockDictionaryEntries
+            schema={schema}
             config={config}
             setConfig={setConfig}
             rootElement={rootElement}

--- a/src/features/scan-config/components/ui-elements/index.tsx
+++ b/src/features/scan-config/components/ui-elements/index.tsx
@@ -8,10 +8,6 @@ import { CircuitGlobal } from '@/features/scan-config/components/ui-elements/ion
 import { CircuitRange } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/range';
 import { Global } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/me-model/global';
 import { Range } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/me-model/range';
-import {
-  type MechanismVariablesRoot,
-  RootSelector,
-} from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/mapping';
 import { ModelIdentifier } from '@/features/scan-config/components/ui-elements/model-identifier';
 import { ModelIdentifierMultiple } from '@/features/scan-config/components/ui-elements/model-identifier-multiple';
 import { EntitySelectorSingle } from '@/features/scan-config/components/ui-elements/model-selector-single';
@@ -48,11 +44,11 @@ import {
   ScanConfigUIElementDict,
   type TSupportedEntitiesForScanConfiguration,
 } from '@/features/scan-config/types';
-import { isObject } from '@/util/type-guards';
 
 import type { TEntityTypeDict } from '@/api/entitycore/types';
 import type { TSchemaMappingConfiguration } from '@/features/scan-config/components/hooks/schema';
 import type { Nullish } from '@/utils/type';
+
 export type SetAtom<Args extends unknown[], Result> = (...args: Args) => Result;
 
 export function UIElementRender({
@@ -308,15 +304,14 @@ export function UIElementRender({
           );
         }
 
-        // me-model variant: variables come from the form-level mapped-circuit-properties
-        const rawMechanismConfig = get(schemaMappingConfig?.properties, RootSelector, null);
-        const mechanismConfig: MechanismVariablesRoot | null =
-          rawMechanismConfig && isObject(rawMechanismConfig)
-            ? (rawMechanismConfig as unknown as MechanismVariablesRoot)
-            : null;
         return (
           <Global
-            data={mechanismConfig}
+            endpoint={
+              paramSchema.property_group
+                ? schema.property_endpoints?.[paramSchema.property_group]
+                : undefined
+            }
+            entityId={entity?.id}
             disabled={disabled}
             state={state}
             setState={setState}
@@ -341,7 +336,6 @@ export function UIElementRender({
         );
         const manipulationVariantType = typeof state.type === 'string' ? state.type : undefined;
 
-        // circuit variant (variant type.const prefixed with `Circuit`)
         if (isCircuitNeuronalManipulationType(manipulationVariantType)) {
           return (
             <CircuitRange
@@ -365,14 +359,14 @@ export function UIElementRender({
           );
         }
 
-        const rawMechanismConfig = get(schemaMappingConfig?.properties, RootSelector, null);
-        const mechanismConfig: MechanismVariablesRoot | null =
-          rawMechanismConfig && isObject(rawMechanismConfig)
-            ? (rawMechanismConfig as unknown as MechanismVariablesRoot)
-            : null;
         return (
           <Range
-            data={mechanismConfig}
+            endpoint={
+              paramSchema.property_group
+                ? schema.property_endpoints?.[paramSchema.property_group]
+                : undefined
+            }
+            entityId={entity?.id}
             disabled={disabled}
             state={state}
             setState={setState}

--- a/src/features/scan-config/components/ui-elements/index.tsx
+++ b/src/features/scan-config/components/ui-elements/index.tsx
@@ -4,8 +4,10 @@ import { match, P } from 'ts-pattern';
 
 import BooleanInput from '@/features/scan-config/components/ui-elements/boolean-input';
 import EntityPropertyDropdown from '@/features/scan-config/components/ui-elements/entity-property-dropdown';
-import { Global } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/global';
-import { Range } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/range';
+import { CircuitGlobal } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/global';
+import { CircuitRange } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/range';
+import { Global } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/me-model/global';
+import { Range } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/me-model/range';
 import {
   type MechanismVariablesRoot,
   RootSelector,
@@ -37,9 +39,11 @@ import {
   type TEntityQuery,
 } from '@/features/scan-config/helpers';
 import {
+  CIRCUIT_NEURONAL_MANIPULATION_SOURCE_FIELD,
   type Config,
   type ConfigSchema,
   type ConfigValue,
+  isCircuitNeuronalManipulationType,
   type ParamSchema,
   ScanConfigUIElementDict,
   type TSupportedEntitiesForScanConfiguration,
@@ -278,12 +282,38 @@ export function UIElementRender({
         paramSchema: { ui_element: ScanConfigUIElementDict.IonChannelVariableModificationByNeuron },
       },
       ({ paramSchema }) => {
+        const modificationType = get(paramSchema, 'properties.type.const', 'ByNeuronModification');
+        const manipulationVariantType = typeof state.type === 'string' ? state.type : undefined;
+
+        if (isCircuitNeuronalManipulationType(manipulationVariantType)) {
+          return (
+            <CircuitGlobal
+              config={config}
+              state={state}
+              setState={setState}
+              sourceField={
+                paramSchema.property_source_field ?? CIRCUIT_NEURONAL_MANIPULATION_SOURCE_FIELD
+              }
+              fieldKey={k}
+              endpoint={
+                paramSchema.property_group
+                  ? schema.property_endpoints?.[paramSchema.property_group]
+                  : undefined
+              }
+              entityId={entity?.id}
+              disabled={disabled}
+              modificationType={modificationType}
+              errorPathPrefix={errorPathPrefix}
+            />
+          );
+        }
+
+        // me-model variant: variables come from the form-level mapped-circuit-properties
         const rawMechanismConfig = get(schemaMappingConfig?.properties, RootSelector, null);
         const mechanismConfig: MechanismVariablesRoot | null =
           rawMechanismConfig && isObject(rawMechanismConfig)
             ? (rawMechanismConfig as unknown as MechanismVariablesRoot)
             : null;
-        const modificationType = get(paramSchema, 'properties.type.const', 'ByNeuronModification');
         return (
           <Global
             data={mechanismConfig}
@@ -304,16 +334,42 @@ export function UIElementRender({
         },
       },
       ({ paramSchema }) => {
-        const rawMechanismConfig = get(schemaMappingConfig?.properties, RootSelector, null);
-        const mechanismConfig: MechanismVariablesRoot | null =
-          rawMechanismConfig && isObject(rawMechanismConfig)
-            ? (rawMechanismConfig as unknown as MechanismVariablesRoot)
-            : null;
         const modificationType = get(
           paramSchema,
           'properties.type.const',
           'BySectionListModification'
         );
+        const manipulationVariantType = typeof state.type === 'string' ? state.type : undefined;
+
+        // circuit variant (variant type.const prefixed with `Circuit`)
+        if (isCircuitNeuronalManipulationType(manipulationVariantType)) {
+          return (
+            <CircuitRange
+              config={config}
+              state={state}
+              setState={setState}
+              sourceField={
+                paramSchema.property_source_field ?? CIRCUIT_NEURONAL_MANIPULATION_SOURCE_FIELD
+              }
+              fieldKey={k}
+              endpoint={
+                paramSchema.property_group
+                  ? schema.property_endpoints?.[paramSchema.property_group]
+                  : undefined
+              }
+              entityId={entity?.id}
+              disabled={disabled}
+              modificationType={modificationType}
+              errorPathPrefix={errorPathPrefix}
+            />
+          );
+        }
+
+        const rawMechanismConfig = get(schemaMappingConfig?.properties, RootSelector, null);
+        const mechanismConfig: MechanismVariablesRoot | null =
+          rawMechanismConfig && isObject(rawMechanismConfig)
+            ? (rawMechanismConfig as unknown as MechanismVariablesRoot)
+            : null;
         return (
           <Range
             data={mechanismConfig}

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/global.tsx
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/global.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/use-circuit-manipulation-data';
 import { GlobalModificationBase } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/global-base';
 
+/** Props for the Circuit full-neuron variable modification UI. */
 export type CircuitGlobalProps = TUseCircuitManipulationDataParams & {
   disabled: boolean;
   modificationType: string;
@@ -13,10 +14,11 @@ export type CircuitGlobalProps = TUseCircuitManipulationDataParams & {
 };
 
 /**
- * circuit variant of `ion_channel_variable_modification_by_neuron`.
+ * Circuit UI for `ion_channel_variable_modification_by_neuron`.
  *
- * unlike the me-model `Global`, variables are fetched per block from the selected
- * neuron set; this composes the shared data hook with the presentational base
+ * @param props - Neuron-set source, endpoint/entity, and form field wiring.
+ * @returns Presentational modification UI backed by {@link useCircuitManipulationData}.
+ * @see Global
  */
 export function CircuitGlobal({
   config,

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/global.tsx
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/global.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import {
+  type TUseCircuitManipulationDataParams,
+  useCircuitManipulationData,
+} from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/use-circuit-manipulation-data';
+import { GlobalModificationBase } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/global-base';
+
+export type CircuitGlobalProps = TUseCircuitManipulationDataParams & {
+  disabled: boolean;
+  modificationType: string;
+  errorPathPrefix?: string;
+};
+
+/**
+ * circuit variant of `ion_channel_variable_modification_by_neuron`.
+ *
+ * unlike the me-model `Global`, variables are fetched per block from the selected
+ * neuron set; this composes the shared data hook with the presentational base
+ */
+export function CircuitGlobal({
+  config,
+  state,
+  setState,
+  sourceField,
+  fieldKey,
+  endpoint,
+  entityId,
+  disabled,
+  modificationType,
+  errorPathPrefix,
+}: CircuitGlobalProps) {
+  const { data, loading, reason } = useCircuitManipulationData({
+    config,
+    state,
+    setState,
+    sourceField,
+    fieldKey,
+    endpoint,
+    entityId,
+  });
+
+  return (
+    <GlobalModificationBase
+      data={data}
+      loading={loading}
+      reason={reason}
+      disabled={disabled}
+      state={state}
+      setState={setState}
+      fieldKey={fieldKey}
+      modificationType={modificationType}
+      errorPathPrefix={errorPathPrefix}
+    />
+  );
+}

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/range.tsx
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/range.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/use-circuit-manipulation-data';
 import { RangeModificationBase } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/range-base';
 
+/** Props for the Circuit section-list variable modification UI. */
 export type CircuitRangeProps = TUseCircuitManipulationDataParams & {
   disabled: boolean;
   modificationType: string;
@@ -13,10 +14,11 @@ export type CircuitRangeProps = TUseCircuitManipulationDataParams & {
 };
 
 /**
- * circuit variant of `ion_channel_variable_modification_by_section_list`.
+ * Circuit UI for `ion_channel_variable_modification_by_section_list`.
  *
- * unlike the me-model `Range`, variables are fetched per block from the selected
- * neuron set; this composes the shared data hook with the presentational base.
+ * @param props - Neuron-set source, endpoint/entity, and form field wiring.
+ * @returns Presentational modification UI backed by {@link useCircuitManipulationData}.
+ * @see Range
  */
 export function CircuitRange({
   config,

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/range.tsx
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/range.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import {
+  type TUseCircuitManipulationDataParams,
+  useCircuitManipulationData,
+} from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/use-circuit-manipulation-data';
+import { RangeModificationBase } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/range-base';
+
+export type CircuitRangeProps = TUseCircuitManipulationDataParams & {
+  disabled: boolean;
+  modificationType: string;
+  errorPathPrefix?: string;
+};
+
+/**
+ * circuit variant of `ion_channel_variable_modification_by_section_list`.
+ *
+ * unlike the me-model `Range`, variables are fetched per block from the selected
+ * neuron set; this composes the shared data hook with the presentational base.
+ */
+export function CircuitRange({
+  config,
+  state,
+  setState,
+  sourceField,
+  fieldKey,
+  endpoint,
+  entityId,
+  disabled,
+  modificationType,
+  errorPathPrefix,
+}: CircuitRangeProps) {
+  const { data, loading, reason } = useCircuitManipulationData({
+    config,
+    state,
+    setState,
+    sourceField,
+    fieldKey,
+    endpoint,
+    entityId,
+  });
+
+  return (
+    <RangeModificationBase
+      data={data}
+      loading={loading}
+      reason={reason}
+      disabled={disabled}
+      state={state}
+      setState={setState}
+      fieldKey={fieldKey}
+      modificationType={modificationType}
+      errorPathPrefix={errorPathPrefix}
+    />
+  );
+}

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/state.nodetest.ts
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/state.nodetest.ts
@@ -1,0 +1,172 @@
+import type { Config } from '@/features/scan-config/types';
+
+const assert: typeof import('node:assert/strict') = require('node:assert/strict');
+const fs: typeof import('node:fs') = require('node:fs');
+const Module: typeof import('node:module') = require('node:module');
+const path: typeof import('node:path') = require('node:path');
+const test: typeof import('node:test') = require('node:test');
+const ts: typeof import('typescript') = require('typescript');
+const { describe, it } = test;
+
+type NodeModuleConstructor = typeof Module & {
+  _nodeModulePaths(from: string): string[];
+};
+type TranspiledModule = InstanceType<typeof Module> & {
+  _compile(code: string, filename: string): void;
+};
+
+const ScanConfigUIElementDict = {
+  BlockSingle: 'block_single',
+  BlockDictionary: 'block_dictionary',
+  BlockUnion: 'block_union',
+  Reference: 'reference',
+  IonChannelVariableModificationByNeuron: 'ion_channel_variable_modification_by_neuron',
+  ionChannelVariableModificationBySectionList: 'ion_channel_variable_modification_by_section_list',
+} as const;
+
+function loadStateHelpers(): typeof import('./state') {
+  const statePath = path.join(__dirname, 'state.ts');
+  const source = fs.readFileSync(statePath, 'utf8');
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }).outputText;
+  const NodeModule = Module as NodeModuleConstructor;
+  const stateModule = new NodeModule(statePath, module) as TranspiledModule;
+
+  stateModule.filename = statePath;
+  stateModule.paths = NodeModule._nodeModulePaths(path.dirname(statePath));
+  stateModule.require = ((id: string) => {
+    if (id === '../../../utils') {
+      return {
+        isPlainObject: (value: unknown) =>
+          typeof value === 'object' && value !== null && !Array.isArray(value),
+      };
+    }
+
+    if (id === '../../../../types') {
+      return {
+        isType: (value: unknown) =>
+          typeof value === 'object' &&
+          value !== null &&
+          !Array.isArray(value) &&
+          'const' in value &&
+          !('ui_element' in value),
+        ScanConfigUIElementDict,
+      };
+    }
+
+    return require(id);
+  }) as NodeJS.Require;
+
+  stateModule._compile(output, statePath);
+  return stateModule.exports;
+}
+
+const stateHelpers = loadStateHelpers();
+const { clearDeletedBlockReferences, resolveNeuronSet } = stateHelpers;
+
+describe('circuit ion-channel manipulation state', () => {
+  it('changes the target signature when the referenced neuron-set content changes', () => {
+    const firstConfig: Config = {
+      neuron_sets: {
+        selected: {
+          type: 'NeuronSet',
+          population: 'S1',
+          node_id: [1, 2],
+        },
+      },
+    };
+    const secondConfig: Config = {
+      neuron_sets: {
+        selected: {
+          type: 'NeuronSet',
+          population: 'S1',
+          node_id: [1, 2, 3],
+        },
+      },
+    };
+    const reference = {
+      block_name: 'selected',
+      block_dict_name: 'neuron_sets',
+    };
+
+    assert.notEqual(
+      resolveNeuronSet(firstConfig, reference).signature,
+      resolveNeuronSet(secondConfig, reference).signature
+    );
+  });
+
+  it('clears a circuit manipulation when its referenced neuron-set entry is deleted', () => {
+    const schema = {
+      properties: {
+        initialize: {
+          ui_element: ScanConfigUIElementDict.BlockSingle,
+          properties: {
+            type: { const: 'Initialize', default: 'Initialize' },
+            neuron_set: {
+              ui_element: ScanConfigUIElementDict.Reference,
+              reference_type: 'NeuronSet',
+              title: 'Neuron set',
+              description: '',
+            },
+            manipulation: {
+              ui_element: ScanConfigUIElementDict.ionChannelVariableModificationBySectionList,
+              property_source_field: 'neuron_set',
+              title: 'Manipulation',
+              description: '',
+              type: 'object',
+              properties: {
+                type: {
+                  const: 'BySectionListModification',
+                  default: 'BySectionListModification',
+                },
+              },
+            },
+          },
+        },
+        neuron_sets: {
+          ui_element: ScanConfigUIElementDict.BlockDictionary,
+          additionalProperties: {
+            oneOf: [
+              {
+                properties: {
+                  type: { const: 'NeuronSet', default: 'NeuronSet' },
+                },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as Parameters<typeof clearDeletedBlockReferences>[1];
+    const config: Config = {
+      initialize: {
+        type: 'Initialize',
+        neuron_set: {
+          block_name: 'target-set',
+          block_dict_name: 'neuron_sets',
+        },
+        manipulation: {
+          type: 'BySectionListModification',
+          ion_channel_id: 'channel-1',
+          variable_name: 'gbar',
+        },
+      },
+      neuron_sets: {
+        'target-set': {
+          type: 'NeuronSet',
+        },
+      },
+    };
+
+    const next = clearDeletedBlockReferences(config, schema, 'neuron_sets', 'target-set');
+
+    assert.deepEqual(next.initialize, {
+      type: 'Initialize',
+      neuron_set: null,
+      manipulation: null,
+    });
+  });
+});

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/state.ts
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/state.ts
@@ -1,0 +1,221 @@
+import { isPlainObject } from '@/features/scan-config/components/utils';
+import { isType, ScanConfigUIElementDict } from '@/features/scan-config/types';
+
+import type {
+  Config,
+  ConfigObject,
+  ConfigSchema,
+  ConfigValue,
+  TBlock,
+} from '@/features/scan-config/types';
+
+export type ResolvedNeuronSet = {
+  /** referenced neuron-set block key; null means the default target */
+  key: string | null;
+  /** resolved neuron-set block config sent to the endpoint; null means default or missing */
+  value: ConfigValue | null;
+  /** stable identity for the targeted neuron-set content */
+  signature: string;
+};
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+
+  if (isPlainObject(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+function referenceMatchesDeletedBlock(
+  value: unknown,
+  deletedBlockDictionaryName: string,
+  deletedBlockName: string
+) {
+  if (
+    !isPlainObject(value) ||
+    value.block_name !== deletedBlockName ||
+    (typeof value.block_dict_name === 'string' &&
+      value.block_dict_name !== deletedBlockDictionaryName)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function findMatchingBlock(blocks: TBlock[] | undefined, state: ConfigObject): TBlock | null {
+  if (!blocks) return null;
+  const stateType = state.type;
+  return (
+    blocks.find((block) => {
+      const typeSchema = block.properties?.type;
+      return isPlainObject(typeSchema) && typeSchema.const === stateType;
+    }) ?? null
+  );
+}
+
+function getBlockSchemaForState(
+  rootSchema: ConfigSchema['properties'][string] | undefined,
+  state: ConfigObject
+): TBlock | null {
+  if (!rootSchema) return null;
+
+  if (rootSchema.ui_element === ScanConfigUIElementDict.BlockDictionary) {
+    return findMatchingBlock(rootSchema.additionalProperties?.oneOf, state);
+  }
+
+  if (rootSchema.ui_element === ScanConfigUIElementDict.BlockUnion) {
+    return findMatchingBlock(rootSchema.oneOf, state);
+  }
+
+  return rootSchema;
+}
+
+function getDependentManipulationFields(blockSchema: TBlock | null, sourceField: string) {
+  if (!blockSchema?.properties) return [];
+
+  return Object.entries(blockSchema.properties)
+    .filter(([, fieldSchema]) => {
+      if (isType(fieldSchema)) return false;
+      if (!isPlainObject(fieldSchema)) return false;
+      if (fieldSchema.property_source_field !== sourceField) return false;
+      return (
+        fieldSchema.ui_element === ScanConfigUIElementDict.IonChannelVariableModificationByNeuron ||
+        fieldSchema.ui_element ===
+          ScanConfigUIElementDict.ionChannelVariableModificationBySectionList
+      );
+    })
+    .map(([fieldKey]) => fieldKey);
+}
+
+function clearSourceReferenceAndDependents({
+  state,
+  blockSchema,
+  rootKey,
+  sourceField,
+}: {
+  state: ConfigObject;
+  blockSchema: TBlock | null;
+  rootKey: string;
+  sourceField: string;
+}) {
+  if (rootKey === 'initialize') {
+    state[sourceField] = null;
+  } else {
+    delete state[sourceField];
+  }
+
+  for (const dependentField of getDependentManipulationFields(blockSchema, sourceField)) {
+    if (dependentField in state) {
+      state[dependentField] = null;
+    }
+  }
+}
+
+function clearDeletedReferencesInState({
+  state,
+  blockSchema,
+  rootKey,
+  deletedBlockDictionaryName,
+  deletedBlockName,
+}: {
+  state: ConfigObject;
+  blockSchema: TBlock | null;
+  rootKey: string;
+  deletedBlockDictionaryName: string;
+  deletedBlockName: string;
+}) {
+  for (const [fieldKey, fieldValue] of Object.entries(state)) {
+    if (!referenceMatchesDeletedBlock(fieldValue, deletedBlockDictionaryName, deletedBlockName)) {
+      continue;
+    }
+
+    clearSourceReferenceAndDependents({
+      state,
+      blockSchema,
+      rootKey,
+      sourceField: fieldKey,
+    });
+  }
+}
+
+/**
+ * resolves a reference value (`{ block_name, block_dict_name }`) to the concrete
+ * neuron-set block config it points at
+ * the stable signature changes when either the selected block name or the selected block's contents change.
+ */
+export function resolveNeuronSet(
+  config: Config,
+  reference: ConfigValue | undefined
+): ResolvedNeuronSet {
+  if (
+    !isPlainObject(reference) ||
+    typeof reference.block_name !== 'string' ||
+    typeof reference.block_dict_name !== 'string'
+  ) {
+    return {
+      key: null,
+      value: null,
+      signature: stableStringify({ key: null, value: null }),
+    };
+  }
+
+  const dictionary = config[reference.block_dict_name];
+  const value = isPlainObject(dictionary) ? (dictionary[reference.block_name] ?? null) : null;
+
+  return {
+    key: reference.block_name,
+    value,
+    signature: stableStringify({ key: reference.block_name, value }),
+  };
+}
+
+/**
+ * removes references to a deleted block dictionary entry and clears circuit
+ * manipulation fields that depend on those references.
+ */
+export function clearDeletedBlockReferences(
+  config: Config,
+  schema: Pick<ConfigSchema, 'properties'>,
+  deletedBlockDictionaryName: string,
+  deletedBlockName: string
+): Config {
+  const nextConfig = structuredClone(config);
+
+  for (const [rootKey, rootValue] of Object.entries(nextConfig)) {
+    if (!isPlainObject(rootValue)) continue;
+
+    const rootSchema = schema.properties[rootKey];
+
+    if (rootSchema?.ui_element === ScanConfigUIElementDict.BlockDictionary) {
+      for (const entryValue of Object.values(rootValue)) {
+        if (!isPlainObject(entryValue)) continue;
+        clearDeletedReferencesInState({
+          state: entryValue,
+          blockSchema: getBlockSchemaForState(rootSchema, entryValue),
+          rootKey,
+          deletedBlockDictionaryName,
+          deletedBlockName,
+        });
+      }
+      continue;
+    }
+
+    clearDeletedReferencesInState({
+      state: rootValue,
+      blockSchema: getBlockSchemaForState(rootSchema, rootValue),
+      rootKey,
+      deletedBlockDictionaryName,
+      deletedBlockName,
+    });
+  }
+
+  return nextConfig;
+}

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/use-circuit-manipulation-data.tsx
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/use-circuit-manipulation-data.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { get } from 'es-toolkit/compat';
+import { type ReactNode, useEffect, useRef } from 'react';
+
+import { useNeuronalManipulationProperties } from '@/features/scan-config/components/hooks/use-neuronal-manipulation-properties';
+import { resolveNeuronSet } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/state';
+import { useWorkspace } from '@/ui/hooks/use-workspace';
+
+import type { MechanismVariablesRoot } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/mapping';
+import type { Config, ConfigValue } from '@/features/scan-config/types';
+
+const NO_VARIABLES_MESSAGE = 'No ion-channel variables are available for the selected neuron set.';
+const ERROR_MESSAGE = 'Could not load variables for the selected neuron set.';
+
+/**
+ * Pulls the human-readable message the endpoint returned (FastAPI `detail`, parsed onto
+ * `ApiError.cause`) so it can be appended to the generic error note. Returns null when
+ * there is no usable string to show.
+ */
+function extractEndpointErrorMessage(error: unknown): string | null {
+  const message = get(error, 'cause.message') as unknown;
+  if (typeof message === 'string' && message.trim()) return message.trim();
+
+  const details = get(error, 'cause.details') as unknown;
+  if (typeof details === 'string' && details.trim()) return details.trim();
+
+  return null;
+}
+
+export type TUseCircuitManipulationDataParams = {
+  config: Config;
+  state: Record<string, ConfigValue>;
+  setState: (newState: Record<string, ConfigValue>) => void;
+  /** sibling block field holding the neuron-set reference (schema `property_source_field`) */
+  sourceField: string;
+  /** the modification field key being edited */
+  fieldKey: string;
+  endpoint: string | undefined;
+  entityId: string | undefined;
+};
+
+export type TCircuitManipulationData = {
+  data: MechanismVariablesRoot | null;
+  loading: boolean;
+  /** rendered status note shown in place of the picker (error / no variables); null when usable */
+  reason: ReactNode | null;
+};
+
+/**
+ * shared data layer for the circuit neuronal-manipulation components. resolves the
+ * sibling neuron-set selection, fetches the matching mechanism variables, derives the
+ * gating note, and resets the modification when the targeted neuron set changes
+ */
+export function useCircuitManipulationData({
+  config,
+  state,
+  setState,
+  sourceField,
+  fieldKey,
+  endpoint,
+  entityId,
+}: TUseCircuitManipulationDataParams): TCircuitManipulationData {
+  const workspace = useWorkspace();
+  const { signature: neuronSetSignature, value: neuronSet } = resolveNeuronSet(
+    config,
+    state[sourceField]
+  );
+
+  // reset the modification when the targeted neuron set changes: the available variables differ between sets,
+  // so a previously-picked variable may no longer be valid.
+  // a ref to the latest state keeps this off the effect deps so it fires only on an actual change
+  const latestRef = useRef({ state, setState, fieldKey });
+  latestRef.current = { state, setState, fieldKey };
+  const previousTargetRef = useRef(neuronSetSignature);
+  useEffect(() => {
+    if (previousTargetRef.current === neuronSetSignature) return;
+    previousTargetRef.current = neuronSetSignature;
+
+    const { state: latestState, setState: applyState, fieldKey: key } = latestRef.current;
+    if (latestState[key] == null) return;
+    applyState({ ...latestState, [key]: null });
+  }, [neuronSetSignature]);
+
+  const { data, isLoading, isError, error } = useNeuronalManipulationProperties({
+    workspace,
+    entityId,
+    endpoint,
+    neuronSet,
+  });
+
+  let reason: ReactNode | null = null;
+  if (isError) {
+    const endpointMessage = extractEndpointErrorMessage(error);
+    reason = (
+      <div className="flex flex-col gap-1">
+        <span className="text-error font-medium">{ERROR_MESSAGE}</span>
+        {endpointMessage && <span className="text-gray-400">{endpointMessage}</span>}
+      </div>
+    );
+  } else if (!isLoading && data && Object.keys(data).length === 0) {
+    reason = NO_VARIABLES_MESSAGE;
+  }
+
+  return {
+    data: data ?? null,
+    loading: isLoading,
+    reason,
+  };
+}

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/use-circuit-manipulation-data.tsx
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/use-circuit-manipulation-data.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { get } from 'es-toolkit/compat';
 import { type ReactNode, useEffect, useRef } from 'react';
 
+import { getObiOneErrorReason, toObiOneErrorBody } from '@/api/one/utils';
 import { useNeuronalManipulationProperties } from '@/features/scan-config/components/hooks/use-neuronal-manipulation-properties';
 import { resolveNeuronSet } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/circuit/state';
 import { useWorkspace } from '@/ui/hooks/use-workspace';
@@ -13,44 +13,35 @@ import type { Config, ConfigValue } from '@/features/scan-config/types';
 const NO_VARIABLES_MESSAGE = 'No ion-channel variables are available for the selected neuron set.';
 const ERROR_MESSAGE = 'Could not load variables for the selected neuron set.';
 
-/**
- * Pulls the human-readable message the endpoint returned (FastAPI `detail`, parsed onto
- * `ApiError.cause`) so it can be appended to the generic error note. Returns null when
- * there is no usable string to show.
- */
-function extractEndpointErrorMessage(error: unknown): string | null {
-  const message = get(error, 'cause.message') as unknown;
-  if (typeof message === 'string' && message.trim()) return message.trim();
-
-  const details = get(error, 'cause.details') as unknown;
-  if (typeof details === 'string' && details.trim()) return details.trim();
-
-  return null;
-}
-
+/** Parameters for {@link useCircuitManipulationData}. */
 export type TUseCircuitManipulationDataParams = {
   config: Config;
   state: Record<string, ConfigValue>;
   setState: (newState: Record<string, ConfigValue>) => void;
-  /** sibling block field holding the neuron-set reference (schema `property_source_field`) */
+  /** Sibling field holding the neuron-set reference (`property_source_field`). */
   sourceField: string;
-  /** the modification field key being edited */
+  /** Modification field key being edited. */
   fieldKey: string;
+  /** Schema `property_endpoints.NeuronalManipulation` path. */
   endpoint: string | undefined;
+  /** Target Circuit entity id. */
   entityId: string | undefined;
 };
 
+/** Data and gating state for Circuit neuronal-manipulation UI. */
 export type TCircuitManipulationData = {
   data: MechanismVariablesRoot | null;
   loading: boolean;
-  /** rendered status note shown in place of the picker (error / no variables); null when usable */
+  /** Status note for the picker (error / empty); `null` when usable. */
   reason: ReactNode | null;
 };
 
 /**
- * shared data layer for the circuit neuronal-manipulation components. resolves the
- * sibling neuron-set selection, fetches the matching mechanism variables, derives the
- * gating note, and resets the modification when the targeted neuron set changes
+ * Resolves the sibling neuron set, fetches Circuit mechanism variables, and clears
+ * the modification when the targeted neuron set changes.
+ *
+ * @param params - Form config/state, source field, endpoint, and Circuit entity id.
+ * @returns Mechanism variables, loading flag, and optional status reason.
  */
 export function useCircuitManipulationData({
   config,
@@ -67,9 +58,6 @@ export function useCircuitManipulationData({
     state[sourceField]
   );
 
-  // reset the modification when the targeted neuron set changes: the available variables differ between sets,
-  // so a previously-picked variable may no longer be valid.
-  // a ref to the latest state keeps this off the effect deps so it fires only on an actual change
   const latestRef = useRef({ state, setState, fieldKey });
   latestRef.current = { state, setState, fieldKey };
   const previousTargetRef = useRef(neuronSetSignature);
@@ -87,15 +75,19 @@ export function useCircuitManipulationData({
     entityId,
     endpoint,
     neuronSet,
+    includeNeuronSet: true,
   });
 
   let reason: ReactNode | null = null;
   if (isError) {
-    const endpointMessage = extractEndpointErrorMessage(error);
+    const body = toObiOneErrorBody(error);
+    const endpointMessage = body ? getObiOneErrorReason(body) : null;
     reason = (
       <div className="flex flex-col gap-1">
         <span className="text-error font-medium">{ERROR_MESSAGE}</span>
-        {endpointMessage && <span className="text-gray-400">{endpointMessage}</span>}
+        {endpointMessage && endpointMessage !== 'Unknown error' && (
+          <span className="text-gray-400">{endpointMessage}</span>
+        )}
       </div>
     );
   } else if (!isLoading && data && Object.keys(data).length === 0) {

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/me-model/global.tsx
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/me-model/global.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import {
+  GlobalModificationBase,
+  type GlobalModificationBaseProps,
+} from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/global-base';
+
+/**
+ * MEModel (single-neuron) variant of `ion_channel_variable_modification_by_neuron`.
+ *
+ * Variables come from the form-level mapped-circuit-properties config; there is no
+ * neuron-set selection, so this is a thin pass-through to the presentational base.
+ * The circuit variant lives in `../circuit/circuit-global.tsx` and must not reuse this.
+ */
+export function Global(props: Omit<GlobalModificationBaseProps, 'loading' | 'reason'>) {
+  return <GlobalModificationBase {...props} />;
+}

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/me-model/global.tsx
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/me-model/global.tsx
@@ -1,17 +1,53 @@
 'use client';
 
 import {
-  GlobalModificationBase,
-  type GlobalModificationBaseProps,
-} from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/global-base';
+  type TUseMeModelManipulationDataParams,
+  useMeModelManipulationData,
+} from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/me-model/use-memodel-manipulation-data';
+import { GlobalModificationBase } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/global-base';
+
+import type { ConfigValue } from '@/features/scan-config/types';
+
+/** Props for the MEModel full-neuron variable modification UI. */
+export type MeModelGlobalProps = TUseMeModelManipulationDataParams & {
+  disabled: boolean;
+  state: Record<string, ConfigValue>;
+  setState: (newState: Record<string, ConfigValue>) => void;
+  fieldKey: string;
+  modificationType: string;
+  errorPathPrefix?: string;
+};
 
 /**
- * MEModel (single-neuron) variant of `ion_channel_variable_modification_by_neuron`.
+ * MEModel UI for `ion_channel_variable_modification_by_neuron`.
  *
- * Variables come from the form-level mapped-circuit-properties config; there is no
- * neuron-set selection, so this is a thin pass-through to the presentational base.
- * The circuit variant lives in `../circuit/circuit-global.tsx` and must not reuse this.
+ * @param props - Endpoint/entity fetch params plus form field wiring.
+ * @returns Presentational modification UI backed by {@link useMeModelManipulationData}.
+ * @see CircuitGlobal
  */
-export function Global(props: Omit<GlobalModificationBaseProps, 'loading' | 'reason'>) {
-  return <GlobalModificationBase {...props} />;
+export function Global({
+  endpoint,
+  entityId,
+  disabled,
+  state,
+  setState,
+  fieldKey,
+  modificationType,
+  errorPathPrefix,
+}: MeModelGlobalProps) {
+  const { data, loading, reason } = useMeModelManipulationData({ endpoint, entityId });
+
+  return (
+    <GlobalModificationBase
+      data={data}
+      loading={loading}
+      reason={reason}
+      disabled={disabled}
+      state={state}
+      setState={setState}
+      fieldKey={fieldKey}
+      modificationType={modificationType}
+      errorPathPrefix={errorPathPrefix}
+    />
+  );
 }

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/me-model/range.tsx
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/me-model/range.tsx
@@ -1,17 +1,53 @@
 'use client';
 
 import {
-  RangeModificationBase,
-  type RangeModificationBaseProps,
-} from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/range-base';
+  type TUseMeModelManipulationDataParams,
+  useMeModelManipulationData,
+} from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/me-model/use-memodel-manipulation-data';
+import { RangeModificationBase } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/range-base';
+
+import type { ConfigValue } from '@/features/scan-config/types';
+
+/** Props for the MEModel section-list variable modification UI. */
+export type MeModelRangeProps = TUseMeModelManipulationDataParams & {
+  disabled: boolean;
+  state: Record<string, ConfigValue>;
+  setState: (newState: Record<string, ConfigValue>) => void;
+  fieldKey: string;
+  modificationType: string;
+  errorPathPrefix?: string;
+};
 
 /**
- * MEModel (single-neuron) variant of `ion_channel_variable_modification_by_section_list`.
+ * MEModel UI for `ion_channel_variable_modification_by_section_list`.
  *
- * Variables come from the form-level mapped-circuit-properties config; there is no
- * neuron-set selection, so this is a thin pass-through to the presentational base.
- * The circuit variant lives in `../circuit/circuit-range.tsx` and must not reuse this.
+ * @param props - Endpoint/entity fetch params plus form field wiring.
+ * @returns Presentational modification UI backed by {@link useMeModelManipulationData}.
+ * @see CircuitRange
  */
-export function Range(props: Omit<RangeModificationBaseProps, 'loading' | 'reason'>) {
-  return <RangeModificationBase {...props} />;
+export function Range({
+  endpoint,
+  entityId,
+  disabled,
+  state,
+  setState,
+  fieldKey,
+  modificationType,
+  errorPathPrefix,
+}: MeModelRangeProps) {
+  const { data, loading, reason } = useMeModelManipulationData({ endpoint, entityId });
+
+  return (
+    <RangeModificationBase
+      data={data}
+      loading={loading}
+      reason={reason}
+      disabled={disabled}
+      state={state}
+      setState={setState}
+      fieldKey={fieldKey}
+      modificationType={modificationType}
+      errorPathPrefix={errorPathPrefix}
+    />
+  );
 }

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/me-model/range.tsx
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/me-model/range.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import {
+  RangeModificationBase,
+  type RangeModificationBaseProps,
+} from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/range-base';
+
+/**
+ * MEModel (single-neuron) variant of `ion_channel_variable_modification_by_section_list`.
+ *
+ * Variables come from the form-level mapped-circuit-properties config; there is no
+ * neuron-set selection, so this is a thin pass-through to the presentational base.
+ * The circuit variant lives in `../circuit/circuit-range.tsx` and must not reuse this.
+ */
+export function Range(props: Omit<RangeModificationBaseProps, 'loading' | 'reason'>) {
+  return <RangeModificationBase {...props} />;
+}

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/me-model/use-memodel-manipulation-data.tsx
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/me-model/use-memodel-manipulation-data.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { getObiOneErrorReason, toObiOneErrorBody } from '@/api/one/utils';
+import { useNeuronalManipulationProperties } from '@/features/scan-config/components/hooks/use-neuronal-manipulation-properties';
+import { useWorkspace } from '@/ui/hooks/use-workspace';
+
+import type { ReactNode } from 'react';
+import type { MechanismVariablesRoot } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/mapping';
+
+const NO_VARIABLES_MESSAGE = 'No ion-channel variables are available for this model.';
+const ERROR_MESSAGE = 'Could not load ion-channel variables for this model.';
+
+/** Parameters for {@link useMeModelManipulationData}. */
+export type TUseMeModelManipulationDataParams = {
+  /** Schema `property_endpoints.NeuronalManipulation` path. */
+  endpoint: string | undefined;
+  /** Target MEModel entity id. */
+  entityId: string | undefined;
+};
+
+/** Data and gating state for MEModel neuronal-manipulation UI. */
+export type TMeModelManipulationData = {
+  data: MechanismVariablesRoot | null;
+  loading: boolean;
+  /** Status note for the picker (error / empty); `null` when usable. */
+  reason: ReactNode | null;
+};
+
+/**
+ * Fetches MEModel mechanism variables and derives picker gating state.
+ *
+ * @param params - Endpoint path and MEModel entity id.
+ * @returns Mechanism variables, loading flag, and optional status reason.
+ */
+export function useMeModelManipulationData({
+  endpoint,
+  entityId,
+}: TUseMeModelManipulationDataParams): TMeModelManipulationData {
+  const workspace = useWorkspace();
+
+  const { data, isLoading, isError, error } = useNeuronalManipulationProperties({
+    workspace,
+    entityId,
+    endpoint,
+  });
+
+  let reason: ReactNode | null = null;
+  if (isError) {
+    const body = toObiOneErrorBody(error);
+    const endpointMessage = body ? getObiOneErrorReason(body) : null;
+    reason = (
+      <div className="flex flex-col gap-1">
+        <span className="text-error font-medium">{ERROR_MESSAGE}</span>
+        {endpointMessage && endpointMessage !== 'Unknown error' && (
+          <span className="text-gray-400">{endpointMessage}</span>
+        )}
+      </div>
+    );
+  } else if (!isLoading && data && Object.keys(data).length === 0) {
+    reason = NO_VARIABLES_MESSAGE;
+  }
+
+  return {
+    data: data ?? null,
+    loading: isLoading,
+    reason,
+  };
+}

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/global-base.tsx
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/global-base.tsx
@@ -30,19 +30,18 @@ export interface GlobalModificationBaseProps {
   fieldKey: string;
   modificationType: string;
   errorPathPrefix?: string;
-  /** circuit variant: variables are being fetched for the selected neuron set */
+  /** Whether mechanism variables are still loading. */
   loading?: boolean;
-  /** circuit variant: rendered note for why the picker is unavailable (error, no variables) */
+  /** Status note when the picker is unavailable (error / empty). */
   reason?: ReactNode | null;
 }
 
 /**
- * presentational base for the "Full Neuron Variable Modification"
- * (`ion_channel_variable_modification_by_neuron`) ui element.
+ * Presentational UI for `ion_channel_variable_modification_by_neuron`.
  *
- * renders the channel/variable picker and a single value editor from a provided
- * {@link MechanismVariablesRoot}. it does not fetch data; the me-model and circuit
- * wrappers each supply data (and, for circuit, loading/emptyReason).
+ * Does not fetch data; MEModel/Circuit wrappers supply {@link MechanismVariablesRoot}.
+ *
+ * @param props - Mechanism variables plus form field wiring and optional gating state.
  */
 export function GlobalModificationBase({
   data,

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/global-base.tsx
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/global-base.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { type ReactNode, useMemo } from 'react';
 
 import {
   SectionListConfigEditor,
@@ -15,13 +15,14 @@ import {
   MechanismVariableTypeDict,
   type SectionListEntry,
 } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/mapping';
+import { ModificationShell } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/modification-shell';
 import {
   type IonChannelSelection,
   IonChannelVariableSelector,
 } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/selector';
 import { type ConfigValue, ScanConfigUIElementDict } from '@/features/scan-config/types';
 
-interface GlobalProps {
+export interface GlobalModificationBaseProps {
   data: MechanismVariablesRoot | null;
   disabled: boolean;
   state: Record<string, ConfigValue>;
@@ -29,9 +30,21 @@ interface GlobalProps {
   fieldKey: string;
   modificationType: string;
   errorPathPrefix?: string;
+  /** circuit variant: variables are being fetched for the selected neuron set */
+  loading?: boolean;
+  /** circuit variant: rendered note for why the picker is unavailable (error, no variables) */
+  reason?: ReactNode | null;
 }
 
-export function Global({
+/**
+ * presentational base for the "Full Neuron Variable Modification"
+ * (`ion_channel_variable_modification_by_neuron`) ui element.
+ *
+ * renders the channel/variable picker and a single value editor from a provided
+ * {@link MechanismVariablesRoot}. it does not fetch data; the me-model and circuit
+ * wrappers each supply data (and, for circuit, loading/emptyReason).
+ */
+export function GlobalModificationBase({
   data,
   disabled,
   state,
@@ -39,7 +52,9 @@ export function Global({
   fieldKey,
   modificationType,
   errorPathPrefix,
-}: GlobalProps) {
+  loading = false,
+  reason = null,
+}: GlobalModificationBaseProps) {
   const currentModification = state[fieldKey];
   const isValidModification =
     !!currentModification &&
@@ -111,8 +126,6 @@ export function Global({
     return { [sectionLabel]: newValue };
   }, [isValidModification, newValue, sectionLabel]);
 
-  if (!data) return null;
-
   const handleVariableChange = (selection: IonChannelSelection) => {
     setState({
       ...state,
@@ -135,13 +148,14 @@ export function Global({
   };
 
   return (
-    <div
-      data-scan-config-block-element={
-        ScanConfigUIElementDict.IonChannelVariableModificationByNeuron
-      }
+    <ModificationShell
+      uiElement={ScanConfigUIElementDict.IonChannelVariableModificationByNeuron}
+      data={data}
+      loading={loading}
+      reason={reason}
     >
       <IonChannelVariableSelector
-        data={data}
+        data={data ?? {}}
         variableType={[MechanismVariableTypeDict.Global, MechanismVariableTypeDict.Range]}
         value={currentValue}
         onChange={handleVariableChange}
@@ -158,6 +172,6 @@ export function Global({
           errorPathPrefix={errorPathPrefix}
         />
       )}
-    </div>
+    </ModificationShell>
   );
 }

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/modification-shell.tsx
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/modification-shell.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { LoadingOutlined } from '@ant-design/icons';
+
+import type { MechanismVariablesRoot } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/mapping';
+import type { TScanConfigUIElementDict } from '@/features/scan-config/types';
+
+const LOADING_MESSAGE = 'Loading variables…';
+
+/** inline status note shown in place of the variable picker (loading/gated/empty). */
+function ModificationNote({ children }: { children: React.ReactNode }) {
+  return <div className="px-1 py-2 text-base text-gray-400">{children}</div>;
+}
+
+export interface ModificationShellProps {
+  uiElement: TScanConfigUIElementDict;
+  data: MechanismVariablesRoot | null;
+  loading: boolean;
+  /** status note shown in place of the picker (error / no variables); null when usable */
+  reason: React.ReactNode | null;
+  children: React.ReactNode;
+}
+
+/**
+ * shared frame for the ion-channel modification ui elements. owns the block wrapper
+ * element and the status states (loading/gated/empty) so each variant only declares
+ * its picker + editor. for the me-model variant (loading/reason unset) it renders
+ * nothing until form-level data resolves; matching the original behavior.
+ */
+export function ModificationShell({
+  uiElement,
+  data,
+  loading,
+  reason,
+  children,
+}: ModificationShellProps) {
+  if (!loading && !reason && !data) return null;
+
+  return (
+    <div data-scan-config-block-element={uiElement}>
+      {loading ? (
+        <ModificationNote>
+          {LOADING_MESSAGE} <LoadingOutlined className="ml-1" />
+        </ModificationNote>
+      ) : reason ? (
+        <ModificationNote>{reason}</ModificationNote>
+      ) : (
+        children
+      )}
+    </div>
+  );
+}

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/range-base.tsx
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/range-base.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { type ReactNode, useMemo } from 'react';
 
 import {
   SectionListConfigEditor,
@@ -17,13 +17,14 @@ import {
   MechanismVariableTypeDict,
   type SectionListEntry,
 } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/mapping';
+import { ModificationShell } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/modification-shell';
 import {
   type IonChannelSelection,
   IonChannelVariableSelector,
 } from '@/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/selector';
 import { type ConfigValue, ScanConfigUIElementDict } from '@/features/scan-config/types';
 
-interface RangeProps {
+export interface RangeModificationBaseProps {
   data: MechanismVariablesRoot | null;
   disabled: boolean;
   state: Record<string, ConfigValue>;
@@ -31,9 +32,21 @@ interface RangeProps {
   fieldKey: string;
   modificationType: string;
   errorPathPrefix?: string;
+  /** circuit variant: variables are being fetched for the selected neuron set */
+  loading?: boolean;
+  /** circuit variant: rendered note for why the picker is unavailable (error, no variables) */
+  reason?: ReactNode | null;
 }
 
-export function Range({
+/**
+ * presentational base for the "Variable Modification by Section List"
+ * (`ion_channel_variable_modification_by_section_list`) ui element.
+ *
+ * renders the channel/variable picker and a per-section-list value editor from a
+ * provided {@link MechanismVariablesRoot}. it does not fetch data; the me-model
+ * and circuit wrappers each supply data (and, for circuit, loading/emptyReason respectively).
+ */
+export function RangeModificationBase({
   data,
   disabled,
   state,
@@ -41,7 +54,9 @@ export function Range({
   fieldKey,
   modificationType,
   errorPathPrefix,
-}: RangeProps) {
+  loading = false,
+  reason = null,
+}: RangeModificationBaseProps) {
   const currentModification = state[fieldKey];
   const isValidModification =
     !!currentModification &&
@@ -103,8 +118,6 @@ export function Range({
     return resolvedVariable.section_lists;
   }, [resolvedVariable]);
 
-  if (!data) return null;
-
   const handleVariableChange = (selection: IonChannelSelection) => {
     const sectionListModifications: Record<string, number> = {};
     for (const entry of selection.variable.section_lists) {
@@ -143,13 +156,14 @@ export function Range({
   };
 
   return (
-    <div
-      data-scan-config-block-element={
-        ScanConfigUIElementDict.ionChannelVariableModificationBySectionList
-      }
+    <ModificationShell
+      uiElement={ScanConfigUIElementDict.ionChannelVariableModificationBySectionList}
+      data={data}
+      loading={loading}
+      reason={reason}
     >
       <IonChannelVariableSelector
-        data={data}
+        data={data ?? {}}
         variableType={MechanismVariableTypeDict.Range}
         value={currentValue}
         onChange={handleVariableChange}
@@ -166,6 +180,6 @@ export function Range({
           errorPathPrefix={errorPathPrefix}
         />
       )}
-    </div>
+    </ModificationShell>
   );
 }

--- a/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/range-base.tsx
+++ b/src/features/scan-config/components/ui-elements/ion-channel-variable-modification/shared/range-base.tsx
@@ -32,19 +32,18 @@ export interface RangeModificationBaseProps {
   fieldKey: string;
   modificationType: string;
   errorPathPrefix?: string;
-  /** circuit variant: variables are being fetched for the selected neuron set */
+  /** Whether mechanism variables are still loading. */
   loading?: boolean;
-  /** circuit variant: rendered note for why the picker is unavailable (error, no variables) */
+  /** Status note when the picker is unavailable (error / empty). */
   reason?: ReactNode | null;
 }
 
 /**
- * presentational base for the "Variable Modification by Section List"
- * (`ion_channel_variable_modification_by_section_list`) ui element.
+ * Presentational UI for `ion_channel_variable_modification_by_section_list`.
  *
- * renders the channel/variable picker and a per-section-list value editor from a
- * provided {@link MechanismVariablesRoot}. it does not fetch data; the me-model
- * and circuit wrappers each supply data (and, for circuit, loading/emptyReason respectively).
+ * Does not fetch data; MEModel/Circuit wrappers supply {@link MechanismVariablesRoot}.
+ *
+ * @param props - Mechanism variables plus form field wiring and optional gating state.
  */
 export function RangeModificationBase({
   data,

--- a/src/features/scan-config/components/ui-elements/neuron-ids/index.tsx
+++ b/src/features/scan-config/components/ui-elements/neuron-ids/index.tsx
@@ -2,10 +2,9 @@ import { CopyOutlined, DeleteOutlined, EditOutlined } from '@ant-design/icons';
 import { Button } from 'antd';
 import { Fragment, useMemo, useRef, useState } from 'react';
 
+import NumberEditor from '@/features/scan-config/components/ui-elements/neuron-ids/number-editor';
+import { isPlainObject } from '@/features/scan-config/components/utils';
 import { cn } from '@/utils/css-class';
-
-import { isPlainObject } from '../../utils';
-import NumberEditor from './number-editor';
 
 import type React from 'react';
 import type { ConfigValue } from '@/features/scan-config/types';

--- a/src/features/scan-config/types.ts
+++ b/src/features/scan-config/types.ts
@@ -175,8 +175,10 @@ const CircuitNeuronalManipulationTypes: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * True when a `neuronal_manipulations` variant `type.const` is a circuit variant
- * (endpoint-sourced), as opposed to the ME-model variant (mapped-config-sourced)
+ * Whether a `neuronal_manipulations` variant `type.const` is Circuit-scoped.
+ *
+ * @param typeConst - Variant discriminator from the block state/schema.
+ * @returns `true` for Circuit variants (neuron-set scoped); `false` for MEModel variants.
  */
 export function isCircuitNeuronalManipulationType(typeConst: string | undefined): boolean {
   return typeof typeConst === 'string' && CircuitNeuronalManipulationTypes.has(typeConst);
@@ -314,9 +316,9 @@ export interface IonChannelRangeVariableModification extends TBlockElement {
   ui_element: typeof ScanConfigUIElementDict.ionChannelVariableModificationBySectionList;
   description: string;
   property?: string;
-  /** maps to a `property_endpoints` key; `"NeuronalManipulation"` marks the circuit variant */
+  /** Key into `schema.property_endpoints` (typically `"NeuronalManipulation"`). */
   property_group?: string;
-  /** sibling field whose value scopes the variable fetch (circuit variant only), e.g. `neuron_set` */
+  /** Sibling field that scopes the Circuit fetch (e.g. `neuron_set`). */
   property_source_field?: string;
   title: string;
   type: 'object';
@@ -332,9 +334,9 @@ export interface IonChannelGlobalVariableModification extends TBlockElement {
   description: string;
   title: string;
   property?: string;
-  /** maps to a `property_endpoints` key; `"NeuronalManipulation"` marks the circuit variant */
+  /** Key into `schema.property_endpoints` (typically `"NeuronalManipulation"`). */
   property_group?: string;
-  /** sibling field whose value scopes the variable fetch (circuit variant only), e.g. `neuron_set` */
+  /** Sibling field that scopes the Circuit fetch (e.g. `neuron_set`). */
   property_source_field?: string;
   type: 'object';
   properties: {

--- a/src/features/scan-config/types.ts
+++ b/src/features/scan-config/types.ts
@@ -159,6 +159,28 @@ export const ScanConfigUIElementDict = {
 
 export type TScanConfigUIElementDict =
   (typeof ScanConfigUIElementDict)[keyof typeof ScanConfigUIElementDict];
+
+export const NeuronalManipulationTypeDict = {
+  CircuitByNeuron: 'CircuitByNeuronMechanismVariableNeuronalManipulation',
+  CircuitBySectionList: 'CircuitBySectionListMechanismVariableNeuronalManipulation',
+  ByNeuron: 'ByNeuronMechanismVariableNeuronalManipulation',
+  BySectionList: 'BySectionListMechanismVariableNeuronalManipulation',
+} as const;
+
+export const CIRCUIT_NEURONAL_MANIPULATION_SOURCE_FIELD = 'neuron_set';
+
+const CircuitNeuronalManipulationTypes: ReadonlySet<string> = new Set([
+  NeuronalManipulationTypeDict.CircuitByNeuron,
+  NeuronalManipulationTypeDict.CircuitBySectionList,
+]);
+
+/**
+ * True when a `neuronal_manipulations` variant `type.const` is a circuit variant
+ * (endpoint-sourced), as opposed to the ME-model variant (mapped-config-sourced)
+ */
+export function isCircuitNeuronalManipulationType(typeConst: string | undefined): boolean {
+  return typeof typeConst === 'string' && CircuitNeuronalManipulationTypes.has(typeConst);
+}
 export interface StringInput extends TBlockElement {
   ui_element: typeof ScanConfigUIElementDict.StringInput;
 }
@@ -291,7 +313,11 @@ export interface MorphologySectionTypeSelection extends TBlockElement {
 export interface IonChannelRangeVariableModification extends TBlockElement {
   ui_element: typeof ScanConfigUIElementDict.ionChannelVariableModificationBySectionList;
   description: string;
-  property: 'IonChannelRangeVariables';
+  property?: string;
+  /** maps to a `property_endpoints` key; `"NeuronalManipulation"` marks the circuit variant */
+  property_group?: string;
+  /** sibling field whose value scopes the variable fetch (circuit variant only), e.g. `neuron_set` */
+  property_source_field?: string;
   title: string;
   type: 'object';
   properties: {
@@ -305,7 +331,11 @@ export interface IonChannelGlobalVariableModification extends TBlockElement {
   ui_element: typeof ScanConfigUIElementDict.IonChannelVariableModificationByNeuron;
   description: string;
   title: string;
-  property: 'IonChannelGlobalVariables';
+  property?: string;
+  /** maps to a `property_endpoints` key; `"NeuronalManipulation"` marks the circuit variant */
+  property_group?: string;
+  /** sibling field whose value scopes the variable fetch (circuit variant only), e.g. `neuron_set` */
+  property_source_field?: string;
   type: 'object';
   properties: {
     modification: any;


### PR DESCRIPTION
add circuit vs me-model variants for the ion-channel variable modification ui elements, dispatched by the parent block-dictionary `type.const`