### PR TITLE
Gate brain region simulations behind a feature flag

### DIFF
--- a/src/entity-configuration/domain/simulation/region-circuit-simulation.ts
+++ b/src/entity-configuration/domain/simulation/region-circuit-simulation.ts
@@ -18,6 +18,7 @@ import {
   rows as listSimulationRows,
 } from '@/entity-configuration/domain/simulation/simulation-campaign';
 import { EntitySlug } from '@/entity-configuration/domain/slug';
+import { brainRegionSimulationFlag } from '@/features/feature-flags/flags';
 
 import { migrateConfig } from './utils';
 
@@ -97,6 +98,7 @@ export const RegionCircuitSimulation: EntityCoreTypeConfig<
   group: EntityTypeGroup.Simulations,
   title: 'Region circuit (beta)',
   extendedType: ExtendedEntitiesTypeDict.RegionCircuitSimulation,
+  requiredFeatures: [brainRegionSimulationFlag.key],
   discriminator: { key: 'scale', value: [SCALE] },
   type: EntityTypeDict.SimulationCampaign,
   slug: EntitySlug.RegionCircuitSimulation,

--- a/src/features/feature-flags/flags.ts
+++ b/src/features/feature-flags/flags.ts
@@ -19,7 +19,15 @@ export const extractionActivityFlag = defineFlag<boolean>({
   visible: () => ['local', 'preview'].includes(config.DEPLOYMENT_ENV),
 });
 
-export const flags = [aiPanelStateFlag, extractionActivityFlag] as const;
+export const brainRegionSimulationFlag = defineFlag<boolean>({
+  key: 'brain-region-simulation',
+  defaultValue: false,
+  values: [true, false],
+  description: 'Brain region simulations',
+  visible: () => ['local', 'preview', 'staging'].includes(config.DEPLOYMENT_ENV),
+});
+
+export const flags = [aiPanelStateFlag, extractionActivityFlag, brainRegionSimulationFlag] as const;
 
 export type FlagKey = (typeof flags)[number]['key'];
 

--- a/src/ui/segments/action-menu.tsx
+++ b/src/ui/segments/action-menu.tsx
@@ -23,6 +23,7 @@ import {
 import { useAppNotification } from '@/components/notification';
 import { type TViewVariant, ViewVariant, WorkspaceScope, WorkspaceSection } from '@/constants';
 import { getEntityByExtendedType } from '@/entity-configuration/domain/helpers';
+import { useFlags } from '@/features/feature-flags';
 import { useCopyToClipboard } from '@/hooks/useCopyClipboard';
 import { downloadArchive } from '@/services/entity-download';
 import { Action, ActionKind } from '@/ui/molecules/side-menu-action';
@@ -53,6 +54,7 @@ export default function ActionMenu({
   const queryClient = useQueryClient();
   const [, setCircuit] = useAtom(downloadPanelCircuitAtom);
   const { error: notifyError, success: notifySuccess } = useAppNotification();
+  const flags = useFlags();
   const entityType = getEntityByExtendedType({ type });
   if (!entityType) notFound();
 
@@ -147,8 +149,9 @@ export default function ActionMenu({
       extendedType: type,
       entityId: entity.id,
       entity: 'scale' in entity ? { scale: entity.scale } : {},
+      flags,
     });
-  }, [isSimulatable, ctx, type, entity]);
+  }, [isSimulatable, ctx, type, entity, flags]);
 
   return (
     <div

--- a/src/ui/segments/workflows/config/activities/simulate.ts
+++ b/src/ui/segments/workflows/config/activities/simulate.ts
@@ -1,4 +1,5 @@
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import { brainRegionSimulationFlag } from '@/features/feature-flags/flags';
 import { SchemaNameDict } from '@/features/scan-config/types';
 import { simulateIonChannelWorkflow } from '@/features/scan-config/workflow/definitions/simulate-ion-channel';
 import { simulateMEModelWithSynapsesCircuitWorkflow } from '@/features/scan-config/workflow/definitions/simulate-me-model-with-synapses-circuit';
@@ -203,6 +204,7 @@ export const SimulateWorkflows: readonly IWorkflowDescriptor[] = [
         filters: simulatableCircuitFilters,
       },
     ],
+    requiredFeatures: [brainRegionSimulationFlag.key],
     disabled: false,
     order: 9,
   },

--- a/src/ui/segments/workflows/config/helpers.ts
+++ b/src/ui/segments/workflows/config/helpers.ts
@@ -43,7 +43,7 @@ import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-
 import type { TWorkspaceSection } from '@/constants';
 import type { FeatureFlags, FlagKey } from '@/features/feature-flags/flags';
 
-const featuresSatisfied = (
+export const featuresSatisfied = (
   required: readonly FlagKey[] | undefined,
   flags: FeatureFlags | undefined
 ): boolean => {

--- a/src/ui/segments/workflows/config/routes.ts
+++ b/src/ui/segments/workflows/config/routes.ts
@@ -11,7 +11,7 @@ import {
   type TWorkflowSessionSelectionRef,
   WorkflowSessionSelectionMode,
 } from '@/features/scan-config/workflow/workflow-session-selection';
-import { getTargetType, getWorkflow } from '@/ui/segments/workflows/config/helpers';
+import { featuresSatisfied, getWorkflow } from '@/ui/segments/workflows/config/helpers';
 import {
   type TWorkflowInitialStage,
   WORKFLOW_SESSION_ID_SEARCH_PARAM,
@@ -26,6 +26,7 @@ import { makePathParamUrlFromExtendedType } from '@/utils/url-builder';
 
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import type { FeatureFlags } from '@/features/feature-flags/flags';
 import type { TWorkflowSchemaSelection } from '@/features/scan-config/workflow/workflow-schema-selection';
 import type { WorkspaceContext } from '@/types/common';
 import type { IWorkflowDescriptor, TActivityValue } from '@/ui/segments/workflows/config/types';
@@ -333,29 +334,33 @@ export function buildSimulateConfigureUrlFromDataViewEntity({
   extendedType,
   entityId,
   entity,
+  flags,
 }: {
   workspace: WorkspaceContext;
   extendedType: TExtendedEntitiesTypeDict;
   entityId: string;
   entity: { scale?: ICircuit['scale'] };
+  flags?: FeatureFlags;
 }): string | null {
   const sourceType = resolveSimulateSourceTypeFromDataView(extendedType, entity);
   if (!sourceType) {
     return null;
   }
 
-  const targetType = getTargetType({
+  const workflow = getWorkflow({
     activity: WorkflowActivityDictValue.simulate,
     sourceType,
   });
 
-  if (!targetType) {
+  // Gate the simulate entry point on the resolved workflow's feature flags, so the button is
+  // hidden whenever the workflow requires a flag the user doesn't have (e.g. whole-brain sim).
+  if (!workflow || !featuresSatisfied(workflow.requiredFeatures, flags)) {
     return null;
   }
 
   return buildConfigureUrlForEntity({
     activity: WorkflowActivityDictValue.simulate,
-    targetType,
+    targetType: workflow.targetType,
     workspace,
     entityId,
     entityType: sourceType,


### PR DESCRIPTION
## What

Puts **brain region** simulations behind a new `brain-region-simulation` feature flag (they were previously enabled in all environments).

- **Flag** (`src/features/feature-flags/flags.ts`): `brainRegionSimulationFlag` — key `brain-region-simulation`, **off by default**, togglable via the Experimental Features panel in **`local` / `preview` / `staging`**, hidden in production.
- **Workflow grid** (`activities/simulate.ts`): `requiredFeatures` on the BrainRegion simulate workflow → card is gated out of the simulate activity when the flag is off.
- **Explore tile** (`simulation/region-circuit-simulation.ts`): `requiredFeatures` on `RegionCircuitSimulation` → result tile is hidden from the Simulations tab when the flag is off.

## Reusable Simulate-button gate

The Simulate button (`ActionMenu`) was only gated by `isSimulatable` + a non-null URL — neither consulted feature flags. This adds a single, generic gate:

- Export the existing `featuresSatisfied()` predicate from `workflows/config/helpers.ts`.
- `buildSimulateConfigureUrlFromDataViewEntity` (`routes.ts`) now returns `null` when the resolved workflow's `requiredFeatures` are not satisfied, and `ActionMenu` passes the current `useFlags()`.

Because the base `Circuit.isSimulatable` already returns `true` for `Region` scale, the button is reachable for region circuits and this gate hides it when the flag is off / shows it when on. The mechanism works for **any** flag-gated simulate workflow, so future gating only needs `requiredFeatures` on the workflow descriptor — no button-logic changes.

## Verification

Suggested manual checks:
- [x] Flag **off** (default): region circuit detail page has no Simulate button; the Brain region card is absent from the simulate grid; the Region circuit result tile is absent from the Simulations tab.
- [x] Toggle **on** in Profile → Experimental Features → all reappear and the Simulate button resolves to the configure URL.
- [x] A non-flagged entity (e.g. microcircuit) still shows its Simulate button.