### PR TITLE
ephys-viewer: improvements (loading skeleton, dark-background fixes, NWB asset caching)

### DIFF
--- a/src/features/ephys-viewer/atoms/index.ts
+++ b/src/features/ephys-viewer/atoms/index.ts
@@ -3,6 +3,7 @@ import { atom } from 'jotai';
 
 import { downloadAsset } from '@/api/entitycore/queries/assets';
 import { AssetContentType } from '@/api/entitycore/types/shared/global';
+import { NWB_ASSET_CACHE_CONFIG } from '@/features/ephys-viewer/constants';
 import { readAtomFamilyWithExpiration } from '@/util/atoms';
 
 import type { IElectricalCellRecording } from '@/api/entitycore/types';
@@ -33,6 +34,7 @@ export const nwbArrayBufferAtomFamily = readAtomFamilyWithExpiration(
         entityId: entity.id,
         id: asset.id,
         ctx,
+        cache: NWB_ASSET_CACHE_CONFIG,
       });
     }),
   {

--- a/src/features/ephys-viewer/components/ephys-viewer-skeleton.tsx
+++ b/src/features/ephys-viewer/components/ephys-viewer-skeleton.tsx
@@ -1,0 +1,65 @@
+import { type TViewVariant, ViewVariant } from '@/constants';
+import { TraceViewMode } from '@/features/ephys-viewer/components/trace-view-mode-toggle';
+import { Skeleton } from '@/ui/molecules/skeleton';
+import { cn } from '@/utils/css-class';
+
+const OVERVIEW_GRID_CLASS_NAME =
+  'grid gap-7 @max-xs:grid-cols-1 @lg:grid-cols-2 @3xl:grid-cols-3 @5xl:grid-cols-4 @6xl:grid-cols-5 @7xl:grid-cols-6';
+
+const SELECTOR_KEYS = ['protocol', 'repetition', 'sweep'];
+const TILE_KEYS = ['t0', 't1', 't2', 't3', 't4', 't5', 't6', 't7'];
+
+/**
+ * Placeholder shown while the NWB trace loads. Mirrors the layout the viewer will
+ * land on (driven by `view`) and the surrounding `variant` so it reads well on both
+ * the light (white) and Default (dark) backgrounds.
+ */
+export default function EphysViewerSkeleton({
+  view,
+  variant = ViewVariant.Light,
+}: {
+  view: TraceViewMode;
+  variant?: TViewVariant;
+}) {
+  // A light-grey skeleton is too harsh on the dark page; use a translucent white tone there.
+  const tone = variant === ViewVariant.Default ? 'bg-white/10' : undefined;
+
+  return (
+    <div className="@container flex flex-col gap-6">
+      {/* TraceViewModeToggle placeholder (rendered in both views) */}
+      <div className="flex gap-2">
+        <Skeleton className={cn(tone, 'h-8 w-28 rounded-full')} />
+        <Skeleton className={cn(tone, 'h-8 w-36 rounded-full')} />
+      </div>
+
+      {view === TraceViewMode.OVERVIEW ? (
+        <div className="flex flex-col gap-10">
+          <div className="flex flex-col gap-2">
+            <Skeleton className={cn(tone, 'h-4 w-40')} />
+            <Skeleton className={cn(tone, 'h-8 w-[200px]')} />
+          </div>
+          <div className={OVERVIEW_GRID_CLASS_NAME}>
+            {TILE_KEYS.map((key) => (
+              <Skeleton key={key} className={cn(tone, 'aspect-4/3 w-full')} />
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-10">
+          <div className="flex flex-wrap gap-8">
+            {SELECTOR_KEYS.map((key) => (
+              <div key={key} className="flex flex-col gap-3">
+                <Skeleton className={cn(tone, 'h-4 w-24')} />
+                <Skeleton className={cn(tone, 'h-8 w-[180px]')} />
+              </div>
+            ))}
+          </div>
+          <div className="flex flex-col gap-10 2xl:flex-row">
+            <Skeleton className={cn(tone, 'h-[40vh] w-full')} />
+            <Skeleton className={cn(tone, 'h-[40vh] w-full')} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/ephys-viewer/components/option-select.tsx
+++ b/src/features/ephys-viewer/components/option-select.tsx
@@ -4,6 +4,7 @@ import { type TViewVariant, ViewVariant } from '@/constants';
 import {
   ephysControlLabelClass,
   ephysControlSubLabelClass,
+  ephysSelectClass,
 } from '@/features/ephys-viewer/label-styles';
 
 import type { JSX } from 'react';
@@ -42,7 +43,7 @@ function OptionSelect({
 
       <Select
         id="optionSelect"
-        className="w-[180px]"
+        className={ephysSelectClass(variant, 'w-[180px]')}
         value={value}
         placeholder="Please select"
         onChange={handleChange}

--- a/src/features/ephys-viewer/components/trace-details-view.tsx
+++ b/src/features/ephys-viewer/components/trace-details-view.tsx
@@ -10,7 +10,11 @@ import InteractivePlot, {
 } from '@/features/ephys-viewer/components/interactive-plot';
 import OptionSelect from '@/features/ephys-viewer/components/option-select';
 import SweepSelector from '@/features/ephys-viewer/components/sweep-selector';
-import { ephysHeadingClass, ephysSectionLabelClass } from '@/features/ephys-viewer/label-styles';
+import {
+  ephysHeadingClass,
+  ephysSectionLabelClass,
+  ephysSelectClass,
+} from '@/features/ephys-viewer/label-styles';
 import { RecordingType, type SweepData } from '@/features/ephys-viewer/nwb-trace';
 import useResizeObserver from '@/hooks/use-resize-observer-w-ref';
 
@@ -274,7 +278,7 @@ function TraceDetailsView({
             Select cell ({cellIds.length} available)
           </div>
           <Select
-            className="cell-select w-48"
+            className={ephysSelectClass(variant, 'cell-select w-48')}
             placeholder="Select a cell"
             value={selectedCellId}
             onChange={setSelectedCellId}

--- a/src/features/ephys-viewer/components/trace-overview.tsx
+++ b/src/features/ephys-viewer/components/trace-overview.tsx
@@ -8,7 +8,11 @@ import createPlotlyComponent from 'react-plotly.js/factory';
 import { type TViewVariant, ViewVariant } from '@/constants';
 import { CHART_LINE_COLOR } from '@/features/ephys-viewer/constants';
 import { useOverviewPlotConfig } from '@/features/ephys-viewer/hooks/config-hooks';
-import { ephysSectionLabelClass } from '@/features/ephys-viewer/label-styles';
+import {
+  ephysHeadingClass,
+  ephysSectionLabelClass,
+  ephysSelectClass,
+} from '@/features/ephys-viewer/label-styles';
 import { RecordingType } from '@/features/ephys-viewer/nwb-trace';
 import useResizeObserver from '@/hooks/use-resize-observer-w-ref';
 import optimizePlotData from '@/util/explore-section/optimizeTrace';
@@ -31,6 +35,7 @@ interface ImageSetComponentProps {
   repetitionMap: Map<string, string[]>;
   singleRecMultiCellMode: boolean;
   onRepetitionClick: (stimulusType: string, rep: string) => () => void;
+  variant?: TViewVariant;
 }
 
 interface CellComponentProps {
@@ -40,6 +45,7 @@ interface CellComponentProps {
   singleRecMultiCellMode: boolean;
   showCellLabel?: boolean;
   onRepetitionClick: (stimulusType: string, rep: string) => () => void;
+  variant?: TViewVariant;
 }
 
 interface TraceOverviewComponentProps {
@@ -156,6 +162,7 @@ function ImageSetComponent({
   repetitionMap,
   singleRecMultiCellMode,
   onRepetitionClick,
+  variant = ViewVariant.Light,
 }: ImageSetComponentProps) {
   const repetitions = repetitionMap.get(protocol) ?? [];
 
@@ -186,7 +193,9 @@ function ImageSetComponent({
         onClick={onRepetitionClick(protocol, repetition)}
         type="button"
       >
-        <span className="text-lg">{singleRecMultiCellMode ? cellId : repetition}</span>
+        <span className={cn('text-lg', variant === ViewVariant.Default && 'text-white')}>
+          {singleRecMultiCellMode ? cellId : repetition}
+        </span>
 
         <div
           className={
@@ -221,7 +230,7 @@ function ImageSetComponent({
 
   return (
     <div className="divide-neutral-2 flex flex-col gap-3 divide-y">
-      <div className="text-primary-9 flex items-baseline gap-2 text-lg font-bold">
+      <div className={ephysHeadingClass(variant, 'flex items-baseline gap-2 text-lg')}>
         {protocol}
         <small className="font-light">{`${repetitions.length} ${
           repetitions.length === 1 ? 'repetition' : 'repetitions'
@@ -240,6 +249,7 @@ function CellComponent({
   onRepetitionClick,
   singleRecMultiCellMode,
   showCellLabel,
+  variant = ViewVariant.Light,
 }: CellComponentProps) {
   const repetitionMap = useMemo(
     () =>
@@ -259,6 +269,7 @@ function CellComponent({
       repetitionMap={repetitionMap}
       onRepetitionClick={onRepetitionClick}
       singleRecMultiCellMode={singleRecMultiCellMode}
+      variant={variant}
     />
   ));
 
@@ -266,7 +277,7 @@ function CellComponent({
 
   return (
     <div className="flex flex-col gap-5">
-      {showCellLabel && <div className="text-primary-9 text-xl font-bold">{cellId}</div>}
+      {showCellLabel && <div className={ephysHeadingClass(variant)}>{cellId}</div>}
       {content}
     </div>
   );
@@ -321,7 +332,7 @@ export default function TraceOverview({
         <div className={cn('flex flex-col gap-2', ephysSectionLabelClass(variant))}>
           Select cell ({cellIds.length} available)
           <Select
-            className="cell-select"
+            className={ephysSelectClass(variant, 'cell-select')}
             placeholder="Select a cell"
             value={cellId}
             onChange={onCellIdChange}
@@ -340,7 +351,7 @@ export default function TraceOverview({
         <div className={cn('flex flex-col gap-2', ephysSectionLabelClass(variant))}>
           Select Stimulus ({allProtocols.length} available)
           <Select
-            className="stimulus-select"
+            className={ephysSelectClass(variant, 'stimulus-select')}
             placeholder="Select a stimulus"
             value={protocol}
             onChange={onProtocolChange}
@@ -365,6 +376,7 @@ export default function TraceOverview({
             onRepetitionClick={onRepetitionClick}
             singleRecMultiCellMode={singleRecMultiCellMode}
             showCellLabel={cellIds.length > 1}
+            variant={variant}
           />
         ))}
       </div>

--- a/src/features/ephys-viewer/constants.ts
+++ b/src/features/ephys-viewer/constants.ts
@@ -1,1 +1,11 @@
+import { swrCacheConfig } from '@/api/cache-storage';
+
 export const CHART_LINE_COLOR = '#0050b3';
+
+// NWB assets are immutable per asset id, so use a long fresh window. Large binaries may still be
+// evicted by the browser under storage pressure. Tune as needed.
+export const NWB_ASSET_CACHE_CONFIG = swrCacheConfig(
+  'ephys-nwb-assets',
+  7 * 24 * 60 * 60, //  7 days fresh
+  30 * 24 * 60 * 60 // 30 days stale-while-revalidate
+);

--- a/src/features/ephys-viewer/ephys-viewer.tsx
+++ b/src/features/ephys-viewer/ephys-viewer.tsx
@@ -1,9 +1,10 @@
-import { Empty, Spin } from 'antd';
+import { Empty } from 'antd';
 import { useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import SimpleErrorComponent from '@/components/GenericErrorFallback';
 import { type TViewVariant, ViewVariant } from '@/constants';
+import EphysViewerSkeleton from '@/features/ephys-viewer/components/ephys-viewer-skeleton';
 import TraceDetailsView from '@/features/ephys-viewer/components/trace-details-view';
 import TraceOverview from '@/features/ephys-viewer/components/trace-overview';
 import {
@@ -53,7 +54,7 @@ export default function EphysViewer({
   }
 
   if (!trace) {
-    return <Spin />;
+    return <EphysViewerSkeleton view={view} variant={variant} />;
   }
 
   return (

--- a/src/features/ephys-viewer/hooks/use-nwb-trace.ts
+++ b/src/features/ephys-viewer/hooks/use-nwb-trace.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
 
 import { downloadAsset } from '@/api/entitycore/queries/assets';
+import { NWB_ASSET_CACHE_CONFIG } from '@/features/ephys-viewer/constants';
 import NWBTrace from '@/features/ephys-viewer/nwb-trace';
 import { keyBuilder } from '@/ui/use-query-keys/data';
 
@@ -48,6 +49,7 @@ export default function useTrace({
         entityId: entity.id,
         id: asset.id,
         ctx,
+        cache: NWB_ASSET_CACHE_CONFIG,
       }),
   });
 

--- a/src/features/ephys-viewer/label-styles.ts
+++ b/src/features/ephys-viewer/label-styles.ts
@@ -23,3 +23,21 @@ export function ephysHeadingClass(variant: TViewVariant, className?: string) {
 export function ephysSectionLabelClass(variant: TViewVariant, className?: string) {
   return cn('text-sm font-medium', { 'text-white': variant === ViewVariant.Default }, className);
 }
+
+/**
+ * Restyles the *closed* antd `<Select>` box so it reads on the dark (Default) background:
+ * transparent box, light border and near-white text. Mirrors the dark-variant styling in
+ * `trace-view-mode-toggle`. The dropdown popup renders in a body portal on its default
+ * white background, so it is left untouched. Returns no overrides for the Light variant.
+ */
+export function ephysSelectClass(variant: TViewVariant, className?: string) {
+  return cn(
+    variant === ViewVariant.Default && [
+      '[&_.ant-select-selector]:border-white/35! [&_.ant-select-selector]:bg-transparent!',
+      '[&_.ant-select-selection-item]:text-white',
+      '[&_.ant-select-selection-placeholder]:text-white/50',
+      '[&_.ant-select-arrow]:text-white/70',
+    ],
+    className
+  );
+}


### PR DESCRIPTION
A few improvements to the ephys viewer (`src/features/ephys-viewer/`).

The viewer is mounted in two visual contexts:

- **Dark background** — the ElectricalCellRecording detail page (`ViewVariant.Default`)
- **Light/white background** — the scan-config file viewer and simulation detail pages (`ViewVariant.Light`)

The UI fixes below are **variant-aware**, so the light/white contexts are visually unchanged.

## 1. Spinner → loading skeleton

Replaces the bare antd `<Spin />` with a new `EphysViewerSkeleton` that mirrors the layout the viewer will land on (keyed off the same `view` state):

- *Detailed* (scan-config + recording detail): toggle placeholder + a row of selector boxes + two `40vh` plot blocks.
- *Overview* (simulation results): toggle + selector + a grid of 4:3 tiles.

Color tone follows the variant (`bg-gray-200` on white, translucent `bg-white/10` on the dark page); pulse animation on, matching the rest of the app's skeletons. Built on the reusable `@/ui/molecules/skeleton`.

## 2. Invisible labels on the dark background

`variant` was never threaded below `TraceOverview`; it is now passed through `CellComponent`/`ImageSetComponent`. The hardcoded `text-primary-9` protocol/cell/repetition labels now use the existing `ephysHeadingClass(variant)` helper, so they render white (visible) on the dark page and stay `text-primary-9` on the light contexts.

## 3. Selector text barely visible on the dark background

New `ephysSelectClass(variant)` helper (mirroring the existing dark-variant pattern in `trace-view-mode-toggle`) dark-themes the *closed* antd `<Select>` box on the Default variant — transparent box, `border-white/35`, near-white text and lightened arrow. The dropdown popup (white, body portal) is left readable. Applied to the cell / stimulus / protocol / repetition selects. The sweep selector uses color-box checkboxes (no `<Select>`), so it needed no change.

## 4. Cache NWB assets in browser Cache Storage

Enables browser Cache Storage (CacheAPI) for the (large, immutable) NWB binaries so they persist across page reloads and navigation instead of only living in React Query's in-memory cache. Reuses the existing `cache-storage` / `api-client` SWR layer — no new caching code:

- Adds a shared `NWB_ASSET_CACHE_CONFIG` (`swrCacheConfig('ephys-nwb-assets', 7d fresh, 30d stale-while-revalidate)`).
- Passes it to the `downloadAsset` calls in `use-nwb-trace` (main viewer) and the `nwbArrayBufferAtomFamily` atom (ion-channel recording viewer).

Keyed on the stable entitycore `…/assets/{id}/download` URL; decoding is transparent (cached `Content-Type` preserved), so trace/plot rendering is unchanged.
