### PR TITLE
feat(cell-morphology): has_segmented_spines filter and detail field

### DIFF
--- a/src/api/entitycore/types/entities/cell-morphology.ts
+++ b/src/api/entitycore/types/entities/cell-morphology.ts
@@ -112,6 +112,7 @@ export interface ICellMorphology
   mtypes: Array<IMType> | null;
   contributions?: Array<IContributor> | null;
   cell_morphology_protocol: NestedCellMorphologyProtocolRead;
+  has_segmented_spines?: boolean | null;
 }
 
 export interface ICellMorphologyExpanded extends ICellMorphology {

--- a/src/entity-configuration/definitions/fields-defs/enums.ts
+++ b/src/entity-configuration/definitions/fields-defs/enums.ts
@@ -105,6 +105,7 @@ export enum EntityCoreFields {
   LevelOfDetail = 'level_of_detail',
   GenerationParameters = 'generation_parameters',
   MeshType = 'mesh_type',
+  HasSegmentedSpines = 'has_segmented_spines',
 }
 
 export type EntityCoreFieldsValue = `${EntityCoreFields}`;

--- a/src/entity-configuration/definitions/fields-defs/experimental.tsx
+++ b/src/entity-configuration/definitions/fields-defs/experimental.tsx
@@ -54,6 +54,21 @@ const emodelEtypes = (emodel?: IEModel) => {
 };
 
 export const FieldsDefinition: Partial<FieldsDefinitionRegistry<EntityCoreObjectTypes>> = {
+  [EntityCoreFields.HasSegmentedSpines]: {
+    className: 'text-left',
+    title: 'Segmented spines',
+    filter: CoreFieldFilterTypeEnum.Boolean,
+    defaultConstraint: 'has_segmented_spines',
+    isFilterable: true,
+    render: (r) => {
+      if (!('has_segmented_spines' in r)) return EmptyValue;
+      const value = (r as ICellMorphology).has_segmented_spines;
+      // null/undefined -> "—" so morphologies without the property aren't mislabeled "False"
+      if (value === true) return 'True';
+      if (value === false) return 'False';
+      return EmptyValue;
+    },
+  },
   [EntityCoreFields.License]: {
     title: 'License',
     filter: CoreFieldFilterTypeEnum.CheckList,

--- a/src/entity-configuration/definitions/view-defs/experimental/cell-morphology.ts
+++ b/src/entity-configuration/definitions/view-defs/experimental/cell-morphology.ts
@@ -96,6 +96,7 @@ export const viewDefForCellMorphology: ViewDefinitionConfig = {
     { field: EntityCoreFields.BrainRegion },
     { field: EntityCoreFields.MType },
     { field: EntityCoreFields.License },
+    { field: EntityCoreFields.HasSegmentedSpines },
   ],
   miniDetailView: [
     { field: EntityCoreFields.BrainRegion },
@@ -103,5 +104,6 @@ export const viewDefForCellMorphology: ViewDefinitionConfig = {
     { field: EntityCoreFields.MType },
     { field: EntityCoreFields.License },
   ],
+  filterableFields: [EntityCoreFields.HasSegmentedSpines],
   mlTopic: 'Neuron morphology',
 };


### PR DESCRIPTION
## Summary

Adds `has_segmented_spines` support to CellMorphology in two places, as requested in the ticket:

- **Details page** — shows a **"Segmented spines"** property (rendered as True/False, or — when the value is absent/null).
- **Data → Morphologies list** — adds a **"Segmented spines"** filter so users can narrow the list to spiny morphologies.

The backend (`entitycore`) work is already done and deployed to staging — the field is in the read schema and the filter is queryable. This PR is the frontend wiring only.

## Implementation

Reuses the existing Boolean-filter pipeline (`CoreFieldFilterTypeEnum.Boolean` → the —/True/False `Select` → constraint mapping), mirroring how **IonChannelModel** already exposes its boolean filters.

- `src/api/entitycore/types/entities/cell-morphology.ts` — add `has_segmented_spines?: boolean | null` to `ICellMorphology`
- `src/entity-configuration/definitions/fields-defs/enums.ts` — add `HasSegmentedSpines` field key
- `src/entity-configuration/definitions/fields-defs/experimental.tsx` — new field definition (title "Segmented spines", Boolean filter, constraint `has_segmented_spines`)
- `src/entity-configuration/definitions/view-defs/experimental/cell-morphology.ts` — add to `summaryViewFields` (details page) + `filterableFields` (filter only, no default table column)

## Scope decisions

- Exposed as a **filter + details-page field only** — intentionally **not** a default table column.
- No backend changes (already deployed).

## Related ticket

[[Implementation] has_segmented_spines listed on Details page & filter ability](https://github.com/openbraininstitute/entitycore/issues/541)