### PR TITLE
fix(grading): rename exercise_id to assignment_id for LTI 1.3 launches

### DIFF
--- a/src/api/entitycore/queries/experimental/analysis-notebook-template.ts
+++ b/src/api/entitycore/queries/experimental/analysis-notebook-template.ts
@@ -18,7 +18,7 @@ const AnalysisNotebookTemplateSchema = z.object({
       message: 'Experimental analysis notebook template description is required',
     }),
   scale: z.string().optional(),
-  exercise_id: z.string().optional(),
+  assignment_id: z.string().optional(),
 });
 
 export type TAnalysisNotebookTemplateCreate = z.infer<typeof AnalysisNotebookTemplateSchema>;

--- a/src/api/entitycore/types/entities/notebook.ts
+++ b/src/api/entitycore/types/entities/notebook.ts
@@ -81,7 +81,7 @@ export interface TAnalysisNotebookTemplateBase {
   description?: string | null;
   specifications?: TAnalysisNotebookTemplateSpecifications | null;
   scale: TAnalysisScaleDictionary;
-  exercise_id?: string | null;
+  assignment_id?: string | null;
 }
 
 export type NotebookFilter = Partial<
@@ -91,8 +91,8 @@ export type NotebookFilter = Partial<
     PaginationFilter &
     SharedFilter &
     IlikeSearchFilter & {
-      exercise_id?: string | null;
-      exercise_id__in?: string[] | null;
+      assignment_id?: string | null;
+      assignment_id__in?: string[] | null;
     }
 >;
 
@@ -105,5 +105,5 @@ export interface INotebook
     EntityCoreOwnership,
     TAnalysisNotebookTemplateBase {
   description: string;
-  exercise_id?: string | null;
+  assignment_id?: string | null;
 }

--- a/src/app/app/grading/launch/route.ts
+++ b/src/app/app/grading/launch/route.ts
@@ -53,7 +53,7 @@ export async function GET(request: NextRequest) {
   const q = request.nextUrl.searchParams;
   const launch = await resolveGradingLaunch({
     token: q.get('token'),
-    exercise_id: q.get('exercise_id'),
+    assignment_id: q.get('assignment_id'),
     virtual_lab_id: q.get('virtual_lab_id'),
     exp: q.get('exp'),
     sig: q.get('sig'),
@@ -64,7 +64,7 @@ export async function GET(request: NextRequest) {
 
   const { params, projects, cloud } = launch;
   log('info', '[grading-launch] launch URL verified', {
-    exercise_id: params.exercise_id,
+    assignment_id: params.assignment_id,
     virtual_lab_id: params.virtual_lab_id,
     exp: params.exp,
   });
@@ -84,11 +84,11 @@ export async function GET(request: NextRequest) {
   log('info', '[grading-launch] workspace resolved', {
     virtual_lab_id: params.virtual_lab_id,
     project_id: projectId,
-    exercise_id: params.exercise_id,
+    assignment_id: params.assignment_id,
   });
 
   const result = await startGradingNotebook({
-    exercise_id: params.exercise_id,
+    assignment_id: params.assignment_id,
     virtual_lab_id: params.virtual_lab_id,
     project_id: projectId,
     compute_cell: cloud,

--- a/src/features/grading/actions.ts
+++ b/src/features/grading/actions.ts
@@ -31,11 +31,11 @@ export async function launchGradingNotebook(input: LaunchGradingInput): Promise<
   log('info', '[grading-launch] action: launching', {
     virtual_lab_id: params.virtual_lab_id,
     project_id: input.project_id,
-    exercise_id: params.exercise_id,
+    assignment_id: params.assignment_id,
   });
 
   return startGradingNotebook({
-    exercise_id: params.exercise_id,
+    assignment_id: params.assignment_id,
     virtual_lab_id: params.virtual_lab_id,
     project_id: input.project_id,
     compute_cell: cloud,

--- a/src/features/grading/launch.test.ts
+++ b/src/features/grading/launch.test.ts
@@ -1,0 +1,79 @@
+import { createHmac } from 'node:crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import { verifyLaunchParams } from './launch';
+
+import type { RawParams } from './launch';
+
+const SECRET = 'test-hmac-secret';
+
+// Mirror grading-service's signing contract exactly: HMAC-SHA256 over
+// `token|assignment_id|virtual_lab_id|exp` (see grading-service app/launch.py / docs/system-design.md §1).
+function sign(p: { token: string; assignment_id: string; virtual_lab_id: string; exp: string }) {
+  return createHmac('sha256', SECRET)
+    .update(`${p.token}|${p.assignment_id}|${p.virtual_lab_id}|${p.exp}`, 'utf8')
+    .digest('hex');
+}
+
+function validRaw(overrides: Partial<Record<keyof RawParams, string>> = {}): RawParams {
+  const base = {
+    token: 'tok-123',
+    assignment_id: 'rc_circuit_lab',
+    virtual_lab_id: 'vlab-1',
+    exp: String(Math.floor(Date.now() / 1000) + 600),
+    ...overrides,
+  };
+  return { ...base, sig: sign(base) };
+}
+
+describe('verifyLaunchParams', () => {
+  it('accepts a correctly signed assignment_id launch', () => {
+    const result = verifyLaunchParams(validRaw(), SECRET);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.params.assignment_id).toBe('rc_circuit_lab');
+      expect(result.params.token).toBe('tok-123');
+    }
+  });
+
+  it('rejects a tampered signature as invalid', () => {
+    expect(verifyLaunchParams({ ...validRaw(), sig: 'deadbeef' }, SECRET)).toEqual({
+      ok: false,
+      reason: 'invalid',
+    });
+  });
+
+  it('rejects an altered field whose signature no longer matches', () => {
+    // Sign for one assignment, then swap the value while keeping the old sig.
+    const raw = { ...validRaw(), assignment_id: 'other_assignment' };
+    expect(verifyLaunchParams(raw, SECRET)).toEqual({ ok: false, reason: 'invalid' });
+  });
+
+  it('rejects the wrong secret as invalid', () => {
+    expect(verifyLaunchParams(validRaw(), 'different-secret')).toEqual({
+      ok: false,
+      reason: 'invalid',
+    });
+  });
+
+  it('reports an expired (but validly signed) launch as expired', () => {
+    const raw = validRaw({ exp: String(Math.floor(Date.now() / 1000) - 10) });
+    expect(verifyLaunchParams(raw, SECRET)).toEqual({ ok: false, reason: 'expired' });
+  });
+
+  it('rejects a non-numeric exp before HMAC as invalid', () => {
+    const raw = validRaw({ exp: 'abc' });
+    expect(verifyLaunchParams(raw, SECRET)).toEqual({ ok: false, reason: 'invalid' });
+  });
+
+  it('rejects a launch missing assignment_id (e.g. a legacy exercise_id-only URL)', () => {
+    const raw: RawParams = {
+      token: 'tok-123',
+      virtual_lab_id: 'vlab-1',
+      exp: String(Math.floor(Date.now() / 1000) + 600),
+      sig: 'anything',
+    };
+    expect(verifyLaunchParams(raw, SECRET)).toEqual({ ok: false, reason: 'invalid' });
+  });
+});

--- a/src/features/grading/launch.ts
+++ b/src/features/grading/launch.ts
@@ -26,7 +26,7 @@ export const LAUNCH_PATHS = {
 
 export interface VerifiedParams {
   token: string;
-  exercise_id: string;
+  assignment_id: string;
   virtual_lab_id: string;
   exp: string;
   sig: string;
@@ -43,7 +43,7 @@ export type StartResult = { ok: true; url: string } | { ok: false; reason: Launc
 // arrive in, so it's the single input contract for `resolveGradingLaunch`.
 export type RawParams = {
   token?: string | null;
-  exercise_id?: string | null;
+  assignment_id?: string | null;
   virtual_lab_id?: string | null;
   exp?: string | null;
   sig?: string | null;
@@ -54,11 +54,12 @@ type VerificationResult =
   | { ok: false; reason: 'invalid' | 'expired' };
 
 // Sign the raw `exp` string from the URL (not the re-stringified int) so a value like
-// "007" round-trips without breaking the signature.
-function verifyLaunchParams(raw: RawParams, secret: string): VerificationResult {
-  const { token, exercise_id, virtual_lab_id, exp, sig } = raw;
+// "007" round-trips without breaking the signature. Exported for unit testing — the HMAC contract
+// must stay byte-for-byte in sync with grading-service (`token|assignment_id|virtual_lab_id|exp`).
+export function verifyLaunchParams(raw: RawParams, secret: string): VerificationResult {
+  const { token, assignment_id, virtual_lab_id, exp, sig } = raw;
 
-  if (!token || !exercise_id || !virtual_lab_id || !exp || !sig) {
+  if (!token || !assignment_id || !virtual_lab_id || !exp || !sig) {
     return { ok: false, reason: 'invalid' };
   }
   if (!/^\d+$/.test(exp)) {
@@ -70,7 +71,7 @@ function verifyLaunchParams(raw: RawParams, secret: string): VerificationResult 
     return { ok: false, reason: 'expired' };
   }
 
-  const signingString = `${token}|${exercise_id}|${virtual_lab_id}|${exp}`;
+  const signingString = `${token}|${assignment_id}|${virtual_lab_id}|${exp}`;
   const expected = createHmac('sha256', secret).update(signingString, 'utf8').digest('hex');
   const a = Buffer.from(expected, 'utf8');
   const b = Buffer.from(sig, 'utf8');
@@ -78,7 +79,7 @@ function verifyLaunchParams(raw: RawParams, secret: string): VerificationResult 
     return { ok: false, reason: 'invalid' };
   }
 
-  return { ok: true, params: { token, exercise_id, virtual_lab_id, exp, sig } };
+  return { ok: true, params: { token, assignment_id, virtual_lab_id, exp, sig } };
 }
 
 // The 5 signed params as a plain string record, ready for `URLSearchParams` / redirect building.
@@ -86,7 +87,7 @@ function verifyLaunchParams(raw: RawParams, secret: string): VerificationResult 
 export function signedParams(p: VerifiedParams): Record<string, string> {
   return {
     token: p.token,
-    exercise_id: p.exercise_id,
+    assignment_id: p.assignment_id,
     virtual_lab_id: p.virtual_lab_id,
     exp: p.exp,
     sig: p.sig,
@@ -208,20 +209,20 @@ export async function resolveGradingLaunch(raw: RawParams): Promise<LaunchResolu
   };
 }
 
-// Looks up the analysis notebook for an exercise within a project, then starts it carrying the
+// Looks up the analysis notebook for an assignment within a project, then starts it carrying the
 // grading payload. Shared by the route's single-project auto-launch and the picker's action.
 export async function startGradingNotebook(args: {
-  exercise_id: string;
+  assignment_id: string;
   virtual_lab_id: string;
   project_id: string;
   compute_cell: string;
   token: string;
 }): Promise<StartResult> {
-  const { exercise_id, virtual_lab_id, project_id, compute_cell, token } = args;
+  const { assignment_id, virtual_lab_id, project_id, compute_cell, token } = args;
 
   const { data: notebooksResponse, error: notebooksError } = await tryCatch(
     getNotebooks({
-      filters: { exercise_id },
+      filters: { assignment_id },
       context: { virtualLabId: virtual_lab_id, projectId: project_id },
     })
   );
@@ -231,8 +232,8 @@ export async function startGradingNotebook(args: {
   }
   const notebookId = notebooksResponse?.data?.[0]?.id;
   if (!notebookId) {
-    log('info', '[grading-launch] no analysis notebook for exercise_id', {
-      exercise_id,
+    log('info', '[grading-launch] no analysis notebook for assignment_id', {
+      assignment_id,
       virtual_lab_id,
       project_id,
     });
@@ -249,7 +250,7 @@ export async function startGradingNotebook(args: {
       0,
       {
         token,
-        exercise_id,
+        assignment_id,
       }
     );
     if (!retval?.url) {

--- a/src/features/grading/project-picker.tsx
+++ b/src/features/grading/project-picker.tsx
@@ -42,7 +42,7 @@ export function ProjectPicker({ projects, virtualLabName, params }: Props) {
         <p className="text-primary-7">
           You have access to several projects in{' '}
           <span className="font-semibold">{virtualLabName}</span>. Pick the one to launch this
-          exercise in.
+          notebook in.
         </p>
       </div>
 
@@ -64,7 +64,7 @@ export function ProjectPicker({ projects, virtualLabName, params }: Props) {
         disabled={!projectId}
         onClick={onLaunch}
       >
-        Launch exercise
+        Launch notebook
       </Button>
 
       {error && (

--- a/src/i18n/en/grading.ts
+++ b/src/i18n/en/grading.ts
@@ -3,11 +3,11 @@ import type { LaunchErrorReason } from '@/features/grading/errors';
 export const messages: Record<LaunchErrorReason, { title: string; body: string }> = {
   invalid: {
     title: 'Invalid launch URL',
-    body: 'This launch link is not valid. Please re-launch the exercise from Moodle.',
+    body: 'This launch link is not valid. Please re-launch the assignment from Moodle.',
   },
   expired: {
     title: 'Launch link expired',
-    body: 'This launch link has expired. Please re-launch the exercise from Moodle.',
+    body: 'This launch link has expired. Please re-launch the assignment from Moodle.',
   },
   disabled: {
     title: 'Grading launch not configured',
@@ -15,11 +15,11 @@ export const messages: Record<LaunchErrorReason, { title: string; body: string }
   },
   'notebook-service-failed': {
     title: 'Could not start your notebook',
-    body: 'Something went wrong starting your notebook. Please try again, or re-launch the exercise from Moodle.',
+    body: 'Something went wrong starting your notebook. Please try again, or re-launch the assignment from Moodle.',
   },
   'insufficient-funds': {
     title: 'Not enough credits',
-    body: 'Your virtual lab does not have enough credits to launch this exercise. Top up your balance and try again.',
+    body: 'Your virtual lab does not have enough credits to launch this assignment. Top up your balance and try again.',
   },
   'accounting-error': {
     title: 'Could not reserve compute',
@@ -27,14 +27,14 @@ export const messages: Record<LaunchErrorReason, { title: string; body: string }
   },
   'jupyter-error': {
     title: 'Jupyter could not start',
-    body: 'The notebook environment failed to launch in Jupyter. Please try again, or re-launch the exercise from Moodle.',
+    body: 'The notebook environment failed to launch in Jupyter. Please try again, or re-launch the assignment from Moodle.',
   },
   'no-project-access': {
     title: 'No access to this course project',
     body: "You don't have access to a project in this virtual lab. Please contact your instructor.",
   },
   'notebook-not-found': {
-    title: 'Exercise not found',
-    body: "We couldn't find the notebook for this exercise. Please re-launch from Moodle or contact your instructor.",
+    title: 'Assignment not found',
+    body: "We couldn't find the notebook for this assignment. Please re-launch from Moodle or contact your instructor.",
   },
 };

--- a/src/services/notebooks/index.ts
+++ b/src/services/notebooks/index.ts
@@ -29,7 +29,7 @@ export interface NotebookStartInNumberedPodRequest {
 
 export interface NotebookGradingLaunch {
   token: string;
-  exercise_id: string;
+  assignment_id: string;
 }
 
 export interface EmptyNotebookStartRequest {
@@ -57,7 +57,7 @@ export interface EmptyNotebookStartRequest {
  * @param cloud : notebook service accepts 'cell_a', 'aws', 'cell_b', 'azure'
  * @param podNum : a user can have multiple pods, but normally simply 0
  * @param grading : optional grading-launch context. When set, the notebook service writes the
- *   per-exercise launch file in the spawned pod so the in-pod `obi-notebook` module can
+ *   per-assignment launch file in the spawned pod so the in-pod `obi-notebook` module can
  *   call /params and /grade against grading-service.
  */
 export async function startNotebook(

--- a/src/ui/segments/contribute/analysis-notebook-template/pipeline.ts
+++ b/src/ui/segments/contribute/analysis-notebook-template/pipeline.ts
@@ -56,7 +56,7 @@ export function useAnalysisNotebookTemplatePipeline({
           name: values.setup.name,
           description: values.setup.description,
           scale: values.setup.scale,
-          exercise_id: values.setup.exercise_id?.trim() || undefined,
+          assignment_id: values.setup.assignment_id?.trim() || undefined,
         },
       }),
     onSettled: invalidateNotebookQueries,

--- a/src/ui/segments/contribute/analysis-notebook-template/schema.ts
+++ b/src/ui/segments/contribute/analysis-notebook-template/schema.ts
@@ -19,7 +19,7 @@ export const AnalysisNotebookTemplateSchema = z.object({
       .string({ message: 'Description is required' })
       .nonempty({ message: 'Description is required' }),
     scale: ScaleEnum,
-    exercise_id: z.string().trim().optional(),
+    assignment_id: z.string().trim().optional(),
   }),
 
   assets: AnalysisNotebookTemplateAssetsSchema,

--- a/src/ui/segments/contribute/analysis-notebook-template/steps/setup.tsx
+++ b/src/ui/segments/contribute/analysis-notebook-template/steps/setup.tsx
@@ -78,11 +78,11 @@ export function Setup() {
         />
       </Form.Item>
 
-      <Form.Item name={['setup', 'exercise_id']} label={renderLabel('Exercise ID', 'main')}>
+      <Form.Item name={['setup', 'assignment_id']} label={renderLabel('Assignment ID', 'main')}>
         <Input
           className="h-12 rounded-full placeholder:text-sm"
           size="large"
-          placeholder="Optional — exercise ID this notebook grades"
+          placeholder="Optional — assignment ID this notebook grades"
         />
       </Form.Item>
     </div>


### PR DESCRIPTION
## Context

`grading-service` migrated from **LTI 1.1** to **LTI 1.3 Advantage + AGS** ([grading-service#4](https://github.com/openbraininstitute/grading-service/pull/4)). A Moodle activity now is an **assignment** (one notebook holding one or more independently-graded exercises), so the signed web-launch handed off to the Core Web app now carries **`assignment_id`** instead of `exercise_id`.

The Core Web app never speaks LTI itself — it verifies the HMAC-signed handoff URL and spawns the notebook pod. Grade write-back stays in-pod (`obi-notebook`), so this is an identifier rename, not new grading logic.

## Changes — `exercise_id` → `assignment_id` end to end

**Launch handoff**
- HMAC signing string is now `token|assignment_id|virtual_lab_id|exp` (byte-for-byte matching grading-service), the parsed query param, and the notebook-service `grading` block key.

**Notebook-template lookup + authoring**
- `getNotebooks` filter, `INotebook` / `NotebookFilter` types (`assignment_id` / `assignment_id__in`), the create payload, and the authoring form field (now **"Assignment ID"**).

**Copy**
- User-facing error/copy strings; the project-picker button now reads **"Launch notebook"** (it opens a notebook for the assignment).

**Tests**
- New `src/features/grading/launch.test.ts` pins the HMAC verification contract: a correctly-signed `assignment_id` launch passes; tampered / altered / wrong-secret / expired / non-numeric / missing-field are rejected (the last also covers a legacy `exercise_id`-only URL now being rejected).
