### PR TITLE
feat(circuit): derivation type column + filter on circuits overview

### DIFF
--- a/src/api/entitycore/queries/model/circuit.ts
+++ b/src/api/entitycore/queries/model/circuit.ts
@@ -1,7 +1,11 @@
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import { compactRecord } from '@/utils/dictionary';
 
-import type { ICircuit, ICircuitFilter } from '@/api/entitycore/types/entities/circuit';
+import type {
+  ExpandCircuitParam,
+  ICircuit,
+  ICircuitFilter,
+} from '@/api/entitycore/types/entities/circuit';
 import type { TDerivationType } from '@/api/entitycore/types/entities/derivation';
 import type { HierarchyTreeResponse } from '@/api/entitycore/types/shared/hierarchy';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
@@ -24,16 +28,19 @@ const baseUri = '/circuit';
 export async function getCircuits({
   withFacets,
   filters,
+  expand,
   context,
 }: {
   withFacets?: boolean;
   filters?: Partial<ICircuitFilter>;
+  expand?: ExpandCircuitParam;
   context?: WorkspaceContext | null;
 }) {
   const api = await entityCoreApi();
   return await api.get<EntityCoreResponse<ICircuit>>(baseUri, {
     queryParams: compactRecord({
       ...filters,
+      expand,
       with_facets: withFacets,
     }),
     headers: {

--- a/src/api/entitycore/queries/model/circuit.ts
+++ b/src/api/entitycore/queries/model/circuit.ts
@@ -1,12 +1,11 @@
 import { entityCoreApi, getEntityCoreContext } from '@/api/entitycore/utils';
 import { compactRecord } from '@/utils/dictionary';
 
+import type { ICircuit, ICircuitFilter } from '@/api/entitycore/types/entities/circuit';
 import type {
-  ExpandCircuitParam,
-  ICircuit,
-  ICircuitFilter,
-} from '@/api/entitycore/types/entities/circuit';
-import type { TDerivationType } from '@/api/entitycore/types/entities/derivation';
+  EntityExpandParam,
+  TDerivationType,
+} from '@/api/entitycore/types/entities/derivation';
 import type { HierarchyTreeResponse } from '@/api/entitycore/types/shared/hierarchy';
 import type { EntityCoreResponse } from '@/api/entitycore/types/shared/response';
 import type { WorkspaceContext } from '@/types/common';
@@ -33,7 +32,7 @@ export async function getCircuits({
 }: {
   withFacets?: boolean;
   filters?: Partial<ICircuitFilter>;
-  expand?: ExpandCircuitParam;
+  expand?: EntityExpandParam;
   context?: WorkspaceContext | null;
 }) {
   const api = await entityCoreApi();

--- a/src/api/entitycore/types/entities/circuit.ts
+++ b/src/api/entitycore/types/entities/circuit.ts
@@ -1,5 +1,7 @@
-import type { TDerivationType } from '@/api/entitycore/types/entities/derivation';
-import type { TEntityTypeDict } from '@/api/entitycore/types/entity-type';
+import type {
+  EntityDerivationFilter,
+  EntityDerivations,
+} from '@/api/entitycore/types/entities/derivation';
 import type {
   EntityAuthorization,
   EntityCoreBaseAsset,
@@ -101,19 +103,6 @@ interface CircuitBase {
   target_simulator: TCircuitTargetSimulator | null;
 }
 
-/** Opt-in derivation lists exposed by the circuit API via the `expand` query param. */
-export type ExpandCircuitParam = 'generated_derivations' | 'used_derivations';
-
-/**
- * A derivation where the circuit is the `generated` (derived) entity — i.e. "how it was derived".
- * Populated only when the list/detail request opts in via `?expand=generated_derivations`.
- */
-export interface ICircuitGeneratedDerivation {
-  used: { id: string; type?: TEntityTypeDict | null; name?: string };
-  derivation_type: TDerivationType;
-  label?: string | null;
-}
-
 export interface ICircuit
   extends EntityCoreIdentifiableNamed,
     EntityAuthorization,
@@ -121,13 +110,9 @@ export interface ICircuit
     Timestamps,
     EntityCoreOwnership,
     EntityCoreType,
-    EntityCoreBaseAsset {
+    EntityCoreBaseAsset,
+    EntityDerivations {
   subject?: ISubject;
-  /**
-   * Derivations where this circuit is the generated entity. `null`/absent unless the request
-   * expanded `generated_derivations`; `[]` when expanded but the circuit is not derived.
-   */
-  generated_derivations?: Array<ICircuitGeneratedDerivation> | null;
 }
 
 type CircuitScaleFilter = {
@@ -141,12 +126,11 @@ export interface ICircuitFilter
     SharedFilter,
     PaginationFilter,
     CircuitScaleFilter,
-    IlikeSearchFilter {
+    IlikeSearchFilter,
+    // `generated_derivation__derivation_type[__in]` drives the "Derivation type" column filter.
+    EntityDerivationFilter {
   has_electrical_cell_models?: boolean;
   target_simulator__in?: Array<string>;
-  // Filter by how the circuit was derived (it is the `generated` entity of the derivation).
-  generated_derivation__derivation_type?: TDerivationType;
-  generated_derivation__derivation_type__in?: Array<TDerivationType>;
 }
 
 export type SonataCircuitNetworkEdgeConfigItem = {

--- a/src/api/entitycore/types/entities/circuit.ts
+++ b/src/api/entitycore/types/entities/circuit.ts
@@ -1,3 +1,5 @@
+import type { TDerivationType } from '@/api/entitycore/types/entities/derivation';
+import type { TEntityTypeDict } from '@/api/entitycore/types/entity-type';
 import type {
   EntityAuthorization,
   EntityCoreBaseAsset,
@@ -99,6 +101,19 @@ interface CircuitBase {
   target_simulator: TCircuitTargetSimulator | null;
 }
 
+/** Opt-in derivation lists exposed by the circuit API via the `expand` query param. */
+export type ExpandCircuitParam = 'generated_derivations' | 'used_derivations';
+
+/**
+ * A derivation where the circuit is the `generated` (derived) entity — i.e. "how it was derived".
+ * Populated only when the list/detail request opts in via `?expand=generated_derivations`.
+ */
+export interface ICircuitGeneratedDerivation {
+  used: { id: string; type?: TEntityTypeDict | null; name?: string };
+  derivation_type: TDerivationType;
+  label?: string | null;
+}
+
 export interface ICircuit
   extends EntityCoreIdentifiableNamed,
     EntityAuthorization,
@@ -108,6 +123,11 @@ export interface ICircuit
     EntityCoreType,
     EntityCoreBaseAsset {
   subject?: ISubject;
+  /**
+   * Derivations where this circuit is the generated entity. `null`/absent unless the request
+   * expanded `generated_derivations`; `[]` when expanded but the circuit is not derived.
+   */
+  generated_derivations?: Array<ICircuitGeneratedDerivation> | null;
 }
 
 type CircuitScaleFilter = {
@@ -124,6 +144,9 @@ export interface ICircuitFilter
     IlikeSearchFilter {
   has_electrical_cell_models?: boolean;
   target_simulator__in?: Array<string>;
+  // Filter by how the circuit was derived (it is the `generated` entity of the derivation).
+  generated_derivation__derivation_type?: TDerivationType;
+  generated_derivation__derivation_type__in?: Array<TDerivationType>;
 }
 
 export type SonataCircuitNetworkEdgeConfigItem = {

--- a/src/api/entitycore/types/entities/derivation.test.ts
+++ b/src/api/entitycore/types/entities/derivation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DerivationTypeDictionary,
+  getCircuitDerivationColumnLabels,
+} from '@/api/entitycore/types/entities/derivation';
+
+describe('getCircuitDerivationColumnLabels', () => {
+  it('maps a single circuit derivation type to its short label', () => {
+    expect(
+      getCircuitDerivationColumnLabels([
+        { derivation_type: DerivationTypeDictionary.CircuitExtraction },
+      ])
+    ).toEqual(['Extracted']);
+  });
+
+  it('ignores non-circuit derivation types, keeping only the circuit ones', () => {
+    expect(
+      getCircuitDerivationColumnLabels([
+        { derivation_type: DerivationTypeDictionary.CircuitExtraction },
+        { derivation_type: DerivationTypeDictionary.EmodelCircuit },
+        { derivation_type: DerivationTypeDictionary.Unspecified },
+      ])
+    ).toEqual(['Extracted']);
+  });
+
+  it('lists multiple circuit derivation types', () => {
+    expect(
+      getCircuitDerivationColumnLabels([
+        { derivation_type: DerivationTypeDictionary.CircuitExtraction },
+        { derivation_type: DerivationTypeDictionary.CircuitRewiring },
+      ])
+    ).toEqual(['Extracted', 'Rewired']);
+  });
+
+  it('de-duplicates repeated derivation types', () => {
+    expect(
+      getCircuitDerivationColumnLabels([
+        { derivation_type: DerivationTypeDictionary.CircuitCustomization },
+        { derivation_type: DerivationTypeDictionary.CircuitCustomization },
+      ])
+    ).toEqual(['Customized']);
+  });
+
+  it('returns an empty list when only non-circuit derivation types are present', () => {
+    expect(
+      getCircuitDerivationColumnLabels([
+        { derivation_type: DerivationTypeDictionary.EmodelCircuit },
+      ])
+    ).toEqual([]);
+  });
+
+  it('returns an empty list for no derivations', () => {
+    expect(getCircuitDerivationColumnLabels([])).toEqual([]);
+  });
+});

--- a/src/api/entitycore/types/entities/derivation.ts
+++ b/src/api/entitycore/types/entities/derivation.ts
@@ -1,3 +1,5 @@
+import { find } from 'es-toolkit/compat';
+
 import type { TEntityTypeDict } from '@/api/entitycore/types/entity-type';
 import type { EntityCoreIdentifiable, EntityCoreType } from '@/api/entitycore/types/shared/global';
 import type {
@@ -52,6 +54,30 @@ export const DerivationTypeDictionary = Object.fromEntries(
 
 export type TDerivationType =
   (typeof DerivationTypeDictionary)[keyof typeof DerivationTypeDictionary];
+
+/**
+ * Short, circuit-overview labels for the "Derivation type" column/filter (issue #517).
+ * Any derivation type not listed here falls back to its generic `DerivationType[...].label`
+ * (see {@link getCircuitDerivationLabel}), so future derivation types still render sensibly.
+ */
+export const CircuitDerivationShortLabel: Partial<Record<TDerivationType, string>> = {
+  [DerivationTypeDictionary.CircuitExtraction]: 'Extracted',
+  [DerivationTypeDictionary.CircuitRewiring]: 'Rewired',
+  [DerivationTypeDictionary.CircuitCustomization]: 'Customized',
+};
+
+/** Options offered in the static "Derivation type" dropdown filter, derived from the short labels. */
+export const CircuitDerivationFilterOptions: Array<{ value: TDerivationType; label: string }> =
+  Object.entries(CircuitDerivationShortLabel).map(([value, label]) => ({
+    value: value as TDerivationType,
+    label: label as string,
+  }));
+
+/** Display label for a derivation type: short circuit label when known, else the generic label. */
+export const getCircuitDerivationLabel = (derivationType: TDerivationType): string =>
+  CircuitDerivationShortLabel[derivationType] ??
+  find(DerivationType, { key: derivationType })?.label ??
+  derivationType;
 
 export interface IDerivationBase extends EntityCoreIdentifiable, EntityCoreType {}
 

--- a/src/api/entitycore/types/entities/derivation.ts
+++ b/src/api/entitycore/types/entities/derivation.ts
@@ -1,4 +1,4 @@
-import { find } from 'es-toolkit/compat';
+import { uniq } from 'es-toolkit/compat';
 
 import type { TEntityTypeDict } from '@/api/entitycore/types/entity-type';
 import type { EntityCoreIdentifiable, EntityCoreType } from '@/api/entitycore/types/shared/global';
@@ -73,11 +73,14 @@ export const CircuitDerivationFilterOptions: Array<{ value: TDerivationType; lab
     label: label as string,
   }));
 
-/** Display label for a derivation type: short circuit label when known, else the generic label. */
-export const getCircuitDerivationLabel = (derivationType: TDerivationType): string =>
-  CircuitDerivationShortLabel[derivationType] ??
-  find(DerivationType, { key: derivationType })?.label ??
-  derivationType;
+export const getCircuitDerivationColumnLabels = (
+  derivations: ReadonlyArray<{ derivation_type: TDerivationType }>
+): string[] =>
+  uniq(
+    derivations
+      .map((d) => CircuitDerivationShortLabel[d.derivation_type])
+      .filter((label): label is string => Boolean(label))
+  );
 
 export interface IDerivationBase extends EntityCoreIdentifiable, EntityCoreType {}
 

--- a/src/api/entitycore/types/entities/derivation.ts
+++ b/src/api/entitycore/types/entities/derivation.ts
@@ -86,6 +86,57 @@ export interface IBasicEntityRead extends EntityCoreIdentifiable {
   type?: TEntityTypeDict | null;
 }
 
+/** `NestedEntityRead`, the nested entity ref on an entity's derivation lists (adds an optional name). */
+export interface INestedEntityRead extends IBasicEntityRead {
+  name?: string | null;
+}
+
+/** A derivation where THIS entity is the generated (derived) side — "how it was derived". */
+export interface IGeneratedFromDerivation {
+  used: INestedEntityRead;
+  derivation_type: TDerivationType;
+  label?: string | null;
+}
+
+/** A derivation where THIS entity is the used (source) side — "what was derived from it". */
+export interface IUsedByDerivation {
+  generated: INestedEntityRead;
+  derivation_type: TDerivationType;
+  label?: string | null;
+}
+
+/**
+ * Derivation lists exposed by every entity read (entitycore #647), opt-in via the `expand` param.
+ * `null`/absent unless expanded; `[]` when expanded but the entity has none in that direction.
+ */
+export interface EntityDerivations {
+  generated_from_derivations?: Array<IGeneratedFromDerivation> | null;
+  used_by_derivations?: Array<IUsedByDerivation> | null;
+}
+
+/** Opt-in derivation lists any entity read can request via `?expand=...` (repeatable). */
+export type EntityExpandParam = 'generated_from_derivations' | 'used_by_derivations';
+
+/**
+ * Derivation filters available on every entity list endpoint (entitycore #647).
+ * `generated_derivation__*` = this entity is the generated (derived) side;
+ * `used_derivation__*` = this entity is the used (source) side.
+ */
+export interface EntityDerivationFilter {
+  generated_derivation__derivation_type?: TDerivationType;
+  generated_derivation__derivation_type__in?: Array<TDerivationType>;
+  generated_derivation__used_id?: string;
+  generated_derivation__used_id__in?: Array<string>;
+  generated_derivation__generated_id?: string;
+  generated_derivation__generated_id__in?: Array<string>;
+  used_derivation__derivation_type?: TDerivationType;
+  used_derivation__derivation_type__in?: Array<TDerivationType>;
+  used_derivation__used_id?: string;
+  used_derivation__used_id__in?: Array<string>;
+  used_derivation__generated_id?: string;
+  used_derivation__generated_id__in?: Array<string>;
+}
+
 /**
  * `DerivationRead`, a derivation read response, exposing the linked entities.
  * - `used`: the source entity (e.g. the EM dense reconstruction dataset).

--- a/src/entity-configuration/definitions/fields-defs/enums.ts
+++ b/src/entity-configuration/definitions/fields-defs/enums.ts
@@ -84,6 +84,7 @@ export enum EntityCoreFields {
   CircuitName = 'circuit_name',
   CircuitBuildCategory = 'build_category',
   CircuitTargetSimulator = 'target_simulator',
+  CircuitDerivationType = 'derivation_type',
   CircuitScale = 'scale',
   CircuitRootCircuit = 'root_circuit_id',
   ArtifactPublishedIn = 'published_in',

--- a/src/entity-configuration/definitions/fields-defs/model.tsx
+++ b/src/entity-configuration/definitions/fields-defs/model.tsx
@@ -1,5 +1,5 @@
 import { LoadingOutlined, WarningFilled } from '@ant-design/icons';
-import { find, isNil, map, omit, pick, uniq } from 'es-toolkit/compat';
+import { find, isNil, map, omit, pick } from 'es-toolkit/compat';
 
 import { hasAssets } from '@/api/entitycore/guards';
 import {
@@ -9,7 +9,7 @@ import {
 } from '@/api/entitycore/types/entities/circuit';
 import {
   CircuitDerivationFilterOptions,
-  getCircuitDerivationLabel,
+  getCircuitDerivationColumnLabels,
 } from '@/api/entitycore/types/entities/derivation';
 import { ValidationStatus } from '@/api/entitycore/types/entities/me-model';
 import { ElectrodeTypeDict } from '@/api/entitycore/types/entities/simulatable-extracellular-recording-array';
@@ -349,11 +349,8 @@ export const FieldsDefinition: Partial<FieldsDefinitionRegistry<EntityCoreObject
       // hierarchy/enriched rows omit it, so guard like CircuitSubCircuit does.
       const derivations =
         'generated_from_derivations' in r ? (r as ICircuit).generated_from_derivations : null;
-      if (!derivations?.length) {
-        return EmptyValue;
-      }
-      // A circuit normally has a single derivation; if several, list the types comma-separated.
-      return uniq(derivations.map((d) => getCircuitDerivationLabel(d.derivation_type))).join(', ');
+      const labels = derivations ? getCircuitDerivationColumnLabels(derivations) : [];
+      return labels.length ? labels.join(', ') : EmptyValue;
     },
     vocabulary: {
       plural: 'Derivation types',

--- a/src/entity-configuration/definitions/fields-defs/model.tsx
+++ b/src/entity-configuration/definitions/fields-defs/model.tsx
@@ -1,5 +1,5 @@
 import { LoadingOutlined, WarningFilled } from '@ant-design/icons';
-import { find, isNil, map, omit, pick } from 'es-toolkit/compat';
+import { find, isNil, map, omit, pick, uniq } from 'es-toolkit/compat';
 
 import { hasAssets } from '@/api/entitycore/guards';
 import {
@@ -7,6 +7,10 @@ import {
   CircuitScale,
   CircuitTargetSimulator,
 } from '@/api/entitycore/types/entities/circuit';
+import {
+  CircuitDerivationFilterOptions,
+  getCircuitDerivationLabel,
+} from '@/api/entitycore/types/entities/derivation';
 import { ValidationStatus } from '@/api/entitycore/types/entities/me-model';
 import { ElectrodeTypeDict } from '@/api/entitycore/types/entities/simulatable-extracellular-recording-array';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
@@ -325,6 +329,35 @@ export const FieldsDefinition: Partial<FieldsDefinitionRegistry<EntityCoreObject
     vocabulary: {
       plural: 'Target simulators',
       singular: 'Target simulator',
+    },
+    style: { align: 'left' },
+  },
+  [EntityCoreFields.CircuitDerivationType]: {
+    className: 'text-left',
+    title: 'Derivation type',
+    // Static dropdown of the known circuit derivation types (issue #517). The backend exposes this
+    // as a plain enum filter (not a facet), so the options are sourced statically. Adding a future
+    // type = one entry in CircuitDerivationFilterOptions.
+    filter: CoreFieldFilterTypeEnum.DropdownList,
+    filterData: CircuitDerivationFilterOptions,
+    isFilterable: true,
+    isDisplayable: true,
+    // Not sortable: the backend exposes no order_by for derivation type.
+    defaultConstraint: 'generated_derivation__derivation_type__in',
+    render: (r) => {
+      // `generated_derivations` is loaded only on the flat list (expand=generated_derivations);
+      // hierarchy/enriched rows omit it, so guard like CircuitSubCircuit does.
+      const derivations =
+        'generated_derivations' in r ? (r as ICircuit).generated_derivations : null;
+      if (!derivations?.length) {
+        return EmptyValue;
+      }
+      // A circuit normally has a single derivation; if several, list the types comma-separated.
+      return uniq(derivations.map((d) => getCircuitDerivationLabel(d.derivation_type))).join(', ');
+    },
+    vocabulary: {
+      plural: 'Derivation types',
+      singular: 'Derivation type',
     },
     style: { align: 'left' },
   },

--- a/src/entity-configuration/definitions/fields-defs/model.tsx
+++ b/src/entity-configuration/definitions/fields-defs/model.tsx
@@ -345,10 +345,10 @@ export const FieldsDefinition: Partial<FieldsDefinitionRegistry<EntityCoreObject
     // Not sortable: the backend exposes no order_by for derivation type.
     defaultConstraint: 'generated_derivation__derivation_type__in',
     render: (r) => {
-      // `generated_derivations` is loaded only on the flat list (expand=generated_derivations);
+      // `generated_from_derivations` is loaded only on the flat list (expand=generated_from_derivations);
       // hierarchy/enriched rows omit it, so guard like CircuitSubCircuit does.
       const derivations =
-        'generated_derivations' in r ? (r as ICircuit).generated_derivations : null;
+        'generated_from_derivations' in r ? (r as ICircuit).generated_from_derivations : null;
       if (!derivations?.length) {
         return EmptyValue;
       }

--- a/src/entity-configuration/definitions/view-defs/model/circuit.ts
+++ b/src/entity-configuration/definitions/view-defs/model/circuit.ts
@@ -21,6 +21,7 @@ export const ViewDefForCircuit: ViewDefinitionConfig = {
     EntityCoreFields.CircuitNumberConnections,
     EntityCoreFields.CircuitBuildCategory,
     EntityCoreFields.CircuitTargetSimulator,
+    EntityCoreFields.CircuitDerivationType,
     EntityCoreFields.ArtifactPublishedIn,
     EntityCoreFields.ArtifactExperimentDate,
   ],

--- a/src/entity-configuration/domain/model/circuit.ts
+++ b/src/entity-configuration/domain/model/circuit.ts
@@ -54,6 +54,9 @@ export const Circuit: EntityCoreTypeConfig<ICircuit> = {
           context: params[0].context,
           withFacets: params[0].withFacets,
           filters: mergedFilters,
+          // Needed for the "Derivation type" column (issue #517): load each circuit's
+          // incoming derivations so the column can show how the circuit was derived.
+          expand: 'generated_derivations',
         });
       },
       one: getCircuit,

--- a/src/entity-configuration/domain/model/circuit.ts
+++ b/src/entity-configuration/domain/model/circuit.ts
@@ -56,7 +56,7 @@ export const Circuit: EntityCoreTypeConfig<ICircuit> = {
           filters: mergedFilters,
           // Needed for the "Derivation type" column (issue #517): load each circuit's
           // incoming derivations so the column can show how the circuit was derived.
-          expand: 'generated_derivations',
+          expand: 'generated_from_derivations',
         });
       },
       one: getCircuit,

--- a/src/ui/segments/explore/circuit/use-hierarchy.tsx
+++ b/src/ui/segments/explore/circuit/use-hierarchy.tsx
@@ -81,12 +81,17 @@ export function useFullRawHierarchy({
               withFacets: false,
               virtualLabId,
               projectId,
+              // Keep the cache key in sync with the expanded fetch below.
+              expand: 'generated_from_derivations',
               ...circuitScaleFilter,
             }),
             queryFn: () =>
               getCircuits({
                 withFacets: false,
                 context: virtualLabId && projectId ? { virtualLabId, projectId } : undefined,
+                // Enrich hierarchy rows with their incoming derivations so the "Derivation type"
+                // column renders in the tree view too, matching the flat list (issue #517).
+                expand: 'generated_from_derivations',
                 filters: {
                   page: 1,
                   page_size: DEFAULT_PAGE_SIZE,


### PR DESCRIPTION
## Summary

Adds a **"Derivation type"** column to the Circuits overview showing how each circuit was derived — `Extracted` (`circuit_extraction`), `Rewired` (`circuit_rewiring`), `Customized` (`circuit_customization`), or empty when not derived — plus a **static dropdown filter** by derivation type. The column renders identically in both the **flat list and the hierarchical (tree) view**. Sub-types are out of scope per the issue.

The implementation mirrors the existing **Build category** field (`fields-defs/model.tsx`):
- **Column data:** the circuit list request opts in via `?expand=generated_from_derivations`; each circuit carries its incoming derivations, and the column renders the derivation type(s) — comma-separated in the rare multi-derivation case. The hierarchical view's enrichment fetch (`useFullRawHierarchy`) opts into the same `expand`, so the column populates in the tree too.
- **Filter:** static dropdown using the `generated_derivation__derivation_type__in` query param (a plain enum filter, not a facet).
- **Scope:** only the three circuit derivation types above are labelled (via `CircuitDerivationShortLabel`); other/future types are omitted from the column. The column (`getCircuitDerivationColumnLabels`) and the filter (`CircuitDerivationFilterOptions`) both derive from that one map, so adding a type is a one-line change.

## Files changed

- `api/entitycore/types/entities/derivation.ts` — short labels (`CircuitDerivationShortLabel`), `getCircuitDerivationColumnLabels`, `CircuitDerivationFilterOptions`; **new shared mixins** `EntityDerivations` / `EntityExpandParam` / `EntityDerivationFilter` (+ `INestedEntityRead`, `IGeneratedFromDerivation`, `IUsedByDerivation`)
- `api/entitycore/types/entities/derivation.test.ts` — **new** unit tests for `getCircuitDerivationColumnLabels` (single / multiple / dedup / non-circuit / empty cases)
- `api/entitycore/types/entities/circuit.ts` — `ICircuit` composes `EntityDerivations`, `ICircuitFilter` composes `EntityDerivationFilter` (dropped the Circuit-specific `generated_derivations` field, `ExpandCircuitParam`, `ICircuitGeneratedDerivation`, inline filter keys)
- `api/entitycore/queries/model/circuit.ts` — `expand` param on `getCircuits` typed `EntityExpandParam`
- `entity-configuration/domain/model/circuit.ts` — list query sends `expand: 'generated_from_derivations'`
- `entity-configuration/definitions/fields-defs/{enums.ts,model.tsx}` — new field + definition
- `entity-configuration/definitions/view-defs/model/circuit.ts` — column added to the overview
- `ui/segments/explore/circuit/use-hierarchy.tsx` — hierarchy enrichment fetch (`useFullRawHierarchy`) opts into `expand=generated_from_derivations` (+ matching query key) so the column renders in the tree view

## Related

- Feature request: openbraininstitute/prod-explore-functionality#517
- Backend: openbraininstitute/entitycore#647
- Sibling (shares the backend work): openbraininstitute/prod-explore-functionality#518
