### PR TITLE
feat(circuit): generalize Related artifacts derived tabs to all derivation types

### DIFF
--- a/src/api/entitycore/types/entities/derivation.ts
+++ b/src/api/entitycore/types/entities/derivation.ts
@@ -57,7 +57,7 @@ export type TDerivationType =
 
 /**
  * Short, circuit-overview labels for the "Derivation type" column/filter (issue #517).
- * Any derivation type not listed here falls back to its generic `DerivationType[...].label`
+ * Any derivation type not listed here falls back to its raw key
  * (see {@link getCircuitDerivationLabel}), so future derivation types still render sensibly.
  */
 export const CircuitDerivationShortLabel: Partial<Record<TDerivationType, string>> = {
@@ -81,6 +81,22 @@ export const getCircuitDerivationColumnLabels = (
       .map((d) => CircuitDerivationShortLabel[d.derivation_type])
       .filter((label): label is string => Boolean(label))
   );
+
+/** Short label for a single circuit derivation type (falls back to the raw key). */
+export function getCircuitDerivationLabel(key: TDerivationType): string {
+  return CircuitDerivationShortLabel[key] ?? key;
+}
+
+/**
+ * Circuit→circuit derivation types that represent a circuit being *derived from* another
+ * circuit, excluding `circuit_extraction` (handled separately as the parent/subcircuits
+ * hierarchy). Used to build the "Derived from" / "Derived circuits" related-artifact tabs.
+ * Order here is the render order of the grouped sections.
+ */
+export const CIRCUIT_DERIVED_DERIVATION_TYPES: readonly TDerivationType[] = [
+  DerivationTypeDictionary.CircuitRewiring,
+  DerivationTypeDictionary.CircuitCustomization,
+];
 
 export interface IDerivationBase extends EntityCoreIdentifiable, EntityCoreType {}
 

--- a/src/ui/segments/explore/circuit/elements/related-circuits/derived-from.tsx
+++ b/src/ui/segments/explore/circuit/elements/related-circuits/derived-from.tsx
@@ -6,20 +6,23 @@ import { unwrap } from 'jotai/utils';
 import { useMemo } from 'react';
 
 import { useDataTableColumns } from '@/ui/segments/data-table/elements/use-data-table-columns';
+import { getCircuitDerivationLabel } from '@/api/entitycore/types/entities/derivation';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { activeColumnsAtom } from '@/ui/segments/data-table/elements/context';
+import { ArrowReturnRight } from '@/components/icons/ArrowReturnRight';
 import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
 import { BaseTable } from '@/ui/segments/data-table/table';
 import { WorkspaceScope } from '@/constants';
 
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
 import type { WorkspaceContext } from '@/types/common';
+import type { DerivedFromGroup } from '@/ui/segments/explore/circuit/use-hierarchy';
 
 type Props = {
-  data: ICircuit | undefined;
+  groups: DerivedFromGroup[];
 };
 
-export function DerivedFrom({ data }: Props) {
+export function DerivedFrom({ groups }: Props) {
   const { push: navigate } = useRouter();
   const { virtualLabId, projectId } = useParams<WorkspaceContext>();
   const cols = useDataTableColumns<ICircuit>({
@@ -35,10 +38,10 @@ export function DerivedFrom({ data }: Props) {
           activeColumnsAtom({
             dataType: ExtendedEntitiesTypeDict.Circuit,
             dataScope: WorkspaceScope.Custom,
-            key: data?.id ?? '',
+            key: '',
           })
         ),
-      [data?.id]
+      []
     )
   );
   const columns = cols.filter(({ key }) => (activeColumns || []).includes(key as string));
@@ -54,13 +57,26 @@ export function DerivedFrom({ data }: Props) {
   };
 
   return (
-    <BaseTable
-      loading={false}
-      wrapperClassname="[&_.ant-table-body]:max-h-full!"
-      columns={columns}
-      dataType={ExtendedEntitiesTypeDict.Circuit}
-      dataSource={data ? [data] : []}
-      onCellClick={onCellClick}
-    />
+    <div className="flex flex-col gap-5">
+      {groups.map(({ derivationType, circuit }) => (
+        <div key={derivationType} className="flex flex-col gap-2">
+          <div className="ml-2 flex flex-row items-center gap-2">
+            <ArrowReturnRight className="text-neutral-4 text-3xl" />
+            <div className="text-neutral-4 text-lg font-semibold uppercase">
+              {getCircuitDerivationLabel(derivationType)}
+            </div>
+          </div>
+          <BaseTable
+            loading={false}
+            wrapperClassname="[&_.ant-table-body]:max-h-full!"
+            columns={columns}
+            dataType={ExtendedEntitiesTypeDict.Circuit}
+            dataSource={[circuit]}
+            onCellClick={onCellClick}
+            rowKey={(record: ICircuit) => `derived-from-${derivationType}-${record.id}`}
+          />
+        </div>
+      ))}
+    </div>
   );
 }

--- a/src/ui/segments/explore/circuit/elements/related-circuits/derived-from.tsx
+++ b/src/ui/segments/explore/circuit/elements/related-circuits/derived-from.tsx
@@ -1,18 +1,18 @@
 'use client';
 
-import { useParams, useRouter } from 'next/navigation';
 import { useAtomValue } from 'jotai';
 import { unwrap } from 'jotai/utils';
+import { useParams, useRouter } from 'next/navigation';
 import { useMemo } from 'react';
 
-import { useDataTableColumns } from '@/ui/segments/data-table/elements/use-data-table-columns';
 import { getCircuitDerivationLabel } from '@/api/entitycore/types/entities/derivation';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
-import { activeColumnsAtom } from '@/ui/segments/data-table/elements/context';
 import { ArrowReturnRight } from '@/components/icons/ArrowReturnRight';
-import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
-import { BaseTable } from '@/ui/segments/data-table/table';
 import { WorkspaceScope } from '@/constants';
+import { activeColumnsAtom } from '@/ui/segments/data-table/elements/context';
+import { useDataTableColumns } from '@/ui/segments/data-table/elements/use-data-table-columns';
+import { BaseTable } from '@/ui/segments/data-table/table';
+import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
 
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
 import type { WorkspaceContext } from '@/types/common';
@@ -61,8 +61,8 @@ export function DerivedFrom({ groups }: Props) {
       {groups.map(({ derivationType, circuit }) => (
         <div key={derivationType} className="flex flex-col gap-2">
           <div className="ml-2 flex flex-row items-center gap-2">
-            <ArrowReturnRight className="text-neutral-4 text-3xl" />
-            <div className="text-neutral-4 text-lg font-semibold uppercase">
+            <ArrowReturnRight className="text-neutral-3 text-3xl" />
+            <div className="text-neutral-3 text-lg font-semibold uppercase">
               {getCircuitDerivationLabel(derivationType)}
             </div>
           </div>

--- a/src/ui/segments/explore/circuit/elements/related-circuits/derived.tsx
+++ b/src/ui/segments/explore/circuit/elements/related-circuits/derived.tsx
@@ -139,8 +139,8 @@ function DerivedGroupSection({
   return (
     <div className="flex flex-col gap-2">
       <div className="ml-2 flex flex-row items-center gap-2">
-        <ArrowReturnRight className="text-neutral-2 text-3xl" />
-        <div className="text-neutral-2 text-lg font-semibold uppercase">
+        <ArrowReturnRight className="text-neutral-3 text-3xl" />
+        <div className="text-neutral-3 text-lg font-semibold uppercase">
           {getCircuitDerivationLabel(derivationType)}
         </div>
       </div>

--- a/src/ui/segments/explore/circuit/elements/related-circuits/derived.tsx
+++ b/src/ui/segments/explore/circuit/elements/related-circuits/derived.tsx
@@ -7,10 +7,10 @@ import { unwrap } from 'jotai/utils';
 import { createExpandableTableConfig } from '@/ui/segments/data-table/expandable-row/expandable-base-table';
 import { RecursiveExpandableTable } from '@/ui/segments/explore/circuit/elements/recursive-expandable-table';
 import { useExpandableTable } from '@/ui/segments/data-table/expandable-row/use-expandable-table';
+import { getCircuitDerivationLabel } from '@/api/entitycore/types/entities/derivation';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { expandIcon } from '@/ui/segments/explore/circuit/elements/expand-icon';
 import { activeColumnsAtom } from '@/ui/segments/data-table/elements/context';
-import { HierarchyOutputNode } from '@/ui/segments/explore/circuit/helpers';
 import { ArrowReturnRight } from '@/components/icons/ArrowReturnRight';
 import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
 import { VirtualLabInfo } from '@/types/virtual-lab/common';
@@ -19,16 +19,41 @@ import { useWorkspace } from '@/ui/hooks/use-workspace';
 import { WorkspaceScope } from '@/constants';
 
 import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
-import type { ICircuitEnriched } from '@/ui/segments/explore/circuit/helpers';
+import type { TDerivationType } from '@/api/entitycore/types/entities/derivation';
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
 import type { KebabCase } from '@/utils/type';
+import type {
+  HierarchyOutputNode,
+  ICircuitEnriched,
+} from '@/ui/segments/explore/circuit/helpers';
+import type { DerivedGroup } from '@/ui/segments/explore/circuit/use-hierarchy';
 import { useDataTableColumns } from '@/ui/segments/data-table/elements/use-data-table-columns';
 
 type Props = {
-  data: HierarchyOutputNode[] | undefined;
+  groups: DerivedGroup[];
 };
 
-export function Derived({ data }: Props) {
+export function Derived({ groups }: Props) {
+  return (
+    <div className="flex flex-col gap-5">
+      {groups.map(({ derivationType, circuits }) => (
+        <DerivedGroupSection
+          key={derivationType}
+          derivationType={derivationType}
+          circuits={circuits}
+        />
+      ))}
+    </div>
+  );
+}
+
+function DerivedGroupSection({
+  derivationType,
+  circuits,
+}: {
+  derivationType: TDerivationType;
+  circuits: HierarchyOutputNode[];
+}) {
   const { push: navigate } = useRouter();
   const { virtualLabId, projectId } = useWorkspace();
   const { type } = useParams<{ type: KebabCase<TExtendedEntitiesTypeDict> }>();
@@ -115,15 +140,22 @@ export function Derived({ data }: Props) {
   const { expandableConfig } = useExpandableTable<ICircuit, VirtualLabInfo>(expandableOptions);
 
   return (
-    <BaseTable
-      loading={false}
-      wrapperClassname="[&_.ant-table-body]:max-h-full!"
-      columns={columns}
-      dataType={ExtendedEntitiesTypeDict.Circuit}
-      dataSource={data}
-      onCellClick={onCellClick}
-      expandableConfig={expandableConfig}
-      rowKey={(record: ICircuit) => `derived-hierarchy-${record.id}`}
-    />
+    <div className="flex flex-col gap-2">
+      <div className="ml-2 flex flex-row items-center gap-2">
+        <ArrowReturnRight className="text-neutral-4 text-3xl" />
+        <div className="text-neutral-4 text-lg font-semibold uppercase">
+          {getCircuitDerivationLabel(derivationType)}
+        </div>
+      </div>
+      <BaseTable
+        loading={false}
+        wrapperClassname="[&_.ant-table-body]:max-h-full!"
+        columns={columns}
+        dataType={ExtendedEntitiesTypeDict.Circuit}
+        dataSource={circuits}
+        onCellClick={onCellClick}
+        expandableConfig={expandableConfig}
+      />
+    </div>
   );
 }

--- a/src/ui/segments/explore/circuit/elements/related-circuits/derived.tsx
+++ b/src/ui/segments/explore/circuit/elements/related-circuits/derived.tsx
@@ -1,33 +1,30 @@
-import { useParams, useRouter } from 'next/navigation';
 import { snakeCase } from 'es-toolkit/compat';
-import { ReactNode, useMemo } from 'react';
 import { useAtomValue } from 'jotai';
 import { unwrap } from 'jotai/utils';
+import { useParams, useRouter } from 'next/navigation';
+import { type ReactNode, useMemo } from 'react';
 
-import { createExpandableTableConfig } from '@/ui/segments/data-table/expandable-row/expandable-base-table';
-import { RecursiveExpandableTable } from '@/ui/segments/explore/circuit/elements/recursive-expandable-table';
-import { useExpandableTable } from '@/ui/segments/data-table/expandable-row/use-expandable-table';
 import { getCircuitDerivationLabel } from '@/api/entitycore/types/entities/derivation';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
-import { expandIcon } from '@/ui/segments/explore/circuit/elements/expand-icon';
-import { activeColumnsAtom } from '@/ui/segments/data-table/elements/context';
 import { ArrowReturnRight } from '@/components/icons/ArrowReturnRight';
-import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
-import { VirtualLabInfo } from '@/types/virtual-lab/common';
-import { BaseTable } from '@/ui/segments/data-table/table';
-import { useWorkspace } from '@/ui/hooks/use-workspace';
 import { WorkspaceScope } from '@/constants';
-
-import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
-import type { TDerivationType } from '@/api/entitycore/types/entities/derivation';
-import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
-import type { KebabCase } from '@/utils/type';
-import type {
-  HierarchyOutputNode,
-  ICircuitEnriched,
-} from '@/ui/segments/explore/circuit/helpers';
-import type { DerivedGroup } from '@/ui/segments/explore/circuit/use-hierarchy';
+import { useWorkspace } from '@/ui/hooks/use-workspace';
+import { activeColumnsAtom } from '@/ui/segments/data-table/elements/context';
 import { useDataTableColumns } from '@/ui/segments/data-table/elements/use-data-table-columns';
+import { createExpandableTableConfig } from '@/ui/segments/data-table/expandable-row/expandable-base-table';
+import { useExpandableTable } from '@/ui/segments/data-table/expandable-row/use-expandable-table';
+import { BaseTable } from '@/ui/segments/data-table/table';
+import { expandIcon } from '@/ui/segments/explore/circuit/elements/expand-icon';
+import { RecursiveExpandableTable } from '@/ui/segments/explore/circuit/elements/recursive-expandable-table';
+import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
+
+import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
+import type { TDerivationType } from '@/api/entitycore/types/entities/derivation';
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import type { VirtualLabInfo } from '@/types/virtual-lab/common';
+import type { HierarchyOutputNode, ICircuitEnriched } from '@/ui/segments/explore/circuit/helpers';
+import type { DerivedGroup } from '@/ui/segments/explore/circuit/use-hierarchy';
+import type { KebabCase } from '@/utils/type';
 
 type Props = {
   groups: DerivedGroup[];
@@ -113,8 +110,8 @@ function DerivedGroupSection({
       return (
         <div className="my-5 flex flex-col items-start gap-5">
           <div className="ml-2 flex flex-row items-center gap-2">
-            <ArrowReturnRight className="text-neutral-4 text-3xl" />
-            <div className="text-neutral-4 text-lg font-semibold uppercase">Derived circuits</div>
+            <ArrowReturnRight className="text-neutral-3 text-3xl" />
+            <div className="text-neutral-3 text-lg font-semibold uppercase">Derived circuits</div>
           </div>
           <div className="w-full">
             <div className="ml-4">
@@ -142,8 +139,8 @@ function DerivedGroupSection({
   return (
     <div className="flex flex-col gap-2">
       <div className="ml-2 flex flex-row items-center gap-2">
-        <ArrowReturnRight className="text-neutral-4 text-3xl" />
-        <div className="text-neutral-4 text-lg font-semibold uppercase">
+        <ArrowReturnRight className="text-neutral-2 text-3xl" />
+        <div className="text-neutral-2 text-lg font-semibold uppercase">
           {getCircuitDerivationLabel(derivationType)}
         </div>
       </div>

--- a/src/ui/segments/explore/circuit/elements/related-circuits/index.tsx
+++ b/src/ui/segments/explore/circuit/elements/related-circuits/index.tsx
@@ -43,20 +43,20 @@ export function RelatedCircuits({ circuit, variant = ViewVariant.Light }: Props)
   return (
     <div className={cn({ 'mt-5': variant !== ViewVariant.Default })}>
       <Tabs defaultMessage="No related circuits found" variant={variant}>
-        <Tab label="Parent circuit" visible={Boolean(circuit.root_circuit_id)}>
-          <Parent data={parent} />
-        </Tab>
         <Tab label="Root circuit" visible={Boolean(circuit.root_circuit_id)}>
           <Root circuit={circuit} />
         </Tab>
-        <Tab label="Derived from" visible={Boolean(derivedFrom)}>
-          <DerivedFrom data={derivedFrom} />
+        <Tab label="Parent circuit" visible={Boolean(circuit.root_circuit_id)}>
+          <Parent data={parent} />
         </Tab>
         <Tab label="Subcircuits" visible={Boolean(subCircuits?.at(0)?.sub_circuits?.length)}>
           <Subcircuits data={subCircuits} />
         </Tab>
-        <Tab label="Derived circuits" visible={Boolean(derived?.at(0)?.sub_circuits?.length)}>
-          <Derived data={derived} />
+        <Tab label="Derived from" visible={derivedFrom.length > 0}>
+          <DerivedFrom groups={derivedFrom} />
+        </Tab>
+        <Tab label="Derived circuits" visible={derived.length > 0}>
+          <Derived groups={derived} />
         </Tab>
       </Tabs>
     </div>

--- a/src/ui/segments/explore/circuit/elements/related-circuits/subcircuits.tsx
+++ b/src/ui/segments/explore/circuit/elements/related-circuits/subcircuits.tsx
@@ -1,24 +1,24 @@
-import { useRouter } from 'next/navigation';
-import { ReactNode, useMemo } from 'react';
 import { useAtomValue } from 'jotai';
 import { unwrap } from 'jotai/utils';
+import { useRouter } from 'next/navigation';
+import { type ReactNode, useMemo } from 'react';
 
-import { createExpandableTableConfig } from '@/ui/segments/data-table/expandable-row/expandable-base-table';
-import { RecursiveExpandableTable } from '@/ui/segments/explore/circuit/elements/recursive-expandable-table';
-import { useExpandableTable } from '@/ui/segments/data-table/expandable-row/use-expandable-table';
-import { useDataTableColumns } from '@/ui/segments/data-table/elements/use-data-table-columns';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
-import { expandIcon } from '@/ui/segments/explore/circuit/elements/expand-icon';
-import { activeColumnsAtom } from '@/ui/segments/data-table/elements/context';
 import { ArrowReturnRight } from '@/components/icons/ArrowReturnRight';
-import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
-import { VirtualLabInfo } from '@/types/virtual-lab/common';
-import { BaseTable } from '@/ui/segments/data-table/table';
-import { useWorkspace } from '@/ui/hooks/use-workspace';
 import { WorkspaceScope } from '@/constants';
+import { useWorkspace } from '@/ui/hooks/use-workspace';
+import { activeColumnsAtom } from '@/ui/segments/data-table/elements/context';
+import { useDataTableColumns } from '@/ui/segments/data-table/elements/use-data-table-columns';
+import { createExpandableTableConfig } from '@/ui/segments/data-table/expandable-row/expandable-base-table';
+import { useExpandableTable } from '@/ui/segments/data-table/expandable-row/use-expandable-table';
+import { BaseTable } from '@/ui/segments/data-table/table';
+import { expandIcon } from '@/ui/segments/explore/circuit/elements/expand-icon';
+import { RecursiveExpandableTable } from '@/ui/segments/explore/circuit/elements/recursive-expandable-table';
+import { resolveExploreDetailsPageUrl } from '@/utils/url-builder';
 
-import type { HierarchyOutputNode, ICircuitEnriched } from '@/ui/segments/explore/circuit/helpers';
 import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
+import type { VirtualLabInfo } from '@/types/virtual-lab/common';
+import type { HierarchyOutputNode, ICircuitEnriched } from '@/ui/segments/explore/circuit/helpers';
 
 type Props = {
   data: HierarchyOutputNode[] | undefined;
@@ -82,8 +82,8 @@ export function Subcircuits({ data }: Props) {
       return (
         <div className="my-5 flex flex-col items-start gap-5">
           <div className="ml-2 flex flex-row items-center gap-2">
-            <ArrowReturnRight className="text-neutral-4 text-3xl" />
-            <div className="text-neutral-4 text-lg font-semibold uppercase">subcircuits</div>
+            <ArrowReturnRight className="text-neutral-3 text-3xl" />
+            <div className="text-neutral-3 text-lg font-semibold uppercase">subcircuits</div>
           </div>
           <div className="w-full">
             <div className="ml-4">

--- a/src/ui/segments/explore/circuit/use-hierarchy.tsx
+++ b/src/ui/segments/explore/circuit/use-hierarchy.tsx
@@ -2,7 +2,7 @@
 
 'use client';
 
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import { chunk, flatMap, get, isArray, keyBy, mergeWith, uniqBy } from 'es-toolkit/compat';
 import { useAtomValue } from 'jotai';
 import pMap from 'p-map';
@@ -11,7 +11,10 @@ import {
   getCircuitHierarchyByDerivation,
   getCircuits,
 } from '@/api/entitycore/queries/model/circuit';
-import { DerivationTypeDictionary } from '@/api/entitycore/types/entities/derivation';
+import {
+  CIRCUIT_DERIVED_DERIVATION_TYPES,
+  DerivationTypeDictionary,
+} from '@/api/entitycore/types/entities/derivation';
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { DEFAULT_PAGE_SIZE, WorkspaceScope } from '@/constants';
 import { circuitScaleFilter } from '@/entity-configuration/domain/model/circuit';
@@ -133,6 +136,32 @@ export function useFullRawHierarchy({
   return { circuitHierarchy, isLoadingFullHierarchy };
 }
 
+/**
+ * Builds the react-query options for one circuit derivation hierarchy tree. Shared by
+ * `useHierarchyDerivationTree` (single type) and `useHierarchyAllLevels` (`useQueries` over
+ * many types), so the queryKey/queryFn live in exactly one place.
+ */
+function buildDerivationTreeQueryOptions({
+  virtualLabId,
+  projectId,
+  view,
+  derivationType,
+}: WorkspaceContext & {
+  view: TCircuitRepresentationView | null;
+  derivationType: TDerivationType;
+}) {
+  return {
+    queryKey: keyBuilder.circuitsByDerivationTree({ virtualLabId, projectId, derivationType }),
+    queryFn: (): Promise<HierarchyTreeResponse> =>
+      getCircuitHierarchyByDerivation({
+        context: { virtualLabId, projectId },
+        derivation_type: derivationType,
+      }),
+    enabled: view === CircuitRepresentationView.Hierarchy,
+    staleTime: Infinity,
+  };
+}
+
 export function useHierarchyDerivationTree({
   view,
   derivationType,
@@ -142,20 +171,9 @@ export function useHierarchyDerivationTree({
 }) {
   const { virtualLabId, projectId } = useWorkspace();
   const { data: hierarchyByDerivation, isLoading: loadingDerivation } =
-    useQuery<HierarchyTreeResponse>({
-      queryKey: keyBuilder.circuitsByDerivationTree({
-        virtualLabId,
-        projectId,
-        derivationType,
-      }),
-      queryFn: () =>
-        getCircuitHierarchyByDerivation({
-          context: { virtualLabId, projectId },
-          derivation_type: derivationType,
-        }),
-      enabled: view === CircuitRepresentationView.Hierarchy,
-      staleTime: Infinity,
-    });
+    useQuery<HierarchyTreeResponse>(
+      buildDerivationTreeQueryOptions({ virtualLabId, projectId, view, derivationType })
+    );
 
   return {
     hierarchyByDerivation,
@@ -302,9 +320,20 @@ export function useHierarchy({
   };
 }
 
+/** A single derivation source (parent) for the "Derived from" tab, with its derivation type. */
+export interface DerivedFromGroup {
+  derivationType: TDerivationType;
+  circuit: ICircuit;
+}
+
+/** A group of derived circuits (subtree) for the "Derived circuits" tab, with its derivation type. */
+export interface DerivedGroup {
+  derivationType: TDerivationType;
+  circuits: HierarchyOutputNode[];
+}
+
 export function useHierarchyAllLevels({ entityId }: WorkspaceContext & { entityId: string }) {
-  let extractionParentCircuitAsParent: ICircuit | undefined;
-  let rewiringParentCircuitAsDerivedFrom: ICircuit | undefined;
+  const { virtualLabId, projectId } = useWorkspace();
   const { circuitHierarchy, isLoadingFullHierarchy } = useFullRawHierarchy({
     view: CircuitRepresentationView.Hierarchy,
   });
@@ -316,44 +345,76 @@ export function useHierarchyAllLevels({ entityId }: WorkspaceContext & { entityI
     derivationType: DerivationTypeDictionary.CircuitExtraction,
   });
 
-  const {
-    hierarchyByDerivation: hierarchyByRewiringDerivation,
-    loadingDerivation: loadingRewiringDerivation,
-  } = useHierarchyDerivationTree({
-    view: CircuitRepresentationView.Hierarchy,
-    derivationType: DerivationTypeDictionary.CircuitRewiring,
+  const { derivedTrees, isLoadingDerived } = useQueries({
+    queries: CIRCUIT_DERIVED_DERIVATION_TYPES.map((derivationType) =>
+      buildDerivationTreeQueryOptions({
+        virtualLabId,
+        projectId,
+        view: CircuitRepresentationView.Hierarchy,
+        derivationType,
+      })
+    ),
+    combine: (
+      results
+    ): {
+      derivedTrees: Array<{ derivationType: TDerivationType; tree: HierarchyTreeResponse | undefined }>;
+      isLoadingDerived: boolean;
+    } => ({
+      derivedTrees: results.map((result, index) => ({
+        derivationType: CIRCUIT_DERIVED_DERIVATION_TYPES[index],
+        tree: result.data,
+      })),
+      isLoadingDerived: results.some((result) => result.isLoading),
+    }),
   });
 
-  if (circuitHierarchy && hierarchyByExtractionDerivation && hierarchyByRewiringDerivation) {
+  const allDerivedReady = derivedTrees.every(({ tree }) => Boolean(tree));
+
+  if (circuitHierarchy && hierarchyByExtractionDerivation && allDerivedReady) {
     const fullById = keyBy(circuitHierarchy.data, 'id');
     const extractionParent = findParentInTree(hierarchyByExtractionDerivation.data, entityId);
-    const rewiringParent = findParentInTree(hierarchyByRewiringDerivation.data, entityId);
     const extractionNode = findNodeInTree(hierarchyByExtractionDerivation.data, entityId);
-    const rewiringNode = findNodeInTree(hierarchyByRewiringDerivation.data, entityId);
-    const extractionTreeAsSubcircuits = extractionNode
+    const subCircuits = extractionNode
       ? filterAndEnrichTree([extractionNode], new Set(collectIdsFromNode(extractionNode)), fullById)
       : [];
+    const parent: ICircuit | undefined = extractionParent
+      ? get(fullById, extractionParent.id)
+      : undefined;
 
-    const rewiringTreeAsDerivedCircuits = rewiringNode
-      ? filterAndEnrichTree([rewiringNode], new Set(collectIdsFromNode(rewiringNode)), fullById)
-      : [];
+    const derivedFrom: DerivedFromGroup[] = [];
+    const derived: DerivedGroup[] = [];
 
-    if (extractionParent) extractionParentCircuitAsParent = get(fullById, extractionParent.id);
-    if (rewiringParent) rewiringParentCircuitAsDerivedFrom = get(fullById, rewiringParent.id);
+    for (const { derivationType, tree } of derivedTrees) {
+      if (!tree) continue;
+
+      const parentNode = findParentInTree(tree.data, entityId);
+      if (parentNode) {
+        const sourceCircuit: ICircuit | undefined = get(fullById, parentNode.id);
+        if (sourceCircuit) derivedFrom.push({ derivationType, circuit: sourceCircuit });
+      }
+
+      const node = findNodeInTree(tree.data, entityId);
+      const circuits = node
+        ? filterAndEnrichTree([node], new Set(collectIdsFromNode(node)), fullById)
+        : [];
+      if (circuits.at(0)?.sub_circuits?.length) {
+        derived.push({ derivationType, circuits });
+      }
+    }
 
     return {
-      subCircuits: extractionTreeAsSubcircuits,
-      derived: rewiringTreeAsDerivedCircuits,
-      parent: extractionParentCircuitAsParent,
-      derivedFrom: rewiringParentCircuitAsDerivedFrom,
+      subCircuits,
+      derived,
+      parent,
+      derivedFrom,
     };
   }
 
   return {
     subCircuits: [],
-    derived: [],
-    parent: extractionParentCircuitAsParent,
-    derivedFrom: rewiringParentCircuitAsDerivedFrom,
-    isLoading: isLoadingFullHierarchy || loadingExtractionDerivation || loadingRewiringDerivation,
+    derived: [] as DerivedGroup[],
+    parent: undefined as ICircuit | undefined,
+    derivedFrom: [] as DerivedFromGroup[],
+    isLoading: isLoadingFullHierarchy || loadingExtractionDerivation || isLoadingDerived,
   };
 }


### PR DESCRIPTION
## Summary

Generalizes the circuit detail page **Related artifacts** section so the *derived* relationships
cover every non-extraction circuit→circuit derivation type instead of only `circuit_rewiring`.

- **Derived from** now shows the source circuit for any derivation type except `circuit_extraction`
  (`circuit_rewiring` + `circuit_customization`), grouped into per-type sections with the type
  label as a header.
- **Derived circuits** shows all circuits derived from the current one, grouped by derivation type
  (recursive/expandable, like Subcircuits).
- Tabs reordered to: **Root circuit, Parent circuit, Subcircuits, Derived from, Derived circuits**.
- Grouping/section labels lightened (`neutral-4` → `neutral-3`) for readability.

Customized circuits, previously invisible here, now appear under both tabs.

## Changes

- `api/entitycore/types/entities/derivation.ts` — add `CIRCUIT_DERIVED_DERIVATION_TYPES` constant
  + `getCircuitDerivationLabel()` helper (short per-type label, falls back to the raw key).
- `ui/segments/explore/circuit/use-hierarchy.tsx` — fetch one hierarchy tree per derived type via
  `useQueries` over a shared `buildDerivationTreeQueryOptions` helper; `useHierarchyAllLevels` now
  returns `derivedFrom` / `derived` as per-type groups (new `DerivedFromGroup` / `DerivedGroup` types).
- `related-circuits/index.tsx` — reorder tabs; pass grouped `derivedFrom` / `derived` props.
- `related-circuits/derived-from.tsx` — render one table per derivation-type group with a labelled header.
- `related-circuits/derived.tsx` — render one expandable table per derivation-type group with a labelled header.
- `related-circuits/subcircuits.tsx` — lighten the grouping label colour for readability.

## Original feature request

openbraininstitute/prod-explore-functionality#518
