### PR TITLE
Circuit: add Target simulator column and filter

### DIFF
--- a/src/api/entitycore/types/entities/circuit.ts
+++ b/src/api/entitycore/types/entities/circuit.ts
@@ -75,7 +75,14 @@ export type TCircuitScaleDictionary =
 export type TCircuitBuildCategoryDictionary =
   (typeof CircuitBuildCategory)[keyof typeof CircuitBuildCategory]['key'];
 
-export type TCircuitTargetSimulator = 'NEURON' | 'Brian2' | 'LearningEngine';
+export const CircuitTargetSimulator = {
+  Neuron: { key: 'NEURON', label: 'NEURON' },
+  Brian2: { key: 'Brian2', label: 'Brian2' },
+  LearningEngine: { key: 'LearningEngine', label: 'LearningEngine' },
+} as const;
+
+export type TCircuitTargetSimulator =
+  (typeof CircuitTargetSimulator)[keyof typeof CircuitTargetSimulator]['key'];
 
 interface CircuitBase {
   description: string;
@@ -116,6 +123,7 @@ export interface ICircuitFilter
     CircuitScaleFilter,
     IlikeSearchFilter {
   has_electrical_cell_models?: boolean;
+  target_simulator__in?: Array<string>;
 }
 
 export type SonataCircuitNetworkEdgeConfigItem = {

--- a/src/entity-configuration/definitions/fields-defs/enums.ts
+++ b/src/entity-configuration/definitions/fields-defs/enums.ts
@@ -82,6 +82,7 @@ export enum EntityCoreFields {
   TaskActivityStatus = 'task_activity_status',
   CircuitName = 'circuit_name',
   CircuitBuildCategory = 'build_category',
+  CircuitTargetSimulator = 'target_simulator',
   CircuitScale = 'scale',
   CircuitRootCircuit = 'root_circuit_id',
   ArtifactPublishedIn = 'published_in',

--- a/src/entity-configuration/definitions/fields-defs/model.tsx
+++ b/src/entity-configuration/definitions/fields-defs/model.tsx
@@ -2,7 +2,11 @@ import { LoadingOutlined, WarningFilled } from '@ant-design/icons';
 import { find, isNil, map, omit } from 'es-toolkit/compat';
 
 import { hasAssets } from '@/api/entitycore/guards';
-import { CircuitBuildCategory, CircuitScale } from '@/api/entitycore/types/entities/circuit';
+import {
+  CircuitBuildCategory,
+  CircuitScale,
+  CircuitTargetSimulator,
+} from '@/api/entitycore/types/entities/circuit';
 import { ValidationStatus } from '@/api/entitycore/types/entities/me-model';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { WorkspaceSection } from '@/constants';
@@ -281,6 +285,37 @@ export const FieldsDefinition: Partial<FieldsDefinitionRegistry<EntityCoreObject
     vocabulary: {
       plural: 'Build categories',
       singular: 'Build category',
+    },
+    style: { align: 'left' },
+  },
+  [EntityCoreFields.CircuitTargetSimulator]: {
+    className: 'text-left',
+    title: 'Target simulator',
+    filter: CoreFieldFilterTypeEnum.DropdownList,
+    filterData: map(CircuitTargetSimulator, (item) => ({
+      label: item.label,
+      value: item.key,
+    })),
+    isFilterable: true,
+    isDisplayable: true,
+    isSortable: true,
+    order: [
+      {
+        types: [ExtendedEntitiesTypeDict.Circuit, ExtendedEntitiesTypeDict.SingleNeuronCircuit],
+        property: 'order_by',
+        value: 'target_simulator',
+      },
+    ],
+    render: (r) => {
+      const targetSimulator = (r as ICircuit).target_simulator;
+      return renderEmptyOrValue(
+        targetSimulator ? find(CircuitTargetSimulator, { key: targetSimulator })?.label : undefined
+      );
+    },
+    defaultConstraint: 'target_simulator__in',
+    vocabulary: {
+      plural: 'Target simulators',
+      singular: 'Target simulator',
     },
     style: { align: 'left' },
   },

--- a/src/entity-configuration/definitions/view-defs/model/circuit.ts
+++ b/src/entity-configuration/definitions/view-defs/model/circuit.ts
@@ -20,6 +20,7 @@ export const ViewDefForCircuit: ViewDefinitionConfig = {
     EntityCoreFields.CircuitNumberSynapses,
     EntityCoreFields.CircuitNumberConnections,
     EntityCoreFields.CircuitBuildCategory,
+    EntityCoreFields.CircuitTargetSimulator,
     EntityCoreFields.ArtifactPublishedIn,
     EntityCoreFields.ArtifactExperimentDate,
   ],


### PR DESCRIPTION
## Description

Adds a **"Target simulator"** column + dropdown filter to the Circuit data table and the workflow entity-selection table, based on the entitycore `Circuit.target_simulator` property.

Because the Data explore table and the workflow circuit picker share a single column/filter registry, one field definition covers both. The implementation mirrors the existing "Build category" column (static `DropdownList` filter, sortable, `target_simulator__in` constraint).

## Changes

- `src/api/entitycore/types/entities/circuit.ts` — add `CircuitTargetSimulator` dictionary (single source of truth; `TCircuitTargetSimulator` now derives from it); add `target_simulator__in` to `ICircuitFilter`
- `src/entity-configuration/definitions/fields-defs/enums.ts` — add `CircuitTargetSimulator` to `EntityCoreFields`
- `src/entity-configuration/definitions/fields-defs/model.tsx` — add the field definition (filter + sortable + null-safe render)
- `src/entity-configuration/definitions/view-defs/model/circuit.ts` — add the column to the Circuit view

## Acceptance criteria

- [x] The Data Circuit table and filter have a "Target simulator" column
- [x] When selecting a circuit, the workflow entity selection table and filter have a "Target simulator" column

## Dependency

Depends on the entitycore change that adds filtering + ordering support for `target_simulator`: [Support ordering circuits by target_simulator](openbraininstitute/entitycore#640). The column renders regardless, but the filter (`target_simulator__in`) and sort (`order_by=target_simulator`) require that backend change to be deployed.

## Original feature request

[Add "Target simulator" column to Data Circuit table and filter, + workflow entity selection table](openbraininstitute/prod-circuit-simulation#217)