### PR TITLE
Remove unused GITHUB_TOKEN config

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,6 @@ When `API_ORIGIN` is set, missing service URLs default to
 | Variable | Purpose |
 | --- | --- |
 | `AUTH_PROXY_URL` | Preview-only auth proxy. Validation rejects it outside `DEPLOYMENT_ENV=preview`. |
-| `GITHUB_TOKEN` | Optional GitHub API access. |
 | `GITHUB_FEEDBACK_TOKEN` | Optional token for feedback issue/project creation. |
 | `GITHUB_FEEDBACK_PROJECT_ID` | Optional GitHub feedback project ID. |
 | `MAILCHIMP_API_KEY` | Optional Mailchimp API key. |

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -238,7 +238,6 @@ Properties with `public: false` are only available via `serverConfig` (imported 
 - `KEYCLOAK_ISSUER`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET`
 - `NEXTAUTH_SECRET`
 - `MAILCHIMP_API_KEY`, `MAILCHIMP_AUDIENCE_ID`, `MAILCHIMP_API_SERVER` (optional)
-- `GITHUB_TOKEN` (optional)
 
 ### Client & Server Properties
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -35,8 +35,6 @@ const configFields = {
     public: false,
   },
 
-  GITHUB_TOKEN: { schema: z.string().optional(), public: false },
-
   GITHUB_FEEDBACK_TOKEN: { schema: z.string().optional(), public: false },
   GITHUB_FEEDBACK_PROJECT_ID: { schema: z.string().optional(), public: false },
 


### PR DESCRIPTION
GITHUB_TOKEN was initially used to fetch notebooks from GitHub but we migrated to fetching them from entitycore.

for: https://github.com/openbraininstitute/INFRA/issues/556