### PR TITLE
fix: restore data detail redirect and tighten explore scroll layout

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -166,6 +166,11 @@ const config = {
         permanent: false,
       },
       {
+        source: '/app/virtual-lab/:vlabId/:projectId/data/view/:type/:id',
+        destination: '/app/virtual-lab/:vlabId/:projectId/data/view/:type/:id/overview',
+        permanent: false,
+      },
+      {
         source: '/static/coming-soon/index.html',
         destination: '/',
         permanent: false,

--- a/src/styles/tailwind-preflight.css
+++ b/src/styles/tailwind-preflight.css
@@ -16,6 +16,7 @@ Based on https://unpkg.com/tailwindcss@3.2.3/src/css/preflight.css
   /* 2 */
   border-style: solid;
   /* 2 */
+  /* biome-ignore lint/correctness/noUnknownFunction: Tailwind CSS theme() helper */
   border-color: theme("borderColor.DEFAULT", currentColor);
   /* 2 */
 }
@@ -60,8 +61,10 @@ html {
     "Noto Color Emoji"
   );
   /* 4 */
+  /* biome-ignore lint/correctness/noUnknownFunction: Tailwind CSS theme() helper */
   font-feature-settings: theme("fontFamily.sans[1].fontFeatureSettings", normal);
   /* 5 */
+  overscroll-behavior-y: none;
 }
 
 /*
@@ -74,6 +77,7 @@ body {
   /* 1 */
   line-height: inherit;
   /* 2 */
+  overscroll-behavior-y: none;
 }
 
 /*

--- a/src/ui/segments/explore/circuit/index.tsx
+++ b/src/ui/segments/explore/circuit/index.tsx
@@ -384,7 +384,7 @@ export function BrowseCircuit({
         id="circuit-table-container"
         data-testid="circuit-table-container"
         className={cn(
-          'h-full max-h-[calc(100vh-11.8rem)] min-h-0 w-full min-w-0 overflow-hidden rounded-2xl [grid-area:body]',
+          'h-full max-h-[calc(100vh-10.8rem)] min-h-0 w-full min-w-0 overflow-hidden rounded-2xl [grid-area:body]',
           classNames?.container
         )}
       >
@@ -435,7 +435,7 @@ export function BrowseCircuit({
       <div
         id="mini-detail-view-container"
         className={cn(
-          'h-full max-h-[calc(100vh-11.8rem)] w-full min-w-0',
+          'h-full max-h-[calc(100vh-10.8rem)] w-full min-w-0',
           '[grid-area:mini-view]',
           {
             hidden: !mdv,

--- a/src/ui/segments/explore/default-content.tsx
+++ b/src/ui/segments/explore/default-content.tsx
@@ -22,7 +22,7 @@ export function DefaultContent({ children, dataKey }: Props) {
         id="explore-left-menu"
         data-testid="explore-left-menu"
         className={cn(
-          'h-full max-h-[calc(100vh-11.8rem)] px-1 min-h-0 w-full overflow-hidden [grid-area:aside]',
+          'h-full max-h-[calc(100vh-10.8rem)] px-1 min-h-0 w-full overflow-hidden [grid-area:aside]',
           { hidden: mdv }
         )}
       >


### PR DESCRIPTION
- re-add the next.config redirect dropped in #1786 so section-less data/view URLs resolve to overview again,
- adjust explore panel heights plus overscroll behavior to reduce layout bounce

| staging | this PR |
|---------|--------|
| https://github.com/user-attachments/assets/49777ab5-b2c5-4459-81db-fb6338a78837 | https://github.com/user-attachments/assets/ff2c4ca0-78ae-459b-8d4a-642cde218a92 |

