### PR TITLE
fix(atlas-viewer): stop spurious "Unable to load mesh" popups

### DIFF
--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.test.ts
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.test.ts
@@ -102,6 +102,10 @@ vi.mock('@/utils/logger', () => ({
 
 // Imported after the mocks are registered (vitest hoists vi.mock above this).
 import { Painter } from './painter';
+// `errors` is intentionally NOT mocked, so the real class is shared with painter.ts
+// and `instanceof` works; `getCachedBrainRegionMeshArrayBuffer` comes from the mock above.
+import { RegionMeshNotAvailableError } from './services/errors';
+import { getCachedBrainRegionMeshArrayBuffer } from './services/services';
 
 import type { VisibleRegion } from './types';
 
@@ -174,6 +178,32 @@ describe('Painter.setRegions — context teardown race (issue #490)', () => {
     await pending;
 
     expect(dispatched).toEqual(['Unable to load mesh for region "Cerebrum"!']);
+    expect(h.logError).toHaveBeenCalled();
+  });
+
+  it('logs but does not show a popup when a region has no mesh in the atlas', async () => {
+    // "grooves" case: the region is selectable in the hierarchy tree but has no
+    // brain-atlas-region mesh entity, so the fetch rejects before any GLB parse.
+    vi.mocked(getCachedBrainRegionMeshArrayBuffer).mockRejectedValueOnce(
+      new RegionMeshNotAvailableError(region.id, 'atlas-2', 'no mesh')
+    );
+
+    const { dispatched, pending } = startMeshLoad();
+    await pending;
+
+    expect(dispatched).toEqual([]);
+    expect(h.logError).toHaveBeenCalled();
+  });
+
+  it('still surfaces a popup when the fetch fails with a non-mesh-availability error', async () => {
+    // A genuine transient failure (not the typed no-mesh error) must NOT be
+    // swallowed by the suppression branch — the user still sees the popup.
+    vi.mocked(getCachedBrainRegionMeshArrayBuffer).mockRejectedValueOnce(new Error('network down'));
+
+    const { dispatched, pending } = startMeshLoad();
+    await pending;
+
+    expect(dispatched).toHaveLength(1);
     expect(h.logError).toHaveBeenCalled();
   });
 });

--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.test.ts
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Shared, hoisted state so the `@tolokoban/tgd` mock factory (hoisted above the
+// imports) can talk back to the test: handles to settle the in-flight GLB
+// `parse`, the contexts every region painter was built against, and a logError spy.
+const h = vi.hoisted(() => ({
+  resolveParse: null as null | ((asset: unknown) => void),
+  rejectParse: null as null | ((reason: unknown) => void),
+  xrayContexts: [] as Array<{ id: number; deleted: boolean }>,
+  logError: vi.fn(),
+}));
+
+// Fake the WebGL toolkit. `TgdDataGlb.parse` is suspended on a controllable
+// promise so the test can settle it after a context teardown, and `TgdPainterXRay`
+// mimics the real use-after-delete: it throws "[TgdContext] This context has been
+// deleted:" when constructed against a deleted context (as the real toolkit does).
+vi.mock('@tolokoban/tgd', () => {
+  let nextId = 1;
+  class TgdContext {
+    public readonly id = nextId++;
+
+    public deleted = false;
+
+    public readonly logic = { add: () => undefined };
+
+    add() {}
+
+    paint() {}
+
+    delete() {
+      this.deleted = true;
+    }
+  }
+  class TgdPainterGroup {
+    add() {}
+
+    remove() {}
+  }
+  const TgdDataGlb = {
+    parse() {
+      return new Promise((resolve, reject) => {
+        h.resolveParse = resolve;
+        h.rejectParse = reject;
+      });
+    },
+  };
+  class TgdGeometryGltf {}
+  class TgdPainterXRay {
+    constructor(context: TgdContext) {
+      h.xrayContexts.push({ id: context.id, deleted: context.deleted });
+      if (context.deleted) {
+        throw new Error(`[TgdContext] This context has been deleted: Context#${context.id}!`);
+      }
+    }
+  }
+  class TgdPainterClear {}
+  class TgdPainterState {}
+  class TgdPainterPointsCloud {
+    delete() {}
+  }
+  class TgdTexture2D {
+    loadBitmap() {
+      return this;
+    }
+  }
+  return {
+    TgdContext,
+    TgdPainterGroup,
+    TgdDataGlb,
+    TgdGeometryGltf,
+    TgdPainterXRay,
+    TgdPainterClear,
+    TgdPainterState,
+    TgdPainterPointsCloud,
+    TgdTexture2D,
+    tgdCanvasCreateFill: () => ({}),
+    webglPresetDepth: { lessOrEqual: 'lessOrEqual' },
+  };
+});
+
+vi.mock('./camera', () => ({
+  setCamera: () => ({ resetCamera: () => undefined, fitToBounds: () => undefined }),
+}));
+
+vi.mock('./hooks', () => ({
+  makeColor: () => ({ color: 'mock' }),
+}));
+
+vi.mock('./services/services', () => ({
+  getCachedBrainRegionMeshArrayBuffer: vi.fn(async () => new ArrayBuffer(8)),
+  getPointCouldData: vi.fn(async () => new Float32Array()),
+}));
+
+vi.mock('@/config', () => ({
+  config: { MOUSE_ATLAS__ID: 'atlas-1' },
+}));
+
+vi.mock('@/utils/logger', () => ({
+  logError: (...args: unknown[]) => h.logError(...args),
+  log: () => undefined,
+}));
+
+// Imported after the mocks are registered (vitest hoists vi.mock above this).
+import { Painter } from './painter';
+
+import type { VisibleRegion } from './types';
+
+const region: VisibleRegion = {
+  id: 'cerebrum',
+  name: 'Cerebrum',
+  color: { color: 'mock' } as never,
+};
+
+/** Drain macrotasks until the suspended GLB `parse` is reached (bounded). */
+async function waitForParse() {
+  for (let i = 0; i < 50 && !h.resolveParse && !h.rejectParse; i += 1) {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  }
+}
+
+describe('Painter.setRegions — context teardown race (issue #490)', () => {
+  beforeEach(() => {
+    h.resolveParse = null;
+    h.rejectParse = null;
+    h.xrayContexts.length = 0;
+    h.logError.mockClear();
+  });
+
+  it('does not use a deleted context or show a popup when a mesh load resolves after a restart', async () => {
+    const painter = new Painter('atlas-2', {} as never);
+    const dispatched: unknown[] = [];
+    painter.eventError.addListener((message) => dispatched.push(message));
+
+    painter.start({} as HTMLCanvasElement);
+
+    // Mesh load starts; it suspends on the network fetch, then on `TgdDataGlb.parse`.
+    const pending = painter.setRegions([region], 'access-token');
+    await waitForParse();
+    expect(h.resolveParse).not.toBeNull();
+
+    // Simulate navigating between tabs: cleanup tears the canvas down and the
+    // remount creates a fresh context — deleting the context the load captured.
+    painter.start(null);
+    painter.start({} as HTMLCanvasElement);
+
+    // The in-flight parse now resolves against the stale (deleted) context.
+    h.resolveParse?.({ getJson: () => ({}) });
+    await pending;
+
+    expect(dispatched).toEqual([]);
+    expect(h.xrayContexts.some((context) => context.deleted)).toBe(false);
+    expect(h.logError).not.toHaveBeenCalled();
+  });
+
+  it('still surfaces a popup when a mesh genuinely fails on the current live context', async () => {
+    const painter = new Painter('atlas-2', {} as never);
+    const dispatched: unknown[] = [];
+    painter.eventError.addListener((message) => dispatched.push(message));
+
+    painter.start({} as HTMLCanvasElement);
+
+    const pending = painter.setRegions([region], 'access-token');
+    await waitForParse();
+
+    // No teardown: the context stays live and the GLB simply fails to parse
+    // (e.g. a corrupt mesh). The guard must NOT swallow this — the user sees it.
+    h.rejectParse?.(new Error('corrupt GLB'));
+    await pending;
+
+    expect(dispatched).toEqual(['Unable to load mesh for region "Cerebrum"!']);
+    expect(h.logError).toHaveBeenCalled();
+  });
+});

--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.test.ts
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.test.ts
@@ -120,6 +120,23 @@ async function waitForParse() {
   }
 }
 
+/**
+ * Arrange a started painter that is mid-mesh-load: it has dispatched listeners
+ * wired up and a `setRegions` call in flight, suspended on the GLB `parse`.
+ * Callers `await waitForParse()` then drive the teardown/resolve they're testing.
+ */
+function startMeshLoad() {
+  const painter = new Painter('atlas-2', {} as never);
+  const dispatched: unknown[] = [];
+  painter.eventError.addListener((message) => dispatched.push(message));
+
+  painter.start({} as HTMLCanvasElement);
+
+  // Mesh load starts; it suspends on the network fetch, then on `TgdDataGlb.parse`.
+  const pending = painter.setRegions([region], 'access-token');
+  return { painter, dispatched, pending };
+}
+
 describe('Painter.setRegions — context teardown race (issue #490)', () => {
   beforeEach(() => {
     h.resolveParse = null;
@@ -129,14 +146,7 @@ describe('Painter.setRegions — context teardown race (issue #490)', () => {
   });
 
   it('does not use a deleted context or show a popup when a mesh load resolves after a restart', async () => {
-    const painter = new Painter('atlas-2', {} as never);
-    const dispatched: unknown[] = [];
-    painter.eventError.addListener((message) => dispatched.push(message));
-
-    painter.start({} as HTMLCanvasElement);
-
-    // Mesh load starts; it suspends on the network fetch, then on `TgdDataGlb.parse`.
-    const pending = painter.setRegions([region], 'access-token');
+    const { painter, dispatched, pending } = startMeshLoad();
     await waitForParse();
     expect(h.resolveParse).not.toBeNull();
 
@@ -155,13 +165,7 @@ describe('Painter.setRegions — context teardown race (issue #490)', () => {
   });
 
   it('still surfaces a popup when a mesh genuinely fails on the current live context', async () => {
-    const painter = new Painter('atlas-2', {} as never);
-    const dispatched: unknown[] = [];
-    painter.eventError.addListener((message) => dispatched.push(message));
-
-    painter.start({} as HTMLCanvasElement);
-
-    const pending = painter.setRegions([region], 'access-token');
+    const { dispatched, pending } = startMeshLoad();
     await waitForParse();
 
     // No teardown: the context stays live and the GLB simply fails to parse

--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.tsx
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.tsx
@@ -168,6 +168,11 @@ export class Painter {
       return;
     }
 
+    // Snapshot the context generation so we can detect a teardown/remount
+    // (start() deletes the context and bumps contextVersion) that happens while a
+    // mesh load is in flight. Mirrors setPointCloud's contextVersion guard.
+    const contextVersion = this.contextVersion;
+
     this.loadingMesh = true;
     this.isAddingRegions = true;
     this.nextRegionsToAdd = null;
@@ -195,11 +200,24 @@ export class Painter {
           regionId: region.id,
           queryClient: this.queryClient,
         });
-        const meshBounds = await this.addMesh(data, region);
+        // Context was torn down / replaced while fetching. Abort silently and do
+        // NOT reset isAddingRegions/loadingMesh — a newer start()/setRegions owns
+        // that state now (cf. setPointCloud's guarded finally).
+        if (contextVersion !== this.contextVersion) return;
+
+        const meshBounds = await this.addMesh(data, region, contextVersion);
+        // addMesh swallows its own errors and resolves null, so re-check here
+        // before falling through to the cleanup tail.
+        if (contextVersion !== this.contextVersion) return;
+
         if (shouldAutoFitCamera && meshBounds) {
           mergedBounds = this.mergeBounds(mergedBounds, meshBounds);
         }
       } catch (ex) {
+        // A stale request must never surface a popup on whatever tab the user has
+        // navigated to. Only genuine failures on the current context dispatch.
+        if (contextVersion !== this.contextVersion) return;
+
         logError(`Unable to load mesh for region "${region.name}":`, ex);
         this.eventError.dispatch(
           <>
@@ -322,11 +340,16 @@ export class Painter {
     context.paint();
   }
 
-  private async addMesh(data: ArrayBuffer | null, region: VisibleRegion) {
+  private async addMesh(data: ArrayBuffer | null, region: VisibleRegion, contextVersion: number) {
     const { context, group, regionPainters } = this;
     if (!context || !group || !data || regionPainters.has(region.id)) return null;
     try {
       const asset = await TgdDataGlb.parse(data);
+      // start() ran during parse(): the captured `context` is now a deleted
+      // TgdContext. Bail before touching it so we never throw
+      // "[TgdContext] This context has been deleted:" (the popup's real cause).
+      if (contextVersion !== this.contextVersion) return null;
+
       const geometry = new TgdGeometryGltf({ data: asset });
       const meshBounds = this.extractBoundsFromGltf(asset);
       const painterXRay = new TgdPainterXRay(context, {
@@ -340,6 +363,15 @@ export class Painter {
       context.paint();
       return meshBounds;
     } catch (ex) {
+      // Defensive backup mirroring setPointCloud: if a stale/deleted context still
+      // produced an error, only log it — never show the user-facing popup.
+      if (
+        contextVersion !== this.contextVersion ||
+        (ex instanceof Error && ex.message.includes('[TgdContext] This context has been deleted:'))
+      ) {
+        logError(`Unable to load mesh for region ${region.name} (stale context):`, ex);
+        return null;
+      }
       logError(`Unable to load mesh for region ${region.name}!`, ex);
       this.eventError.dispatch(`Unable to load mesh for region "${region.name}"!`);
       return null;

--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.tsx
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.tsx
@@ -19,6 +19,7 @@ import { logError } from '@/utils/logger';
 
 import { type CameraController, setCamera } from './camera';
 import { makeColor } from './hooks';
+import { RegionMeshNotAvailableError } from './services/errors';
 import { getCachedBrainRegionMeshArrayBuffer, getPointCouldData } from './services/services';
 
 import type { QueryClient } from '@tanstack/react-query';
@@ -40,6 +41,15 @@ interface MeshBounds {
  */
 function isDeletedContextError(ex: unknown): boolean {
   return ex instanceof Error && ex.message.includes('[TgdContext] This context has been deleted:');
+}
+
+/**
+ * A region that exists in the hierarchy tree but has no 3D mesh in the current
+ * atlas (e.g. non-volumetric grouping regions like "grooves"). This is expected
+ * and benign, so we log it without surfacing a user-facing popup.
+ */
+function isMeshNotAvailableError(ex: unknown): boolean {
+  return ex instanceof RegionMeshNotAvailableError;
 }
 
 let globalId = 1;
@@ -228,6 +238,14 @@ export class Painter {
         // A stale request must never surface a popup on whatever tab the user has
         // navigated to. Only genuine failures on the current context dispatch.
         if (contextVersion !== this.contextVersion) return;
+
+        // The region simply has no mesh in this atlas (a selectable-but-non-volumetric
+        // region, e.g. "grooves"). Expected and benign — log it, skip the popup, and
+        // keep loading the remaining regions.
+        if (isMeshNotAvailableError(ex)) {
+          logError(`No 3D mesh available for region "${region.name}":`, ex);
+          continue;
+        }
 
         logError(`Unable to load mesh for region "${region.name}":`, ex);
         this.eventError.dispatch(

--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.tsx
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.tsx
@@ -31,6 +31,17 @@ interface MeshBounds {
   max: [number, number, number];
 }
 
+/**
+ * The exact error `@tolokoban/tgd` throws when a painter/texture is built against
+ * a TgdContext that has already been deleted — i.e. an async mesh/point-cloud load
+ * that resolved after the canvas was torn down. Matching it lets us log such
+ * failures without surfacing a user-facing popup. Kept in one place so the single
+ * point of coupling to the framework's message lives here.
+ */
+function isDeletedContextError(ex: unknown): boolean {
+  return ex instanceof Error && ex.message.includes('[TgdContext] This context has been deleted:');
+}
+
 let globalId = 1;
 export class Painter {
   public readonly AtlasID: string;
@@ -299,10 +310,7 @@ export class Painter {
         return;
       }
 
-      if (
-        ex instanceof Error &&
-        ex.message.includes('[TgdContext] This context has been deleted:')
-      ) {
+      if (isDeletedContextError(ex)) {
         logError(`Point cloud unavailable for annotation ${annotationValue}:`, ex);
         return;
       }
@@ -365,10 +373,7 @@ export class Painter {
     } catch (ex) {
       // Defensive backup mirroring setPointCloud: if a stale/deleted context still
       // produced an error, only log it — never show the user-facing popup.
-      if (
-        contextVersion !== this.contextVersion ||
-        (ex instanceof Error && ex.message.includes('[TgdContext] This context has been deleted:'))
-      ) {
+      if (contextVersion !== this.contextVersion || isDeletedContextError(ex)) {
         logError(`Unable to load mesh for region ${region.name} (stale context):`, ex);
         return null;
       }

--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/services/errors.ts
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/services/errors.ts
@@ -1,0 +1,23 @@
+/**
+ * Thrown when a brain region has no 3D mesh available in the current atlas —
+ * either the region has no `brain-atlas-region` entity at all (it exists in the
+ * hierarchy tree but not the atlas, e.g. non-volumetric grouping regions like
+ * "grooves"), or it has an entity but no `brain_atlas_region_mesh` gltf asset.
+ *
+ * This is an expected, benign condition (such regions are greyed out but still
+ * selectable), so the viewer suppresses the error popup for it — cf.
+ * `isMeshNotAvailableError` in `../painter`. Lives in its own module so it stays
+ * unmocked when tests mock `./services`, keeping `instanceof` reliable.
+ */
+export class RegionMeshNotAvailableError extends Error {
+  constructor(
+    readonly regionId: string,
+    readonly atlasId: string,
+    message: string
+  ) {
+    super(message);
+    this.name = 'RegionMeshNotAvailableError';
+    // tsconfig target is es2015 (SWC downlevels classes) — keep instanceof reliable.
+    Object.setPrototypeOf(this, RegionMeshNotAvailableError.prototype);
+  }
+}

--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/services/services.ts
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/services/services.ts
@@ -8,6 +8,8 @@ import { fetchPointCloud } from '@/features/brain-atlas-viewer/api';
 import { ensureBrainRegionAtlasData } from '@/features/brain-atlas-viewer/queries';
 import { log } from '@/utils/logger';
 
+import { RegionMeshNotAvailableError } from './errors';
+
 import type { QueryClient } from '@tanstack/react-query';
 
 const cacheMeshes = new Map<string, Promise<ArrayBuffer>>();
@@ -51,7 +53,11 @@ async function getBrainRegionMeshArrayBufferQuery({
   const atlas = await getAtlas({ atlasId, queryClient });
   const entity = atlas.data.find((elem) => elem.brain_region_id === regionId);
   if (!entity) {
-    throw new Error(`Unable to find region "${regionId}" in current Atlas ${atlasId}!`);
+    throw new RegionMeshNotAvailableError(
+      regionId,
+      atlasId,
+      `Unable to find region "${regionId}" in current Atlas ${atlasId}!`
+    );
   }
 
   const contentType = AssetContentType.gltf_binary;
@@ -60,7 +66,9 @@ async function getBrainRegionMeshArrayBufferQuery({
     (elem) => elem.label === 'brain_atlas_region_mesh' && elem.content_type === contentType
   );
   if (!asset) {
-    throw new Error(
+    throw new RegionMeshNotAvailableError(
+      regionId,
+      atlasId,
       `Unable to find entity "brain_atlas_region_mesh" of type "${contentType}" for entity "${entity.id}" (region "${regionId}")!`
     );
   }


### PR DESCRIPTION
## Problem

Fixes openbraininstitute/prod-explore-functionality#490.

A red **`Unable to load mesh`** notification popped up in the 3D brain atlas viewer in two benign situations:

1. **Randomly when navigating between the top-level Data / Workflows / Notebooks tabs** (staging/prod).
2. **When selecting a region that has no 3D mesh in the atlas** — e.g. non-volumetric grouping regions like **"grooves"** on the mouse atlas.

In both cases nothing is actually broken, yet the viewer surfaced a global error toast.

## Root cause

The viewer drives a `Painter` WebGL instance; `setRegions` → `addMesh` `await`s a mesh fetch + `TgdDataGlb.parse()`, then builds painters against the captured `context`. A failure anywhere in that path was dispatched via `eventError` → a **global** antd notification.

- **Tab navigation:** unmount/remount calls `painter.start(null)`, which deletes the WebGL context and bumps `contextVersion`. If the user switches tabs mid-await, the resolved load runs against the **deleted** context and throws `"[TgdContext] This context has been deleted: …"`. `setPointCloud()` already guarded against this with a `contextVersion` snapshot; `setRegions`/`addMesh` did not.
- **No-mesh region:** the region hierarchy is a *superset* of the atlas mesh set. Regions with no `brain-atlas-region` mesh entity are greyed out but still selectable, so selecting one fetches a mesh that cannot exist. The lookup threw a generic `Error` (`Unable to find region "…" in current Atlas …`), surfaced as the popup.

## Fix

Distinguish expected/benign conditions from genuine failures, and only pop up for the latter:

- **Tab navigation:** `setRegions` snapshots `contextVersion` at entry and bails out silently after each await (post-fetch, post-`addMesh`, and in the `catch`); `addMesh` re-checks after `parse()` before touching the context. Suppression is keyed on lifecycle, never on error type.
- **No-mesh region:** a typed `RegionMeshNotAvailableError` (kept in its own `services/errors.ts` so the tests' module-mock of `services.ts` leaves the class real and `instanceof` keeps working) is thrown from both no-mesh sites; `setRegions` detects it via `isMeshNotAvailableError` and logs-and-skips that region instead of dispatching.

Genuine failures on the live context (mesh download errors, corrupt GLB) still show the notification exactly as before.

## Tests

`painter.test.ts` (Vitest) covers both paths: a load that resolves after a teardown, and a region with no atlas mesh, each log without a popup; a genuine failure on the live context still pops. Verified end-to-end against Species: mouse → Region: grooves.
