### PR TITLE
fix(circuit): render analysis figures on a white background

### DIFF
--- a/src/features/model-analysis/viewer/asset-viewers/image-viewer.tsx
+++ b/src/features/model-analysis/viewer/asset-viewers/image-viewer.tsx
@@ -34,7 +34,7 @@ export default function ImageViewer({ entityId, entityType, assetId }: Props) {
       />
     ))
     .with({ cachedUrl, isCaching }, ({ cachedUrl: _cachedUrl }) => (
-      <div className="relative flex h-96 w-full max-w-2xl items-center justify-center">
+      <div className="relative flex h-96 w-full max-w-2xl items-center justify-center rounded-lg bg-white">
         <Image
           fill
           objectFit="contains"

--- a/src/ui/segments/explore/circuit/elements/overview.tsx
+++ b/src/ui/segments/explore/circuit/elements/overview.tsx
@@ -65,7 +65,8 @@ export default function Overview({ circuit, variant = ViewVariant.Light }: Props
                 data-testid={`${key}-overview`}
                 className={cn(
                   'flex w-full flex-col items-center gap-2',
-                  variant === ViewVariant.Default && detailViewInsetPanelClass(variant)
+                  variant === ViewVariant.Default && detailViewInsetPanelClass(variant),
+                  items.length > 0 && 'rounded-lg bg-white'
                 )}
               >
                 {items.length === 0 ? (


### PR DESCRIPTION
## Problem

The entity detail-page content panel uses a blue background (`bg-primary-9`, introduced in #1709). Circuit analysis figures are matplotlib-generated PNGs that frequently have partly transparent backgrounds, so the blue panel shows through and degrades them on the **Analysis** tab.

PR #1748 already fixed the Overview-tab circuit visualization, but the Analysis-tab figures were not covered.

## Fix

Wrap the analysis figures in a white rounded panel at the two existing call sites (mirroring the `bg-white` pattern from #1748):

- **Circuit Analysis tab** — `overview.tsx`: add `rounded-lg bg-white` to each stats-group container when it has figures (Cell statistics + Network statistics now share one white panel per group). Gated on `items.length > 0` so the "Not available" empty state (white-on-blue styling) is untouched.
- **ME-Model / E-Model Analysis tab** — `image-viewer.tsx`: add `rounded-lg bg-white` to the loaded-image wrapper. `ImageViewer` is used only by `ValidationResultCard`, so each validation figure gets its own white panel with no side effects on PDFs/other viewers.

## Scope notes

- `data-view-layout.tsx` blue background is left as-is (intended design).
- The shared `detailViewInsetPanelClass` helper is deliberately not modified (it is reused where text is white-on-blue).

***

Closes openbraininstitute/prod-explore-functionality#519