### PR TITLE
feat(scan-config): refresh project balance on task launch and terminal status

### DIFF
--- a/src/features/scan-config/components/shared/task-config-selection-list.tsx
+++ b/src/features/scan-config/components/shared/task-config-selection-list.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import { TaskConfigSelectionCard } from '@/features/scan-config/components/shared/task-config-selection-card';
 import { TASK_STATUS_QUERY_KEY_HEAD } from '@/features/task-runner';
 import { useTaskConfigExecution } from '@/features/task-runner/hooks/queries';
+import { useBalanceRefreshOnTaskCompletion } from '@/features/task-runner/hooks/use-balance-refresh';
 import { cn } from '@/utils/css-class';
 
 import type {
@@ -160,6 +161,10 @@ function TaskConfigSelectionCardWithStatus<TMeta extends Record<string, unknown>
     pausePolling: pauseStatusPolling,
     fallbackExecution,
   });
+
+  // Live polled status only (not the fallback): fallbackExecution is initial paint fed
+  // back from this same query via onExecutionLoad.
+  useBalanceRefreshOnTaskCompletion({ status: execution?.status, context });
 
   useEffect(() => {
     if (execution !== undefined) {

--- a/src/features/scan-config/use-cases/build/results.tsx
+++ b/src/features/scan-config/use-cases/build/results.tsx
@@ -12,6 +12,7 @@ import { TaskLaunchButton } from '@/features/scan-config/components/shared/task-
 import { ActivityCustomFileRenderer, type TActivityCustomFile } from '@/features/scan-config/types';
 import { InOutFiles } from '@/features/scan-config/use-cases/build/in-out-files';
 import { TaskConfigurationViewer, TaskLogsViewer } from '@/features/task-logs-stream';
+import { isTerminalActivityStatus } from '@/features/task-runner';
 import { useTaskLaunchMutation } from '@/features/task-runner/hooks/mutations';
 import { useTaskRunner } from '@/features/task-runner/hooks/queries';
 import { useWorkspace } from '@/ui/hooks/use-workspace';
@@ -82,10 +83,7 @@ export function BuildTab({
   const activeExecutionJobId = activeConfigExecution?.execution_id ?? undefined;
   const taskLogsViewerEnabled = !!resolvedActiveConfig && !!activeExecutionJobId;
   const taskLogsShouldReadSnapshot =
-    !!activeConfigExecStatus &&
-    [ActivityStatus.CANCELLED, ActivityStatus.DONE, ActivityStatus.ERROR].includes(
-      activeConfigExecStatus
-    );
+    !!activeConfigExecStatus && isTerminalActivityStatus(activeConfigExecStatus);
 
   const onActiveConfigChange = useCallback((config: ITaskConfig<TBuildCampaignMeta>) => {
     setActiveConfig(config);

--- a/src/features/scan-config/use-cases/extraction/results.tsx
+++ b/src/features/scan-config/use-cases/extraction/results.tsx
@@ -13,6 +13,7 @@ import { TaskLaunchButton } from '@/features/scan-config/components/shared/task-
 import { ActivityCustomFileRenderer, type TActivityCustomFile } from '@/features/scan-config/types';
 import { InOutFiles } from '@/features/scan-config/use-cases/extraction/in-out-files';
 import { TaskConfigurationViewer, TaskLogsViewer } from '@/features/task-logs-stream';
+import { isTerminalActivityStatus } from '@/features/task-runner';
 import { useTaskLaunchMutation } from '@/features/task-runner/hooks/mutations';
 import { useTaskRunner } from '@/features/task-runner/hooks/queries';
 import { useWorkspace } from '@/ui/hooks/use-workspace';
@@ -81,10 +82,7 @@ export function ExtractionTab({
   const activeExecutionJobId = activeConfigExecution?.execution_id ?? undefined;
   const taskLogsViewerEnabled = !!resolvedActiveConfig && !!activeExecutionJobId;
   const taskLogsShouldReadSnapshot =
-    !!activeConfigExecStatus &&
-    [ActivityStatus.CANCELLED, ActivityStatus.DONE, ActivityStatus.ERROR].includes(
-      activeConfigExecStatus
-    );
+    !!activeConfigExecStatus && isTerminalActivityStatus(activeConfigExecStatus);
 
   const onActiveConfigChange = useCallback((config: ITaskConfig<TTaskConfigMeta>) => {
     setActiveConfig(config);

--- a/src/features/scan-config/use-cases/simulations/results.tsx
+++ b/src/features/scan-config/use-cases/simulations/results.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { get } from 'es-toolkit/compat';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { match } from 'ts-pattern';
@@ -36,6 +36,8 @@ import { ActivityCustomFileRenderer } from '@/features/scan-config/types';
 import { SimulationsResultsUiAdapter } from '@/features/scan-config/use-cases/simulations/ui-adapter';
 import { SimulationReportsProvider } from '@/features/sonata-viewer/simulation-reports-context';
 import { TaskConfigurationViewer, TaskLogsViewer } from '@/features/task-logs-stream';
+import { isTerminalActivityStatus } from '@/features/task-runner';
+import { invalidateProjectBalance } from '@/features/task-runner/hooks/use-balance-refresh';
 import { messages } from '@/i18n/en/simulation';
 import { runSimulationBatch } from '@/services/small-scale-simulator/circuit';
 import { MessageType } from '@/services/small-scale-simulator/types';
@@ -69,6 +71,7 @@ export default function SimulationsTab({
   taskTypeBindings,
 }: SimulationTabProps) {
   const notification = useAppNotification();
+  const queryClient = useQueryClient();
   const context = useMemo(() => ({ virtualLabId, projectId }), [projectId, virtualLabId]);
 
   const { data: simulations = [], isLoading: simulationsLoading } = useQuery({
@@ -165,10 +168,7 @@ export default function SimulationsTab({
     : undefined;
   const taskLogsViewerEnabled = !!activeSimulation && !!activeJobId;
   const taskLogsShouldReadSnapshot =
-    !!activeSimulationExecStatus &&
-    [ActivityStatus.CANCELLED, ActivityStatus.DONE, ActivityStatus.ERROR].includes(
-      activeSimulationExecStatus
-    );
+    !!activeSimulationExecStatus && isTerminalActivityStatus(activeSimulationExecStatus);
 
   const onActiveSimulationChange = useCallback((simulation: ISimulation) => {
     setActiveSimulation(simulation);
@@ -284,6 +284,10 @@ export default function SimulationsTab({
         }
       }
     }
+    if (nSubmissions > 0) {
+      // Launching reserves credits, so refetch the balance.
+      invalidateProjectBalance({ queryClient, context });
+    }
     setSelectedSimulationIds([]);
     setSimRequestInProgress(false);
     if (lowFundsError) {
@@ -299,8 +303,6 @@ export default function SimulationsTab({
         duration: 10,
       });
     }
-
-    setSelectedSimulationIds([]);
   };
 
   // TODO Refactor
@@ -315,6 +317,8 @@ export default function SimulationsTab({
         ctx: { virtualLabId, projectId },
         simulationIds: simIds,
         onInit: () => {
+          // Earliest signal the batch was accepted — credits are reserved from here.
+          invalidateProjectBalance({ queryClient, context });
           simIds.forEach((simId) => {
             setSimulationStatus(simId, ActivityStatus.PENDING);
           });

--- a/src/features/scan-config/use-cases/simulations/ui-adapter.tsx
+++ b/src/features/scan-config/use-cases/simulations/ui-adapter.tsx
@@ -31,7 +31,7 @@ import {
   TASK_STATUS_POLL_INTERVAL_MS,
   TASK_STATUS_QUERY_KEY_HEAD,
 } from '@/features/task-runner/constants';
-import { keyBuilder } from '@/ui/use-query-keys/workspace';
+import { useBalanceRefreshOnTaskCompletion } from '@/features/task-runner/hooks/use-balance-refresh';
 import { cn } from '@/utils/css-class';
 
 import type { CSSProperties, ReactNode } from 'react';
@@ -191,22 +191,14 @@ function SimulationListItem({
   const statusLoading = isLoading && !execStatus;
   const color = executionStatusColorMap[execStatus ?? ActivityStatus.CREATED];
 
+  useBalanceRefreshOnTaskCompletion({ status: execStatus, context });
+
   useEffect(() => {
     if (execStatus) {
       queryClient.invalidateQueries({
         queryKey: [TASK_STATUS_QUERY_KEY_HEAD, { campaignId, context }],
       });
       onStatusLoad(simulation.id, execStatus);
-      if (execStatus === ActivityStatus.DONE || execStatus === ActivityStatus.ERROR) {
-        queryClient.invalidateQueries({
-          queryKey: keyBuilder.accounting({
-            virtualLabId: context.virtualLabId,
-          }),
-        });
-        queryClient.invalidateQueries({
-          queryKey: keyBuilder.wallet({ ...context }),
-        });
-      }
     }
   }, [execStatus, onStatusLoad, simulation.id, campaignId, context, queryClient.invalidateQueries]);
 

--- a/src/features/scan-config/use-cases/skeletonization/results.tsx
+++ b/src/features/scan-config/use-cases/skeletonization/results.tsx
@@ -16,6 +16,7 @@ import {
   type TActivityCustomFile,
 } from '@/features/scan-config/types';
 import { TaskConfigurationViewer, TaskLogsViewer } from '@/features/task-logs-stream';
+import { isTerminalActivityStatus } from '@/features/task-runner';
 import { useTaskLaunchMutation } from '@/features/task-runner/hooks/mutations';
 import { useTaskRunner } from '@/features/task-runner/hooks/queries';
 import { messages as textMessages } from '@/i18n/en/scan-config';
@@ -93,10 +94,7 @@ export function SkeletonizationTab({
   const activeExecutionJobId = activeConfigExecution?.execution_id ?? undefined;
   const taskLogsViewerEnabled = !!resolvedActiveConfig && !!activeExecutionJobId;
   const taskLogsShouldReadSnapshot =
-    !!activeConfigExecStatus &&
-    [ActivityStatus.CANCELLED, ActivityStatus.DONE, ActivityStatus.ERROR].includes(
-      activeConfigExecStatus
-    );
+    !!activeConfigExecStatus && isTerminalActivityStatus(activeConfigExecStatus);
 
   const onActiveConfigChange = useCallback(
     (config: ITaskConfig<TSkeletonizationTaskConfigMeta>) => {

--- a/src/features/task-runner/hooks/mutations.ts
+++ b/src/features/task-runner/hooks/mutations.ts
@@ -12,6 +12,7 @@ import { getErrorMessage } from '@/utils/error';
 import { log } from '@/utils/logger';
 
 import { TASK_ACTIVITIES_QUERY_KEY_HEAD, TASK_RUNNER_QUERY_KEY_HEAD } from '../constants';
+import { invalidateProjectBalance } from './use-balance-refresh';
 
 import type { QueryClient } from '@tanstack/react-query';
 import type { TTaskActivityType } from '@/api/entitycore/types/entities/task-activity';
@@ -89,6 +90,7 @@ export function useTaskLaunchMutation({
       const configIds = Array.isArray(configIdsOrId) ? configIdsOrId : [configIdsOrId];
 
       const runLaunches = async () => {
+        let launched = false;
         for (const configId of configIds) {
           try {
             const executionId = await runTask({
@@ -96,6 +98,7 @@ export function useTaskLaunchMutation({
               task_type: obiOneTaskType,
               config_id: configId,
             });
+            launched = true;
             log('info', `${logTopic} for ${configId} launched successfully, execution ID`, {
               executionId,
             });
@@ -104,11 +107,15 @@ export function useTaskLaunchMutation({
           }
         }
 
-        await invalidateTaskExecutionActivities({
-          queryClient,
-          context,
-          executionActivityType,
-        });
+        await Promise.all([
+          invalidateTaskExecutionActivities({
+            queryClient,
+            context,
+            executionActivityType,
+          }),
+          // Launching reserves credits, so also refetch the balance — unless nothing launched.
+          launched ? invalidateProjectBalance({ queryClient, context }) : undefined,
+        ]);
       };
 
       if (requiresConsent) {

--- a/src/features/task-runner/hooks/use-balance-refresh.test.tsx
+++ b/src/features/task-runner/hooks/use-balance-refresh.test.tsx
@@ -1,0 +1,109 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ActivityStatus } from '@/api/entitycore/types/entities/task-activity';
+import { keyBuilder } from '@/ui/use-query-keys/workspace';
+
+import { invalidateProjectBalance, useBalanceRefreshOnTaskCompletion } from './use-balance-refresh';
+
+import type { ReactNode } from 'react';
+import type { TActivityStatus } from '@/api/entitycore/types/entities/task-activity';
+
+const context = { virtualLabId: 'vlab-1', projectId: 'proj-1' };
+
+function setup(initialStatus: TActivityStatus | undefined) {
+  const queryClient = new QueryClient();
+  const spy = vi.spyOn(queryClient, 'invalidateQueries');
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  const { rerender } = renderHook(
+    ({ status }: { status: TActivityStatus | undefined }) =>
+      useBalanceRefreshOnTaskCompletion({ status, context }),
+    { wrapper, initialProps: { status: initialStatus } }
+  );
+  return { spy, rerender };
+}
+
+function expectBalanceInvalidated(spy: ReturnType<typeof vi.spyOn>) {
+  expect(spy).toHaveBeenCalledTimes(2);
+  expect(spy).toHaveBeenCalledWith(
+    { queryKey: keyBuilder.accounting({ virtualLabId: context.virtualLabId }) },
+    { cancelRefetch: false }
+  );
+  expect(spy).toHaveBeenCalledWith(
+    { queryKey: keyBuilder.wallet(context) },
+    { cancelRefetch: false }
+  );
+}
+
+describe('invalidateProjectBalance', () => {
+  it('invalidates both the accounting and wallet keys', async () => {
+    const queryClient = new QueryClient();
+    const spy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    await invalidateProjectBalance({ queryClient, context });
+
+    expectBalanceInvalidated(spy);
+  });
+
+  it('builds keys from explicit fields even when context carries extra route params', async () => {
+    const queryClient = new QueryClient();
+    const spy = vi.spyOn(queryClient, 'invalidateQueries');
+    const routeContext = { ...context, campaignId: 'extra-param' } as typeof context;
+
+    await invalidateProjectBalance({ queryClient, context: routeContext });
+
+    expect(spy).toHaveBeenCalledWith(
+      { queryKey: keyBuilder.wallet(context) },
+      { cancelRefetch: false }
+    );
+  });
+});
+
+describe('useBalanceRefreshOnTaskCompletion', () => {
+  it('does not fire when the first observed status is already terminal', () => {
+    const { spy } = setup(ActivityStatus.DONE);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when status loads terminal after being unknown', () => {
+    const { spy, rerender } = setup(undefined);
+    rerender({ status: ActivityStatus.DONE });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [ActivityStatus.PENDING, ActivityStatus.DONE],
+    [ActivityStatus.RUNNING, ActivityStatus.ERROR],
+    [ActivityStatus.RUNNING, ActivityStatus.CANCELLED],
+    [ActivityStatus.CREATED, ActivityStatus.ERROR],
+  ])('fires once (both keys) on %s → %s', (from, to) => {
+    const { spy, rerender } = setup(from);
+    rerender({ status: to });
+    expectBalanceInvalidated(spy);
+  });
+
+  it('does not fire on active → active transitions', () => {
+    const { spy, rerender } = setup(ActivityStatus.PENDING);
+    rerender({ status: ActivityStatus.RUNNING });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does not fire again on re-renders with an unchanged status', () => {
+    const { spy, rerender } = setup(ActivityStatus.RUNNING);
+    rerender({ status: ActivityStatus.DONE });
+    rerender({ status: ActivityStatus.DONE });
+    rerender({ status: ActivityStatus.DONE });
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not fire on terminal → terminal changes', () => {
+    const { spy, rerender } = setup(ActivityStatus.RUNNING);
+    rerender({ status: ActivityStatus.ERROR });
+    spy.mockClear();
+    rerender({ status: ActivityStatus.DONE });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/task-runner/hooks/use-balance-refresh.ts
+++ b/src/features/task-runner/hooks/use-balance-refresh.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+import { usePrevious } from '@/hooks/hooks';
+import { keyBuilder } from '@/ui/use-query-keys/workspace';
+
+import { isTerminalActivityStatus } from '../status';
+
+import type { QueryClient } from '@tanstack/react-query';
+import type { TActivityStatus } from '@/api/entitycore/types/entities/task-activity';
+import type { WorkspaceContext } from '@/types/common';
+
+/**
+ * Refetches the project balance: virtual-lab accounting balance + project wallet.
+ * Both keys are needed — `BalanceCard` reads `accounting`, the top-nav `Wallet` reads `wallet`.
+ */
+export function invalidateProjectBalance({
+  queryClient,
+  context,
+}: {
+  queryClient: QueryClient;
+  context: WorkspaceContext;
+}) {
+  // Build keys from explicit fields: `context` may carry extra route params, and extra
+  // properties in the filter key would prevent React Query's partial matching.
+  // `cancelRefetch: false` lets concurrent calls (several task rows finishing on the same
+  // poll tick) share one in-flight refetch instead of cancel-restarting it.
+  const { virtualLabId, projectId } = context;
+  return Promise.all([
+    queryClient.invalidateQueries(
+      { queryKey: keyBuilder.accounting({ virtualLabId }) },
+      { cancelRefetch: false }
+    ),
+    queryClient.invalidateQueries(
+      { queryKey: keyBuilder.wallet({ virtualLabId, projectId }) },
+      { cancelRefetch: false }
+    ),
+  ]);
+}
+
+/**
+ * Refetches the project balance once when a task transitions in-session from a non-terminal
+ * status into a terminal one (DONE releases the reservation into a charge; ERROR/CANCELLED
+ * return it to the balance). Does not fire when a status first loads already terminal, so
+ * revisiting a page of finished tasks doesn't trigger refetches.
+ */
+export function useBalanceRefreshOnTaskCompletion({
+  status,
+  context,
+}: {
+  status: TActivityStatus | undefined;
+  context: WorkspaceContext;
+}) {
+  const queryClient = useQueryClient();
+  const prevStatus = usePrevious(status);
+
+  useEffect(() => {
+    const wasActive = prevStatus !== undefined && !isTerminalActivityStatus(prevStatus);
+    if (wasActive && status && isTerminalActivityStatus(status)) {
+      invalidateProjectBalance({ queryClient, context });
+    }
+  }, [prevStatus, status, context, queryClient]);
+}

--- a/src/features/task-runner/status.ts
+++ b/src/features/task-runner/status.ts
@@ -1,5 +1,18 @@
+import { ActivityStatus } from '@/api/entitycore/types/entities/task-activity';
+
 import type { ITaskActivity } from '@/api/entitycore/types/entities/task-activity';
 import type { TActivityStatus } from '@/api/entitycore/types/shared/activity';
+
+const TERMINAL_ACTIVITY_STATUSES: readonly TActivityStatus[] = [
+  ActivityStatus.DONE,
+  ActivityStatus.ERROR,
+  ActivityStatus.CANCELLED,
+];
+
+/** Terminal = the run is finished and its status will not change anymore. */
+export function isTerminalActivityStatus(status: TActivityStatus): boolean {
+  return TERMINAL_ACTIVITY_STATUSES.includes(status);
+}
 
 function getExecutionsForEntity(executions: ITaskActivity[], entityId: string): ITaskActivity[] {
   return executions


### PR DESCRIPTION
## Problem

When a scan-config task is launched, the accounting service reserves credits; when the task ends in `error`/`cancelled`, the reservation returns to the project balance. The UI mostly didn't reflect this:

- The generic task-runner path (build / extraction / skeletonization tabs and task-system simulations) never refreshed the balance — not on launch, not on completion.
- Only the legacy simulations adapter refreshed it, on `DONE`/`ERROR` only, and with no transition detection — it re-fired the refetch for already-finished simulations on every page visit.

## Changes

- New `src/features/task-runner/hooks/use-balance-refresh.ts`:
  - `invalidateProjectBalance` — invalidates both balance keys (`keyBuilder.accounting` for the balance card, `keyBuilder.wallet` for the top-nav wallet). Uses `cancelRefetch: false` so several task rows finishing on the same 10s poll tick share one in-flight refetch instead of cancel-restarting it.
  - `useBalanceRefreshOnTaskCompletion` — fires exactly once when a task transitions in-session from an active status to a terminal one (`done`/`error`/`cancelled`); deliberately silent when a status first loads already terminal, so revisiting finished campaigns no longer triggers refetches.
- Launch-time refresh (reservation leaves the balance): once per batch in `useTaskLaunchMutation` (covers build/extraction/skeletonization) and in both simulation launch paths (`runViaLaunchSystem` and the legacy `runSimulationBatch` `onInit`).
- Completion-time refresh (reservation returns on error/cancel): the hook is mounted in the two per-row status observers — `TaskConfigSelectionCardWithStatus` (all three generic tabs) and `SimulationListItem` (both simulation flows, replacing the old inline block).
- Hoisted the terminal-status set into `task-runner/status.ts` as `isTerminalActivityStatus` and deduped the inline `[CANCELLED, DONE, ERROR].includes(...)` copies in the build/extraction/skeletonization tabs.

## Testing

- New Vitest suite for the helper and every transition case (fires on active→terminal, silent on already-terminal mount, active→active, terminal→terminal, unchanged re-renders).
- Full unit suite green; Biome clean; no new `tsc` errors in changed files.
- Manual check worth doing on a real backend: launch a task and watch the wallet refetch — the API's `ProjectBalance.reservation` field is fetched but not rendered, so the visible number only moves if the backend deducts reservations from `balance`.