### PR TITLE
feat(scan-config): show cost estimation modal on task launch

### DIFF
--- a/src/features/scan-config/components/atoms/index.ts
+++ b/src/features/scan-config/components/atoms/index.ts
@@ -263,7 +263,7 @@ export function useModelQuery({
   const isLoading = entityLoading || modelLoading;
   const error = entityError || modelError;
 
-  return { entity, isLoading, error };
+  return { entity, entityType, isLoading, error };
 }
 
 export const jsonFileAtomFamily = readAtomFamilyWithExpiration(

--- a/src/features/scan-config/components/cost-confirmation-modal/index.tsx
+++ b/src/features/scan-config/components/cost-confirmation-modal/index.tsx
@@ -12,6 +12,8 @@ import { useTaskCostEstimates } from './use-task-cost-estimates';
 
 import type { CostConfirmationModalProps } from './types';
 
+export { useCostConfirmation } from './use-cost-confirmation';
+
 const ITEMS_PER_PAGE = 10;
 
 export function CostConfirmationModal({

--- a/src/features/scan-config/components/cost-confirmation-modal/index.tsx
+++ b/src/features/scan-config/components/cost-confirmation-modal/index.tsx
@@ -146,6 +146,20 @@ export function CostConfirmationModal({
                   </span>
                 </div>
               ))}
+
+              {/* Pad the last/partial page with invisible filler rows so every page keeps
+                  the same height and the centered modal does not jump when paginating. */}
+              {hasPagination &&
+                Array.from({ length: ITEMS_PER_PAGE - currentPageItems.length }).map((_, i) => (
+                  <div
+                    // biome-ignore lint/suspicious/noArrayIndexKey: static placeholder fillers
+                    key={`filler-${i}`}
+                    aria-hidden
+                    className="flex items-center justify-between border-b border-transparent py-3"
+                  >
+                    <span className="text-lg invisible font-bold">placeholder</span>
+                  </div>
+                ))}
             </div>
 
             {hasPagination && (

--- a/src/features/scan-config/components/cost-confirmation-modal/use-cost-confirmation.tsx
+++ b/src/features/scan-config/components/cost-confirmation-modal/use-cost-confirmation.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import { CostConfirmationModal } from './index';
+
+import type { ReactNode } from 'react';
+import type { TObiOneTaskType } from '@/api/one/types/task';
+import type { WorkspaceContext } from '@/types/common';
+import type { CostConfirmationItem } from './types';
+
+type UseCostConfirmationParams = {
+  items: CostConfirmationItem[];
+  taskType: TObiOneTaskType;
+  workflowLabel: string;
+  context: WorkspaceContext;
+  onConfirm: (ids: string[]) => void;
+};
+
+/**
+ * Owns the open-state, render, and confirm wiring for the {@link CostConfirmationModal}.
+ *
+ * Callers build the `items` for their selection and call `openModal()` from their launch button;
+ * the returned `modal` node must be rendered (it fetches estimates only while open). On confirm the
+ * modal closes and `onConfirm` runs with the checked ids.
+ */
+export function useCostConfirmation({
+  items,
+  taskType,
+  workflowLabel,
+  context,
+  onConfirm,
+}: UseCostConfirmationParams): { openModal: () => void; modal: ReactNode } {
+  const [open, setOpen] = useState(false);
+
+  const openModal = useCallback(() => setOpen(true), []);
+  const onClose = useCallback(() => setOpen(false), []);
+  const handleConfirm = useCallback(
+    (ids: string[]) => {
+      setOpen(false);
+      onConfirm(ids);
+    },
+    [onConfirm]
+  );
+
+  const modal = (
+    <CostConfirmationModal
+      open={open}
+      onClose={onClose}
+      onConfirm={handleConfirm}
+      items={items}
+      taskType={taskType}
+      workflowLabel={workflowLabel}
+      context={context}
+    />
+  );
+
+  return { openModal, modal };
+}

--- a/src/features/scan-config/use-cases/build/results.tsx
+++ b/src/features/scan-config/use-cases/build/results.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState } from 'react';
 
 import { ActivityStatus } from '@/api/entitycore/types/shared/activity';
 import { ViewVariant, WorkspaceSection } from '@/constants';
+import { useCostConfirmation } from '@/features/scan-config/components/cost-confirmation-modal';
 import { FileViewer } from '@/features/scan-config/components/file-viewer';
 import { ResultsLayout } from '@/features/scan-config/components/shared/results-layout';
 import { TaskConfigSelectionList } from '@/features/scan-config/components/shared/task-config-selection-list';
@@ -128,101 +129,120 @@ export function BuildTab({
     setSelectedConfigIds([]);
   };
 
+  const costModalItems = useMemo(
+    () =>
+      (configsResponse?.configList ?? [])
+        .filter((c) => resolvedSelectedConfigIds.includes(c.id))
+        .map((c) => ({ id: c.id, name: c.name })),
+    [configsResponse?.configList, resolvedSelectedConfigIds]
+  );
+
+  const { openModal, modal: costConfirmationModal } = useCostConfirmation({
+    items: costModalItems,
+    taskType: taskTypeBindings.obiOne,
+    workflowLabel: 'builds',
+    context,
+    onConfirm: onRun,
+  });
+
   const launchBtnLabelPrefix = resolvedSelectedConfigIds.length
     ? `(${resolvedSelectedConfigIds.length})`
     : '';
   const loading = configGenerationLoading || configsLoading;
 
   return (
-    <ResultsLayout
-      campaignId={campaignId}
-      left={
-        <div className="flex h-full w-full flex-col gap-4 overflow-y-hidden">
-          <TaskConfigSelectionList
-            campaignId={campaignId}
-            configs={configs}
-            selectableConfigIds={selectableConfigIds}
-            selectedConfigIds={resolvedSelectedConfigIds}
-            activeConfigId={resolvedActiveConfig?.id}
-            loading={loading}
-            selectionDisabled={runBuildPending}
-            fallbackColor="#389E0D"
-            context={context}
-            executionActivityType={taskTypeBindings.execution}
-            pauseStatusPolling={runBuildPending}
-            executionByConfigId={executionByConfigId}
-            onSelectConfig={onActiveConfigChange}
-            onCheckedChange={onSelectedForBuildChange}
-            onToggleSelectAll={(checked) =>
-              setSelectedConfigIds(checked ? selectableConfigIds : [])
-            }
-            onExecutionLoad={onExecutionLoad}
-          />
-          <TaskLaunchButton
-            label="Launch builds"
-            countLabel={launchBtnLabelPrefix}
-            pending={runBuildPending}
-            disabled={runBuildPending || resolvedSelectedConfigIds.length === 0}
-            onClick={() => onRun(resolvedSelectedConfigIds)}
-            className="rounded-full"
-          />
-        </div>
-      }
-      middle={
-        !!resolvedActiveConfig && (
-          <div className="h-full bg-background! w-full">
-            <InOutFiles
-              config={resolvedActiveConfig}
-              execStatus={activeConfigExecStatus}
-              execution={activeConfigExecution}
-              selectedFile={selectedFile}
+    <>
+      <ResultsLayout
+        campaignId={campaignId}
+        left={
+          <div className="flex h-full w-full flex-col gap-4 overflow-y-hidden">
+            <TaskConfigSelectionList
+              campaignId={campaignId}
+              configs={configs}
+              selectableConfigIds={selectableConfigIds}
+              selectedConfigIds={resolvedSelectedConfigIds}
+              activeConfigId={resolvedActiveConfig?.id}
+              loading={loading}
+              selectionDisabled={runBuildPending}
+              fallbackColor="#389E0D"
               context={context}
-              campaignOrigin={campaignOriginAction}
-              onSelect={setSelectedFile}
+              executionActivityType={taskTypeBindings.execution}
+              pauseStatusPolling={runBuildPending}
+              executionByConfigId={executionByConfigId}
+              onSelectConfig={onActiveConfigChange}
+              onCheckedChange={onSelectedForBuildChange}
+              onToggleSelectAll={(checked) =>
+                setSelectedConfigIds(checked ? selectableConfigIds : [])
+              }
+              onExecutionLoad={onExecutionLoad}
+            />
+            <TaskLaunchButton
+              label="Launch builds"
+              countLabel={launchBtnLabelPrefix}
+              pending={runBuildPending}
+              disabled={runBuildPending || resolvedSelectedConfigIds.length === 0}
+              onClick={openModal}
+              className="rounded-full"
             />
           </div>
-        )
-      }
-      right={
-        <>
-          {selectedFile?.renderer === ActivityCustomFileRenderer.Default && (
-            <FileViewer file={selectedFile} className="h-full" context={context} />
-          )}
-          {selectedFile?.renderer === ActivityCustomFileRenderer.MiniDetailView && (
-            <div className="h-full">
-              <MiniDetailViewRenderer
-                section={WorkspaceSection.Data}
-                record={selectedFile.entity as EntityCoreObjectTypes}
-                dataType={selectedFile.entity.type}
-                theme={ViewVariant.Light}
-                enableAnimation={false}
+        }
+        middle={
+          !!resolvedActiveConfig && (
+            <div className="h-full bg-background! w-full">
+              <InOutFiles
+                config={resolvedActiveConfig}
+                execStatus={activeConfigExecStatus}
+                execution={activeConfigExecution}
+                selectedFile={selectedFile}
+                context={context}
+                campaignOrigin={campaignOriginAction}
+                onSelect={setSelectedFile}
               />
             </div>
-          )}
-          {selectedFile?.renderer === ActivityCustomFileRenderer.TaskConfigurationViewer && (
-            <TaskConfigurationViewer
-              skipStream
-              jobId={activeExecutionJobId}
-              workspace={context}
-              configId={resolvedActiveConfig?.id}
-              enabled={taskLogsViewerEnabled}
-              campaignOriginAction={campaignOriginAction}
-              isCampaignIdChanged={isCampaignIdChanged}
-            />
-          )}
-          {selectedFile?.renderer === ActivityCustomFileRenderer.TaskLogsViewer && (
-            <TaskLogsViewer
-              jobId={activeExecutionJobId}
-              workspace={context}
-              configId={resolvedActiveConfig?.id}
-              enabled={taskLogsViewerEnabled}
-              skipStream={taskLogsShouldReadSnapshot}
-              campaignOriginAction={campaignOriginAction}
-              isCampaignIdChanged={isCampaignIdChanged}
-            />
-          )}
-        </>
-      }
-    />
+          )
+        }
+        right={
+          <>
+            {selectedFile?.renderer === ActivityCustomFileRenderer.Default && (
+              <FileViewer file={selectedFile} className="h-full" context={context} />
+            )}
+            {selectedFile?.renderer === ActivityCustomFileRenderer.MiniDetailView && (
+              <div className="h-full">
+                <MiniDetailViewRenderer
+                  section={WorkspaceSection.Data}
+                  record={selectedFile.entity as EntityCoreObjectTypes}
+                  dataType={selectedFile.entity.type}
+                  theme={ViewVariant.Light}
+                  enableAnimation={false}
+                />
+              </div>
+            )}
+            {selectedFile?.renderer === ActivityCustomFileRenderer.TaskConfigurationViewer && (
+              <TaskConfigurationViewer
+                skipStream
+                jobId={activeExecutionJobId}
+                workspace={context}
+                configId={resolvedActiveConfig?.id}
+                enabled={taskLogsViewerEnabled}
+                campaignOriginAction={campaignOriginAction}
+                isCampaignIdChanged={isCampaignIdChanged}
+              />
+            )}
+            {selectedFile?.renderer === ActivityCustomFileRenderer.TaskLogsViewer && (
+              <TaskLogsViewer
+                jobId={activeExecutionJobId}
+                workspace={context}
+                configId={resolvedActiveConfig?.id}
+                enabled={taskLogsViewerEnabled}
+                skipStream={taskLogsShouldReadSnapshot}
+                campaignOriginAction={campaignOriginAction}
+                isCampaignIdChanged={isCampaignIdChanged}
+              />
+            )}
+          </>
+        }
+      />
+      {costConfirmationModal}
+    </>
   );
 }

--- a/src/features/scan-config/use-cases/extraction/results.tsx
+++ b/src/features/scan-config/use-cases/extraction/results.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { ActivityStatus } from '@/api/entitycore/types/shared/activity';
 import { ViewVariant, WorkspaceSection } from '@/constants';
+import { useCostConfirmation } from '@/features/scan-config/components/cost-confirmation-modal';
 import { FileViewer } from '@/features/scan-config/components/file-viewer';
 import { ResultsLayout } from '@/features/scan-config/components/shared/results-layout';
 import { TaskConfigSelectionList } from '@/features/scan-config/components/shared/task-config-selection-list';
@@ -127,101 +128,120 @@ export function ExtractionTab({
     setSelectedConfigIds([]);
   };
 
+  const costModalItems = useMemo(
+    () =>
+      (configsResponse?.configList ?? [])
+        .filter((c) => resolvedSelectedConfigIds.includes(c.id))
+        .map((c) => ({ id: c.id, name: c.name })),
+    [configsResponse?.configList, resolvedSelectedConfigIds]
+  );
+
+  const { openModal, modal: costConfirmationModal } = useCostConfirmation({
+    items: costModalItems,
+    taskType: taskTypeBindings.obiOne,
+    workflowLabel: 'extractions',
+    context,
+    onConfirm: onRun,
+  });
+
   const launchBtnLabelPrefix = resolvedSelectedConfigIds.length
     ? `(${resolvedSelectedConfigIds.length})`
     : '';
   const loading = configGenerationLoading || configsLoading;
 
   return (
-    <ResultsLayout
-      campaignId={campaignId}
-      left={
-        <div className="flex h-full w-full flex-col gap-4 overflow-y-hidden">
-          <TaskConfigSelectionList
-            campaignId={campaignId}
-            configs={configs}
-            selectableConfigIds={selectableConfigIds}
-            selectedConfigIds={resolvedSelectedConfigIds}
-            activeConfigId={resolvedActiveConfig?.id}
-            loading={loading}
-            selectionDisabled={runExtractionPending}
-            fallbackColor="#004793"
-            context={context}
-            executionActivityType={taskTypeBindings.execution}
-            pauseStatusPolling={runExtractionPending}
-            executionByConfigId={executionByConfigId}
-            onSelectConfig={onActiveConfigChange}
-            onCheckedChange={onSelectedForExtractionChange}
-            onToggleSelectAll={(checked) =>
-              setSelectedConfigIds(checked ? selectableConfigIds : [])
-            }
-            onExecutionLoad={onExecutionLoad}
-          />
-          <TaskLaunchButton
-            label="Launch extractions"
-            countLabel={launchBtnLabelPrefix}
-            pending={runExtractionPending}
-            disabled={runExtractionPending || resolvedSelectedConfigIds.length === 0}
-            onClick={() => onRun(resolvedSelectedConfigIds)}
-            className="rounded-full"
-          />
-        </div>
-      }
-      middle={
-        !!resolvedActiveConfig && (
-          <div className="h-full bg-background! w-full">
-            <InOutFiles
-              config={resolvedActiveConfig}
-              execStatus={activeConfigExecStatus}
-              execution={activeConfigExecution}
-              selectedFile={selectedFile}
+    <>
+      <ResultsLayout
+        campaignId={campaignId}
+        left={
+          <div className="flex h-full w-full flex-col gap-4 overflow-y-hidden">
+            <TaskConfigSelectionList
+              campaignId={campaignId}
+              configs={configs}
+              selectableConfigIds={selectableConfigIds}
+              selectedConfigIds={resolvedSelectedConfigIds}
+              activeConfigId={resolvedActiveConfig?.id}
+              loading={loading}
+              selectionDisabled={runExtractionPending}
+              fallbackColor="#004793"
               context={context}
-              campaignOrigin={campaignOriginAction}
-              onSelect={setSelectedFile}
+              executionActivityType={taskTypeBindings.execution}
+              pauseStatusPolling={runExtractionPending}
+              executionByConfigId={executionByConfigId}
+              onSelectConfig={onActiveConfigChange}
+              onCheckedChange={onSelectedForExtractionChange}
+              onToggleSelectAll={(checked) =>
+                setSelectedConfigIds(checked ? selectableConfigIds : [])
+              }
+              onExecutionLoad={onExecutionLoad}
+            />
+            <TaskLaunchButton
+              label="Launch extractions"
+              countLabel={launchBtnLabelPrefix}
+              pending={runExtractionPending}
+              disabled={runExtractionPending || resolvedSelectedConfigIds.length === 0}
+              onClick={openModal}
+              className="rounded-full"
             />
           </div>
-        )
-      }
-      right={
-        <>
-          {selectedFile?.renderer === ActivityCustomFileRenderer.Default && (
-            <FileViewer file={selectedFile} className="h-full" context={context} />
-          )}
-          {selectedFile?.renderer === ActivityCustomFileRenderer.MiniDetailView && (
-            <div className="h-full">
-              <MiniDetailViewRenderer
-                section={WorkspaceSection.Data}
-                record={selectedFile.entity as ICircuit}
-                dataType={ExtendedEntitiesTypeDict.Circuit}
-                theme={ViewVariant.Light}
-                enableAnimation={false}
+        }
+        middle={
+          !!resolvedActiveConfig && (
+            <div className="h-full bg-background! w-full">
+              <InOutFiles
+                config={resolvedActiveConfig}
+                execStatus={activeConfigExecStatus}
+                execution={activeConfigExecution}
+                selectedFile={selectedFile}
+                context={context}
+                campaignOrigin={campaignOriginAction}
+                onSelect={setSelectedFile}
               />
             </div>
-          )}
-          {selectedFile?.renderer === ActivityCustomFileRenderer.TaskConfigurationViewer && (
-            <TaskConfigurationViewer
-              jobId={activeExecutionJobId}
-              workspace={context}
-              configId={resolvedActiveConfig?.id}
-              enabled={taskLogsViewerEnabled}
-              skipStream
-              campaignOriginAction={campaignOriginAction}
-              isCampaignIdChanged={isCampaignIdChanged}
-            />
-          )}
-          {selectedFile?.renderer === ActivityCustomFileRenderer.TaskLogsViewer && (
-            <TaskLogsViewer
-              jobId={activeExecutionJobId}
-              workspace={context}
-              configId={resolvedActiveConfig?.id}
-              enabled={taskLogsViewerEnabled}
-              skipStream={taskLogsShouldReadSnapshot}
-              campaignOriginAction={campaignOriginAction}
-              isCampaignIdChanged={isCampaignIdChanged}
-            />
-          )}
-        </>
-      }
-    />
+          )
+        }
+        right={
+          <>
+            {selectedFile?.renderer === ActivityCustomFileRenderer.Default && (
+              <FileViewer file={selectedFile} className="h-full" context={context} />
+            )}
+            {selectedFile?.renderer === ActivityCustomFileRenderer.MiniDetailView && (
+              <div className="h-full">
+                <MiniDetailViewRenderer
+                  section={WorkspaceSection.Data}
+                  record={selectedFile.entity as ICircuit}
+                  dataType={ExtendedEntitiesTypeDict.Circuit}
+                  theme={ViewVariant.Light}
+                  enableAnimation={false}
+                />
+              </div>
+            )}
+            {selectedFile?.renderer === ActivityCustomFileRenderer.TaskConfigurationViewer && (
+              <TaskConfigurationViewer
+                jobId={activeExecutionJobId}
+                workspace={context}
+                configId={resolvedActiveConfig?.id}
+                enabled={taskLogsViewerEnabled}
+                skipStream
+                campaignOriginAction={campaignOriginAction}
+                isCampaignIdChanged={isCampaignIdChanged}
+              />
+            )}
+            {selectedFile?.renderer === ActivityCustomFileRenderer.TaskLogsViewer && (
+              <TaskLogsViewer
+                jobId={activeExecutionJobId}
+                workspace={context}
+                configId={resolvedActiveConfig?.id}
+                enabled={taskLogsViewerEnabled}
+                skipStream={taskLogsShouldReadSnapshot}
+                campaignOriginAction={campaignOriginAction}
+                isCampaignIdChanged={isCampaignIdChanged}
+              />
+            )}
+          </>
+        }
+      />
+      {costConfirmationModal}
+    </>
   );
 }

--- a/src/features/scan-config/use-cases/simulations/results.tsx
+++ b/src/features/scan-config/use-cases/simulations/results.tsx
@@ -26,6 +26,7 @@ import {
   useEnsureOfflineTokenConsent,
 } from '@/features/offline-auth-management';
 import { useModelQuery } from '@/features/scan-config/components/atoms';
+import { useCostConfirmation } from '@/features/scan-config/components/cost-confirmation-modal';
 import { FileViewer } from '@/features/scan-config/components/file-viewer';
 import { SimulationFiles } from '@/features/scan-config/components/simulation-files';
 import { InOutFilesColumnSkeleton } from '@/features/scan-config/components/skeletons/columns';
@@ -80,7 +81,7 @@ export default function SimulationsTab({
     enabled: Boolean(campaignId),
   });
 
-  const { entity: model } = useModelQuery({
+  const { entity: model, entityType } = useModelQuery({
     context,
     id: simulations[0]?.entity_id,
   });
@@ -353,6 +354,49 @@ export default function SimulationsTab({
     }
   };
 
+  // Resolve the obi-one task type used to estimate cost. Prefer the workflow definition's resolved
+  // binding so the estimate matches what `run` actually launches; otherwise fall back to deriving
+  // from the model (ion-channel has its own estimable type; circuit scale is resolved server-side).
+  const simTaskType = useMemo(() => {
+    if (taskTypeBindings?.obiOne) {
+      return taskTypeBindings.obiOne;
+    }
+    if (entityType === EntityTypeDict.IonChannelModel) {
+      return ObiOneTaskTypeDict.IonChannelModelSimulationExecution;
+    }
+    if (model && 'target_simulator' in model && model.target_simulator === 'Brian2') {
+      return ObiOneTaskTypeDict.CircuitSimulationBrian2;
+    }
+    return ObiOneTaskTypeDict.CircuitSimulation;
+  }, [taskTypeBindings, entityType, model]);
+
+  const costModalItems = useMemo(
+    () =>
+      simulations
+        .filter((s) => selectedSimulationIds.includes(s.id))
+        .map((s) => ({ id: s.id, name: s.name })),
+    [simulations, selectedSimulationIds]
+  );
+
+  const { openModal, modal: costConfirmationModal } = useCostConfirmation({
+    items: costModalItems,
+    taskType: simTaskType,
+    workflowLabel: 'simulations',
+    context,
+    onConfirm: run,
+  });
+
+  // Me-model ("Single neuron beta") campaigns have no backend cost estimator, so they skip the
+  // confirmation modal and launch directly. All other scan-config sim campaigns show the modal.
+  const isMemodelCampaign = entityType === EntityTypeDict.Memodel;
+  const onLaunch = (simIds: string[]) => {
+    if (isMemodelCampaign) {
+      run(simIds);
+      return;
+    }
+    openModal();
+  };
+
   const onToggleSelectAll = (checked: boolean) => {
     setSelectedSimulationIds(checked ? selectableSimulationIds : []);
   };
@@ -380,7 +424,7 @@ export default function SimulationsTab({
         onActiveSimulationChange={onActiveSimulationChange}
         onSelectedForSimChange={onSelectedForSimChange}
         onSimulationStatusLoad={onSimulationStatusLoad}
-        onRun={run}
+        onRun={onLaunch}
         middle={
           <div className="h-full bg-background! w-full">
             {loading ? (
@@ -446,6 +490,8 @@ export default function SimulationsTab({
         onCancel={cancelOfflineTokenConsent}
         onOpenConsent={() => openConsentLink(offlineTokenConsentModal.consentUrl)}
       />
+
+      {costConfirmationModal}
 
       {creditsModal}
     </>

--- a/src/features/scan-config/use-cases/skeletonization/results.tsx
+++ b/src/features/scan-config/use-cases/skeletonization/results.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { EntityTypeDict } from '@/api/entitycore/types';
 import { ActivityStatus } from '@/api/entitycore/types/shared/activity';
 import { ViewVariant, WorkspaceSection } from '@/constants';
-import { CostConfirmationModal } from '@/features/scan-config/components/cost-confirmation-modal';
+import { useCostConfirmation } from '@/features/scan-config/components/cost-confirmation-modal';
 import { FileViewer } from '@/features/scan-config/components/file-viewer';
 import { ResultsLayout } from '@/features/scan-config/components/shared/results-layout';
 import { TaskConfigSelectionList } from '@/features/scan-config/components/shared/task-config-selection-list';
@@ -48,7 +48,6 @@ export function SkeletonizationTab({
   const [activeConfig, setActiveConfig] =
     useState<ITaskConfig<TSkeletonizationTaskConfigMeta> | null>(null);
   const [selectedFile, setSelectedFile] = useState<TActivityCustomFile | undefined>(undefined);
-  const [showCostModal, setShowCostModal] = useState(false);
   const [executionByConfigId, setExecutionByConfigId] = useState<Map<string, ITaskActivity | null>>(
     new Map()
   );
@@ -139,10 +138,13 @@ export function SkeletonizationTab({
     [configsResponse?.configList, resolvedSelectedConfigIds]
   );
 
-  const onCostConfirm = (confirmedIds: string[]) => {
-    setShowCostModal(false);
-    onRun(confirmedIds);
-  };
+  const { openModal, modal: costConfirmationModal } = useCostConfirmation({
+    items: costModalItems,
+    taskType: taskTypeBindings.obiOne,
+    workflowLabel: 'skeletonizations',
+    context,
+    onConfirm: onRun,
+  });
 
   const launchBtnLabelPrefix = resolvedSelectedConfigIds.length
     ? `(${resolvedSelectedConfigIds.length})`
@@ -180,7 +182,7 @@ export function SkeletonizationTab({
               countLabel={launchBtnLabelPrefix}
               pending={runSkeletonizationPending}
               disabled={runSkeletonizationPending || resolvedSelectedConfigIds.length === 0}
-              onClick={() => setShowCostModal(true)}
+              onClick={openModal}
             />
           </div>
         }
@@ -217,15 +219,7 @@ export function SkeletonizationTab({
           </>
         }
       />
-      <CostConfirmationModal
-        open={showCostModal}
-        onClose={() => setShowCostModal(false)}
-        onConfirm={onCostConfirm}
-        items={costModalItems}
-        taskType={taskTypeBindings.obiOne}
-        workflowLabel="skeletonizations"
-        context={context}
-      />
+      {costConfirmationModal}
     </>
   );
 }


### PR DESCRIPTION
## Summary

Ticket: openbraininstitute/prod-circuit-simulation#213 — *Add workflow coordinate pricing modal on Launch press*

The `CostConfirmationModal` (per-coordinate credit estimate + total, shown on Launch) already existed and was wired only into the **mesh skeletonization** workflow. This enables it across the rest of the scan-config task workflows so every Launch press shows a price estimate before running.

## Changes

- **Shared hook** — new `useCostConfirmation` (`cost-confirmation-modal/use-cost-confirmation.tsx`, re-exported from the modal's barrel) owns the modal open-state, render, and confirm wiring. Adopted in all four scan-config tabs.
- **Skeletonization** — refactored from inline modal wiring to the hook (behavior unchanged).
- **Extraction** — modal added (`circuit_extraction`).
- **Build** — modal added (`em_synapse_mapping`).
- **Simulations** — modal added for **circuit** (all scales, incl. Brian2/LearningEngine) and **ion-channel** campaigns; the obi-one task type is resolved per model entity. **Me-model ("Single neuron beta") campaigns launch directly with no modal**, since the backend has no cost estimator for them.
- **`useModelQuery`** now also returns `entityType` (additive), used to pick the sim task type and detect me-model campaigns.

## Scope notes

- Applies only to launches from the scan-config component. The separate standalone single-neuron / synaptome simulation builder is out of scope and untouched.
- The estimate endpoint (`/declared/task/estimate`) prices circuit, ion-channel, extraction, build and skeletonization tasks; me-model sims have no estimator, hence the client-side exclusion.

## Test plan

- [x] **Skeletonization** (regression): modal → confirm → consent (if needed) → launch, unchanged.
- [x] **Simulations — circuit (small & large) / Brian2**: modal shows real credits; Confirm launches.
- [x] **Simulations — ion-channel**: modal shows real credits (`ion_channel_model_simulation_execution`).
- [x] **Simulations — me-model ("Single neuron beta")**: no modal, launches directly as today.
