### PR TITLE
feat(activities): align activity table with workflows Category → Type pattern

### DIFF
--- a/src/ui/segments/project/activities/elements/header.tsx
+++ b/src/ui/segments/project/activities/elements/header.tsx
@@ -1,135 +1,35 @@
 'use client';
 
-import { useState } from 'react';
-
-import { useDefaultBreakpoint } from '@/ui/hooks/create-break-point';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/ui/molecules/select';
-import {
-  getScaleArray,
-  getScaleAvailableActivities,
-} from '@/ui/segments/project/activities/elements/helpers';
-import { cn } from '@/utils/css-class';
+import { ActivityAndTypeSelectors } from '@/ui/segments/workflows/elements/browse-header';
 
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import type { TActivityValue } from '@/ui/segments/workflows/config';
 
 type Props = {
-  onScaleChange: (s: TExtendedEntitiesTypeDict) => void;
-  onTypeChange: (t: TActivityValue) => void;
-  onPageChange: (p: number) => void;
+  activity: TActivityValue | null;
+  entityType: TExtendedEntitiesTypeDict | null;
+  onActivityChange: (activity: TActivityValue | null) => void;
+  onEntityTypeChange: (entityType: TExtendedEntitiesTypeDict | null) => void;
   showTitle?: boolean;
 };
 
-export function Header({ onScaleChange, onTypeChange, onPageChange, showTitle = true }: Props) {
-  const breakpoint = useDefaultBreakpoint();
-  const scaleOptions = getScaleArray();
-  const defaultScale = scaleOptions.at(0)?.value;
-  const defaultActivities = defaultScale ? getScaleAvailableActivities(defaultScale) : [];
-
-  const [selectedScale, setSelectedScale] = useState<TExtendedEntitiesTypeDict | undefined>(
-    defaultScale
-  );
-  const [activities, setActivities] =
-    useState<Array<{ label: string; value: string }>>(defaultActivities);
-  const [selectedActivityType, setSelectedActivityType] = useState<TActivityValue | undefined>(
-    defaultActivities.at(0)?.value
-  );
-
-  const onScale = (s: TExtendedEntitiesTypeDict) => {
-    const availableActivities = getScaleAvailableActivities(s);
-    const firstActivityType = availableActivities.at(0)?.value;
-
-    setSelectedScale(s);
-    onScaleChange(s);
-    setActivities(availableActivities);
-    setSelectedActivityType(firstActivityType);
-    if (firstActivityType) {
-      onTypeChange(firstActivityType);
-    }
-    onPageChange(1);
-  };
-
-  const onType = (t: TActivityValue) => {
-    setSelectedActivityType(t);
-    onTypeChange(t);
-    onPageChange(1);
-  };
-
-  const triggerClassName = cn(
-    'focus-visible:ring-neutral-2 bg-transparent shadow-none focus-visible:shadow-none focus-visible:ring-1',
-    'max-w-max min-w-36 rounded-full border border-gray-300 text-lg cursor-pointer',
-    "[&>span[data-slot='select-value']]:text-primary-9 [&>span[data-slot='select-value']]:font-bold"
-  );
-
-  const itemClassName = cn(
-    'text-primary-9 text-lg font-bold cursor-pointer',
-    'data-highlighted:text-primary-7!'
-  );
-
+export function Header({
+  activity,
+  entityType,
+  onActivityChange,
+  onEntityTypeChange,
+  showTitle = true,
+}: Props) {
   return (
     <div className="flex w-full flex-col items-start justify-start gap-1.5 lg:flex-row lg:gap-5 xl:items-center xl:gap-10">
       {showTitle && <h1 className="min-w-max grow text-xl">Recent activities</h1>}
       <div className="flex w-full flex-wrap items-center justify-start gap-3 lg:justify-end xl:justify-end">
-        <div className="flex flex-col items-start justify-start gap-0.5 xl:flex-row xl:items-center xl:justify-center xl:gap-3">
-          <div>Scale</div>
-          <Select
-            value={selectedScale ?? undefined}
-            onValueChange={(v: TExtendedEntitiesTypeDict) => onScale(v)}
-          >
-            <SelectTrigger
-              size={breakpoint === 'l' ? 'sm' : 'default'}
-              className={cn(triggerClassName, 'w-[200px]')}
-            >
-              <SelectValue
-                placeholder={<span className="text-base font-light!">Select a scale</span>}
-              />
-            </SelectTrigger>
-            <SelectContent
-              className="max-h-96 rounded-lg border-white bg-white shadow-xl z-9999"
-              side="bottom"
-              sideOffset={3}
-            >
-              {scaleOptions.map(({ label, value }) => (
-                <SelectItem key={`scale-${value}`} value={value} className={itemClassName}>
-                  {label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="flex flex-col items-start justify-start gap-0.5 xl:flex-row xl:items-center xl:justify-center xl:gap-3">
-          <div>Activity type</div>
-          <Select
-            value={selectedActivityType ?? undefined}
-            onValueChange={(v: TActivityValue) => onType(v)}
-          >
-            <SelectTrigger
-              size={breakpoint === 'l' ? 'sm' : 'default'}
-              className={cn(triggerClassName, 'w-[160px]')}
-            >
-              <SelectValue
-                placeholder={<span className="text-base font-light!">Select a type</span>}
-              />
-            </SelectTrigger>
-            <SelectContent
-              className="max-h-96 rounded-lg border-white bg-white shadow-xl z-9999"
-              side="bottom"
-              sideOffset={3}
-            >
-              {activities.map(({ label, value }) => (
-                <SelectItem key={`activity-${value}`} value={value} className={itemClassName}>
-                  {label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+        <ActivityAndTypeSelectors
+          activity={activity}
+          entityType={entityType}
+          onActivityChange={onActivityChange}
+          onEntityTypeChange={onEntityTypeChange}
+        />
       </div>
     </div>
   );

--- a/src/ui/segments/project/activities/elements/helpers.tsx
+++ b/src/ui/segments/project/activities/elements/helpers.tsx
@@ -1,24 +1,13 @@
 'use client';
 
-import { isNil } from 'es-toolkit/compat';
-
 import { ActivityStatus } from '@/api/entitycore/types/shared/activity';
 import EmptyCircleIcon from '@/components/icons/EmptyCircle';
 import FullCircleIcon from '@/components/icons/FullCircle';
 import PartialCircleIcon from '@/components/icons/PartialCircle';
 import TriangleIcon from '@/components/icons/Triangle';
 import { ActivityStatusColorMap } from '@/features/scan-config/constants';
-import {
-  ActivityValues,
-  getActivity,
-  getEntityMeta,
-  listWorkflows,
-  WorkflowInitialStagePolicyDict,
-} from '@/ui/segments/workflows/config';
 
 import type { ReactNode } from 'react';
-import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
-import type { TActivityValue } from '@/ui/segments/workflows/config';
 
 export const StatusMap: Record<
   string,
@@ -96,88 +85,4 @@ export const StatusMap: Record<
     icon: <FullCircleIcon className="mr-2 text-current" />,
     title: 'Done',
   },
-};
-
-type TScaleActivityMap = {
-  title: string;
-  build: TExtendedEntitiesTypeDict | null;
-  simulate: TExtendedEntitiesTypeDict | null;
-  link: 'explore' | 'workflows';
-};
-
-function buildScales(): Partial<Record<TExtendedEntitiesTypeDict, TScaleActivityMap>> {
-  const scales: Partial<Record<TExtendedEntitiesTypeDict, TScaleActivityMap>> = {};
-  const activities = [ActivityValues.Build, ActivityValues.Simulate] as const;
-
-  for (const activity of activities) {
-    const workflows = listWorkflows({ activity, sort: 'order' }).filter(
-      (workflow) => !workflow.disabled
-    );
-
-    for (const workflow of workflows) {
-      const scaleType = workflow.sourceType;
-      const entity = getEntityMeta(scaleType);
-      const existing = scales[scaleType];
-
-      scales[scaleType] = {
-        title: existing?.title ?? workflow.label ?? entity?.title ?? entity?.label ?? scaleType,
-        build: activity === ActivityValues.Build ? workflow.targetType : (existing?.build ?? null),
-        simulate:
-          activity === ActivityValues.Simulate ? workflow.targetType : (existing?.simulate ?? null),
-        link:
-          existing?.link ??
-          (workflow.initialStage === WorkflowInitialStagePolicyDict.Browse ||
-          (workflow.isScanConfig && workflow.initialStage === WorkflowInitialStagePolicyDict.Schema)
-            ? 'workflows'
-            : 'explore'),
-      };
-    }
-  }
-
-  return scales;
-}
-
-export const Scales = buildScales();
-
-// here the function should return the available activities for the scale as build , simulate
-export const getScaleArray = (): Array<{ label: string; value: TExtendedEntitiesTypeDict }> => {
-  return Object.entries(Scales).map(([key, value]) => {
-    return {
-      label: value.title,
-      value: key as TExtendedEntitiesTypeDict,
-    };
-  });
-};
-
-export const getScaleAvailableActivities = (
-  scaleType: TExtendedEntitiesTypeDict
-): Array<{ label: string; value: TActivityValue }> => {
-  const scale = Scales[scaleType];
-  if (!scale) {
-    return [];
-  }
-
-  const availableActivities: Array<{ label: string; value: TActivityValue }> = [];
-
-  if (!isNil(scale.build)) {
-    const buildActivity = getActivity('build');
-    if (buildActivity) {
-      availableActivities.push({
-        label: buildActivity.label,
-        value: buildActivity.value,
-      });
-    }
-  }
-
-  if (!isNil(scale.simulate)) {
-    const simulateActivity = getActivity('simulate');
-    if (simulateActivity) {
-      availableActivities.push({
-        label: simulateActivity.label,
-        value: simulateActivity.value,
-      });
-    }
-  }
-
-  return availableActivities;
 };

--- a/src/ui/segments/project/activities/index.tsx
+++ b/src/ui/segments/project/activities/index.tsx
@@ -12,7 +12,7 @@ import { getEntityByExtendedType } from '@/entity-configuration/domain/helpers';
 import { useWorkspace } from '@/ui/hooks/use-workspace';
 import { Card, CardContent } from '@/ui/molecules/card';
 import { Header } from '@/ui/segments/project/activities/elements/header';
-import { Scales, StatusMap } from '@/ui/segments/project/activities/elements/helpers';
+import { StatusMap } from '@/ui/segments/project/activities/elements/helpers';
 import { useQueryActivity } from '@/ui/segments/project/activities/elements/use-activity';
 import { ActivityValues } from '@/ui/segments/workflows/config';
 import { renderDateAndHour } from '@/util/date';
@@ -42,18 +42,30 @@ export function ProjectActivities({
   const projectId = targetProjectId || context.projectId;
 
   const [page, setPage] = useState(1);
+
+  // Category -> Type selection, mirroring the workflows browse view:
+  // `activity` is the Category (Build / Simulate / Extract / Process data) and
+  // `entityType` is the Type (the target entity the activity produces).
+  const [activity, setActivity] = useState<TActivityValue>(ActivityValues.Build as TActivityValue);
   const [entityType, setEntityType] = useState<TExtendedEntitiesTypeDict>(
     ExtendedEntitiesTypeDict.Memodel
   );
 
-  const [activity, setActivity] = useState<TActivityValue>(ActivityValues.Build as TActivityValue);
-  const entity = getEntityByExtendedType({
-    type: get(Scales, [entityType, activity], null),
-  });
+  const entity = getEntityByExtendedType({ type: entityType });
 
   if (!entity?.extendedType) {
     throw new Error(`No entity found for type: ${entityType}`);
   }
+
+  const onActivityChange = (next: TActivityValue | null) => {
+    if (next) setActivity(next);
+    setPage(1);
+  };
+
+  const onEntityTypeChange = (next: TExtendedEntitiesTypeDict | null) => {
+    if (next) setEntityType(next);
+    setPage(1);
+  };
 
   const tableSlotRef = useRef<HTMLDivElement>(null);
   const [tableBodyScrollY, setTableBodyScrollY] = useState<number>();
@@ -162,9 +174,10 @@ export function ProjectActivities({
       )}
     >
       <Header
-        onScaleChange={setEntityType}
-        onTypeChange={setActivity}
-        onPageChange={setPage}
+        activity={activity}
+        entityType={entityType}
+        onActivityChange={onActivityChange}
+        onEntityTypeChange={onEntityTypeChange}
         showTitle={showTitle}
       />
       <div className="flex-1 overflow-hidden flex flex-col mt-5">

--- a/src/ui/segments/workflows/elements/selectors.tsx
+++ b/src/ui/segments/workflows/elements/selectors.tsx
@@ -48,7 +48,7 @@ export function EntityTypeSelectScrollable({
         <SelectValue placeholder={<span className="text-base font-light!">Select a type</span>} />
       </SelectTrigger>
       <SelectContent
-        className="max-h-96 rounded-lg border-white bg-white shadow-xl"
+        className="z-9999 max-h-96 rounded-lg border-white bg-white shadow-xl"
         side="bottom"
         sideOffset={3}
       >
@@ -104,7 +104,7 @@ export function CategorySelectScrollable({
         />
       </SelectTrigger>
       <SelectContent
-        className="max-h-96 rounded-lg border-white bg-white shadow-xl"
+        className="z-9999 max-h-96 rounded-lg border-white bg-white shadow-xl"
         side="bottom"
         sideOffset={3}
       >


### PR DESCRIPTION
## Summary

The project **Activities** table grouped by **Scale → Activity type**, backed by a bespoke `buildScales()` helper that only iterated `Build` and `Simulate`. As a result, **Process data** (and Extract) workflows were structurally invisible, and `EMCellMesh` — which only has a Process workflow — never appeared as a scale at all.

This PR adopts the same **Category → Type** pattern the **Workflows** browse view already uses, so the two screens are consistent and all activity types are surfaced.

## Changes

- `ProjectActivities` (`index.tsx`) now holds `activity` (Category) + `entityType` (Type = target entity) state, mirroring the workflows browse view, and resolves the queried entity directly from the selected type instead of via a `Scales[scale][activity]` lookup.
- `header.tsx` is a thin controlled wrapper that renders the optional title plus the reused **`ActivityAndTypeSelectors`** component (Category + Type pills).
- Removed the now-dead Scale machinery (`buildScales`, `Scales`, `getScaleArray`, `getScaleAvailableActivities`, `TScaleActivityMap`). `StatusMap` is kept — it is still shared with the workflows activity table.
- Table columns are intentionally unchanged (Name / Status / Date / Actions).

Per equivalent selection the fetched data is identical to before; the change only **adds** the previously-unreachable **Process data** / **Extract** categories. Extract remains gated behind its feature flag.

## How it addresses the request

- The **Category** dropdown now lists all activities (Build, Simulate, Extract, Process data).
- Selecting **Process data → "EM mesh skeletonization"** lists skeletonization campaigns.
- The scale/type corresponds to the selected activity, as required.

Relates to [[Project activity] Activity table is missing Process data as activity type](openbraininstitute/prod-virtual-lab#365).

## Updated UI

<img width="1168" height="850" alt="image" src="https://github.com/user-attachments/assets/57d91c92-4d78-4f41-8288-d6e8093a3cad" />
