### PR TITLE
Graceful UI for missing circuit analysis plots and visualization image

### DIFF
--- a/src/ui/segments/detail-view/overview/index.tsx
+++ b/src/ui/segments/detail-view/overview/index.tsx
@@ -13,6 +13,8 @@ import {
   ExtendedEntitiesTypeDict,
   type TExtendedEntitiesTypeDict,
 } from '@/api/entitycore/types/extended-entity-type';
+import { AssetLabel } from '@/api/entitycore/types/shared/global';
+import { getAssetElement } from '@/api/entitycore/utils';
 import { tryCatch } from '@/api/utils';
 import { ViewVariant } from '@/constants';
 import { EntityCoreFields } from '@/entity-configuration/definitions/fields-defs/enums';
@@ -421,8 +423,17 @@ export default async function Overview({
     ExtendedEntitiesTypeDict.SynthesizedCellMorphology,
   ] as const;
 
+  // Only treat a circuit as having a visualization when the image asset actually exists,
+  // so a missing image skips the block entirely (no red error box, no leftover margin).
+  const circuitVisualizationAsset = circuitTypes.includes(extendedType)
+    ? getAssetElement({
+        assets: (entity as ICircuit).assets,
+        filter: (i) => i.label === AssetLabel.circuit_visualization,
+      })
+    : undefined;
+
   const hasVisualization =
-    circuitTypes.includes(extendedType) ||
+    (circuitTypes.includes(extendedType) && Boolean(circuitVisualizationAsset)) ||
     includes(morphologyTypes, extendedType) ||
     extendedType === ExtendedEntitiesTypeDict.ElectricalCellRecording ||
     extendedType === ExtendedEntitiesTypeDict.IonChannelRecording ||

--- a/src/ui/segments/explore/circuit/elements/overview.tsx
+++ b/src/ui/segments/explore/circuit/elements/overview.tsx
@@ -5,12 +5,16 @@ import toPairs from 'es-toolkit/compat/toPairs';
 import { AssetLabel } from '@/api/entitycore/types/shared/global';
 import { getAssetElement } from '@/api/entitycore/utils';
 import { type TViewVariant, ViewVariant } from '@/constants';
-import { detailViewInsetPanelClass } from '@/ui/segments/detail-view/variant-styles';
+import {
+  detailViewInsetPanelClass,
+  detailViewTabbedEmptyClass,
+} from '@/ui/segments/detail-view/variant-styles';
 import { Header } from '@/ui/segments/explore/circuit/elements/section-header';
 import { ProgressiveEntityImage } from '@/ui/segments/explore/circuit/elements/use-progressive-img';
 import { cn } from '@/utils/css-class';
 
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
+import type { IAsset } from '@/api/entitycore/types/shared/global';
 
 type Props = {
   circuit: ICircuit;
@@ -39,9 +43,14 @@ export default function Overview({ circuit, variant = ViewVariant.Light }: Props
     },
   });
 
+  const present = (asset?: IAsset): asset is IAsset => Boolean(asset);
+
   const list = {
-    cell: { title: 'Cell statistics', items: [cellProperties] },
-    network: { title: 'Network statistics', items: [networkPropertiesA, networkPropertiesB] },
+    cell: { title: 'Cell statistics', items: [cellProperties].filter(present) },
+    network: {
+      title: 'Network statistics',
+      items: [networkPropertiesA, networkPropertiesB].filter(present),
+    },
   };
 
   return (
@@ -59,22 +68,28 @@ export default function Overview({ circuit, variant = ViewVariant.Light }: Props
                   variant === ViewVariant.Default && detailViewInsetPanelClass(variant)
                 )}
               >
-                {items.map((asset, index) => (
-                  <ProgressiveEntityImage
-                    key={`${key}-${asset?.id || index}`}
-                    bordered={false}
-                    asset={asset}
-                    entityId={circuit.id}
-                    alt={asset?.path ?? ''}
-                    height={300}
-                    width="100%"
-                    maxHeight="auto"
-                    maxWidth="100%"
-                    yPadding={16}
-                    xPadding={40}
-                    variant={variant}
-                  />
-                ))}
+                {items.length === 0 ? (
+                  <div className={cn(detailViewTabbedEmptyClass(variant), 'min-h-32 text-sm')}>
+                    Not available
+                  </div>
+                ) : (
+                  items.map((asset, index) => (
+                    <ProgressiveEntityImage
+                      key={`${key}-${asset.id || index}`}
+                      bordered={false}
+                      asset={asset}
+                      entityId={circuit.id}
+                      alt={asset.path ?? ''}
+                      height={300}
+                      width="100%"
+                      maxHeight="auto"
+                      maxWidth="100%"
+                      yPadding={16}
+                      xPadding={40}
+                      variant={variant}
+                    />
+                  ))
+                )}
               </div>
             </div>
           );

--- a/src/ui/segments/explore/circuit/elements/visualization.tsx
+++ b/src/ui/segments/explore/circuit/elements/visualization.tsx
@@ -20,6 +20,9 @@ export function Visualization({ circuit }: Props) {
     },
   });
 
+  // Only render the circuit image when its asset exists; otherwise show nothing.
+  if (!visAsset) return null;
+
   return (
     <div
       id={`visualization-${kebabCase(circuit.type)}-${circuit.id}`}

--- a/src/ui/segments/mini-detail-view/previews/circuit-preview.tsx
+++ b/src/ui/segments/mini-detail-view/previews/circuit-preview.tsx
@@ -1,29 +1,19 @@
-import { Empty } from 'antd';
-
 import { hasAssets } from '@/api/entitycore/guards';
 import { getAsset } from '@/api/entitycore/selectors/assets';
 import { AssetLabel } from '@/api/entitycore/types/shared/global';
-import { EmptyPreview } from '@/entity-configuration/definitions/renderer';
 import { ProgressiveEntityImage } from '@/ui/segments/explore/circuit/elements/use-progressive-img';
 
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
 
 export function CircuitPreview({ record }: { record: ICircuit }) {
-  if (!hasAssets(record)) return EmptyPreview;
+  // Only render the circuit image when its asset exists; otherwise show nothing.
+  if (!hasAssets(record)) return null;
   const visualizationAsset = getAsset({
     assets: record.assets,
     label: AssetLabel.circuit_visualization,
   }).getOneOrNull();
 
-  if (!visualizationAsset)
-    return (
-      <Empty
-        key="no-asset-empty-thumbnail"
-        description="Error loading thumbnail"
-        image={Empty.PRESENTED_IMAGE_SIMPLE}
-        className="h-full! w-full! select-none [&_.ant-empty-description]:text-white!"
-      />
-    );
+  if (!visualizationAsset) return null;
 
   return (
     <div className="w-full bg-white">


### PR DESCRIPTION
## Summary

On a circuit's detail page, missing assets were surfaced as prominent errors even though they're a normal state for newly registered circuits (by users or obi-one tasks). This affected two areas:

1. The **Analysis** section (Cell statistics / Network statistics) rendered a red error box when an analysis plot asset was missing.
2. The **circuit visualization image** rendered a red "Failed to load image / asset missing, please contact support" box when the `circuit_visualization` asset was missing.

This PR makes both degrade gracefully: a quiet **"Not available"** for the analysis plots, and **nothing at all** (no message, no leftover gap) for the missing visualization image.

## Behavior

**Analysis section**
- **Cell statistics** missing → "Not available".
- **Network statistics** (two assets: `network_stats_a`, `network_stats_b`) → a single "Not available" only when **both** are missing; if one exists, only the available plot renders (no per-asset placeholder).

**Circuit visualization image** (the static image, not an interactive/3D viewer)
- Detail page: when `circuit_visualization` is absent, the whole visualization block is skipped — no red box, no message, and no empty margin above the metadata grid.
- Mini-detail-view side-panel thumbnail: shows nothing instead of the previous "Error loading thumbnail".

**Out of scope / unchanged**
- Genuine download/decode failures (asset exists but fails to load) keep their existing error UI + retry — only the *missing-asset* case changed.
- The shared `ProgressiveEntityImage` component and the scan-config build/interactive preview are untouched.

## Changes

- `src/ui/segments/explore/circuit/elements/overview.tsx` — Analysis section: filter each section to assets that exist, show "Not available" when empty (reuses the existing variant-aware `detailViewTabbedEmptyClass`).
- `src/ui/segments/detail-view/overview/index.tsx` — gate the circuit visualization block on the `circuit_visualization` asset existing, so a missing image removes the block and its margin entirely.
- `src/ui/segments/explore/circuit/elements/visualization.tsx` — `Visualization` returns nothing when the asset is absent.
- `src/ui/segments/mini-detail-view/previews/circuit-preview.tsx` — render nothing instead of "Error loading thumbnail" when the image asset is missing.

## Ticket

Fixes [Missing circuit analysis plots should not be displayed as an error](openbraininstitute/prod-explore-functionality#516).
