### PR TITLE
glb mesh upload support

### DIFF
--- a/src/api/one/em-cell-mesh.ts
+++ b/src/api/one/em-cell-mesh.ts
@@ -1,11 +1,11 @@
 import { obioneApi } from '@/api/one/utils';
 
-export type OBJResolution = {
+export type MeshResolution = {
   isValid: boolean;
   buffer: ArrayBuffer;
 };
 
-export async function resolveOBJFile(file: File): Promise<OBJResolution> {
+export async function resolveMeshFile(file: File): Promise<MeshResolution> {
   const api = await obioneApi();
   const formData = new FormData();
   formData.append('file', file, file.name);

--- a/src/i18n/en/upload.ts
+++ b/src/i18n/en/upload.ts
@@ -3,6 +3,8 @@ export const messages = {
     'The nwb file $$ could not be validated by our tool. Please ensure it is a valid .nwb file.',
   ResolveNeuronFileFailed:
     'The neuron file $$ could not be validated by our tool. Please ensure it is a valid .swc, .asc, or .h5 file loadable by neurom.',
+  ResolveMeshFileFailed:
+    'The mesh file $$ could not be validated by our tool. Please ensure it is a valid .obj or .glb file.',
   FileSizeExceeded: 'File "$$" exceeds the maximum size of $$$.',
   FileNotAccepted: 'File "$$" is not an accepted file type.',
   MaxFilesExceeded: 'You can only upload a maximum of $$ files.',

--- a/src/i18n/en/upload.ts
+++ b/src/i18n/en/upload.ts
@@ -1,10 +1,10 @@
 export const messages = {
   ResolveNWBFileFailed:
-    'The nwb file $$ could not be validated by our tool. Please ensure it is a valid .nwb file.',
+    'The nwb file $$ could not be validated. Please ensure it is a valid .nwb file.',
   ResolveNeuronFileFailed:
-    'The neuron file $$ could not be validated by our tool. Please ensure it is a valid .swc, .asc, or .h5 file loadable by neurom.',
+    'The neuron file $$ could not be validated. Please ensure it is a valid .swc, .asc, or .h5 file loadable by neurom.',
   ResolveMeshFileFailed:
-    'The mesh file $$ could not be validated by our tool. Please ensure it is a valid .obj or .glb file.',
+    'The mesh file $$ could not be validated. Please ensure it is a valid .obj or .glb file.',
   FileSizeExceeded: 'File "$$" exceeds the maximum size of $$$.',
   FileNotAccepted: 'File "$$" is not an accepted file type.',
   MaxFilesExceeded: 'You can only upload a maximum of $$ files.',

--- a/src/ui/segments/contribute/em-cell-mesh/pipeline.ts
+++ b/src/ui/segments/contribute/em-cell-mesh/pipeline.ts
@@ -13,7 +13,7 @@ import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity
 import type { ExtendedEntityTypeQueryKey } from '@/ui/hooks/use-query-extended-entity-type';
 import { useWorkspace } from '@/ui/hooks/use-workspace';
 import { EM_CELL_MESH_PROGRESS_STEPS } from '@/ui/segments/contribute/em-cell-mesh/config';
-import type { TEMCellMeshForm } from '@/ui/segments/contribute/em-cell-mesh/schema';
+import { getEMCellMeshMimeType, type TEMCellMeshForm } from '@/ui/segments/contribute/em-cell-mesh/schema';
 import { ContributionSchema } from '@/ui/segments/contribute/shared/schemas';
 import type {
   IMutationKeyConfig,
@@ -77,7 +77,7 @@ export function useEMCellMeshPipeline({
         entityType: ExtendedEntitiesTypeDict.EMCellMesh,
         entityId,
         fileName: file.name,
-        mimeType: 'application/obj',
+        mimeType: getEMCellMeshMimeType(file) ?? file.type,
         payload: file,
         label: 'cell_surface_mesh' as Parameters<typeof createAsset>[0]['label'],
       });
@@ -128,10 +128,10 @@ export function useEMCellMeshPipeline({
     createEntity: async ({ values }: { values: TEMCellMeshForm }) => {
       const cellMorphology = await createEMCellMeshAsync.mutateAsync(values);
 
-      if (values.assets?.obj) {
+      if (values.assets?.mesh) {
         await createAssetsAsync.mutateAsync({
           entityId: cellMorphology.id,
-          file: values.assets.obj,
+          file: values.assets.mesh,
         });
       }
 

--- a/src/ui/segments/contribute/em-cell-mesh/schema.ts
+++ b/src/ui/segments/contribute/em-cell-mesh/schema.ts
@@ -6,7 +6,6 @@ import {
 } from '@/api/entitycore/types/entities/em-cell-mesh';
 import {
   ContributionArraySchema,
-  createFileSchema,
   LicenseIdSchema,
   SubjectIdSchema,
 } from '@/ui/segments/contribute/shared/schemas';
@@ -51,9 +50,21 @@ export const MTypeClassIdSchema = z.uuid().nonempty({
 
 export const EM_CELL_MESH_FILE_TYPES = [
   { type: 'obj', extension: 'obj', mimeType: 'application/obj' },
+  { type: 'glb', extension: 'glb', mimeType: 'model/gltf-binary' },
 ] as const;
 
-export const EMCellMeshAssetsSchema = createFileSchema(['obj']);
+function getEMCellMeshFileType(file: File) {
+  const ext = file.name.split('.').pop()?.toLowerCase();
+  return EM_CELL_MESH_FILE_TYPES.find(
+    (f) => f.extension === ext || file.type.toLowerCase() === f.mimeType.toLowerCase()
+  );
+}
+
+export const EMCellMeshAssetsSchema = z.object({
+  mesh: z.instanceof(File).refine((file) => Boolean(getEMCellMeshFileType(file)), {
+    error: 'File must be a .obj or .glb file',
+  }),
+});
 
 export const EMCellMeshSchema = z.object({
   setup: SetupSchema,
@@ -67,9 +78,5 @@ export const EMCellMeshSchema = z.object({
 export type TEMCellMeshForm = z.infer<typeof EMCellMeshSchema>;
 
 export function getEMCellMeshMimeType(file: File): string | undefined {
-  const ext = file.name.split('.').pop()?.toLowerCase();
-  const fileType = EM_CELL_MESH_FILE_TYPES.find(
-    (f) => f.extension === ext || file.type === f.mimeType
-  );
-  return fileType?.mimeType;
+  return getEMCellMeshFileType(file)?.mimeType;
 }

--- a/src/ui/segments/contribute/em-cell-mesh/steps/asset-upload.tsx
+++ b/src/ui/segments/contribute/em-cell-mesh/steps/asset-upload.tsx
@@ -2,7 +2,7 @@
 
 import { Form } from 'antd';
 
-import { resolveOBJFile } from '@/api/one/em-cell-mesh';
+import { resolveMeshFile } from '@/api/one/em-cell-mesh';
 import { tryCatch } from '@/api/utils';
 import { messages } from '@/i18n/en/upload';
 import { AssetUpload } from '@/ui/segments/contribute/shared/components/asset-upload';
@@ -32,24 +32,24 @@ function HiddenSentinel({ value }: { value?: unknown; onChange?: (val: unknown) 
 export function EMAssetUpload({
   maxFiles = 1,
   maxSize = 500 * 1024 * 1024,
-  accept = ['application/obj', '.obj'],
+  accept = ['application/obj', '.obj', 'model/gltf-binary', '.glb'],
   multiple = true,
   className,
   onFilesChange,
 }: IAssetUploadProps) {
   const form = Form.useFormInstance();
 
-  const validateOBJFile = async (file: File): Promise<string | null> => {
-    const { data: resolution, error } = await tryCatch(resolveOBJFile(file));
+  const validateMeshFile = async (file: File): Promise<string | null> => {
+    const { data: resolution, error } = await tryCatch(resolveMeshFile(file));
     if (error || !resolution?.isValid) {
-      return messages.ResolveOBJFileFailed.replace('$$', file.name);
+      return messages.ResolveMeshFileFailed.replace('$$', file.name);
     }
     return null;
   };
 
   return (
     <>
-      <Form.Item name={['assets', 'obj']} noStyle>
+      <Form.Item name={['assets', 'mesh']} noStyle>
         <HiddenSentinel />
       </Form.Item>
 
@@ -59,14 +59,14 @@ export function EMAssetUpload({
         accept={accept}
         multiple={multiple}
         className={className}
-        acceptLabel="obj"
-        onValidateFile={validateOBJFile}
+        acceptLabel="obj, glb"
+        onValidateFile={validateMeshFile}
         onFilesChange={(files) => {
           const file = files[0]?.file instanceof File ? (files[0].file as File) : undefined;
 
           // Defer form update out of the current render/state-update cycle.
           setTimeout(() => {
-            form.setFieldsValue({ assets: { obj: file } });
+            form.setFieldsValue({ assets: { mesh: file } });
           }, 0);
 
           onFilesChange?.(files);


### PR DESCRIPTION
## Summary

Allow the EM cell mesh upload step to accept a single `.obj` **or** `.glb` file, instead of only `.obj`.

## Changes

- **`schema.ts`**: Replaced the per-extension `assets.obj` field with a single `assets.mesh` field, validated against a shared `EM_CELL_MESH_FILE_TYPES` list (`obj`, `glb`). `getEMCellMeshMimeType` now resolves the mime type for whichever extension was uploaded.
- **`steps/asset-upload.tsx`**: Updated the dropzone `accept` list to include `model/gltf-binary` / `.glb`, bound the form to `assets.mesh`, and renamed the validation handler to `validateMeshFile`.
- **`pipeline.ts`**: Asset creation now reads `values.assets.mesh` and derives `mimeType` via `getEMCellMeshMimeType(file)` instead of hardcoding `application/obj`.
- **`api/one/em-cell-mesh.ts`**: Renamed `resolveOBJFile` → `resolveMeshFile` and `OBJResolution` → `MeshResolution` to reflect that it validates either mesh format. Still hits the same `/declared/test-mesh-file` obi-one endpoint.
- **`i18n/en/upload.ts`**: Added `ResolveMeshFileFailed` (replacing a reference to `ResolveOBJFileFailed`, which was never actually defined — the old error path would have thrown on `.replace()` of `undefined`).

Only one file can be selected at a time (`maxFiles: 1`, unchanged).

## Dependencies

Requires the `/declared/test-mesh-file` endpoint on obi-one to accept `.glb` uploads — tracked separately in the backend mesh validation/registration work: https://github.com/openbraininstitute/obi-one/pull/894
