### PR TITLE
feat(scan-config): combined neuron set ref cleanup and empty filter cue

### DIFF
--- a/.github/workflows/run-audit.yml
+++ b/.github/workflows/run-audit.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.10.0
 
       - name: Set-up Node
         uses: actions/setup-node@v6

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.10.0
 
       - name: Set-up Node
         uses: actions/setup-node@v6
@@ -54,7 +54,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.10.0
 
       - name: Set-up Node
         uses: actions/setup-node@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.10.0
 
       - name: Set-up Node
         uses: actions/setup-node@v6
@@ -98,7 +98,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.10.0
 
       - name: Set-up Node
         uses: actions/setup-node@v6
@@ -208,7 +208,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.10.0
 
       - name: Set-up Node
         uses: actions/setup-node@v6
@@ -370,7 +370,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.10.0
 
       - name: Set-up Node
         uses: actions/setup-node@v6

--- a/src/__tests__/scan-config/rewrite-block-references.test.ts
+++ b/src/__tests__/scan-config/rewrite-block-references.test.ts
@@ -1,0 +1,458 @@
+import { describe, expect, it } from 'vitest';
+
+import { rewriteBlockReferences } from '@/features/scan-config/components/rewrite-block-references';
+import { isPlainObject } from '@/features/scan-config/components/utils';
+
+/** Schema BlockReference shape used by `base_neuron_set` / `combined_with`. */
+function blockRef(block_name: string, block_dict_name = 'neuron_sets') {
+  return {
+    block_dict_name,
+    block_name,
+    type: 'BlockReference' as const,
+  };
+}
+
+/**
+ * Mirrors the delete/rename walk in `block-dictionary-entries.tsx`:
+ * skip `initialize`, then rewrite every dictionary entry.
+ */
+function rewriteConfigEntries(
+  config: Record<string, unknown>,
+  matchName: string,
+  mode: Parameters<typeof rewriteBlockReferences>[2]
+) {
+  for (const [configK, configV] of Object.entries(config)) {
+    if (configK === 'initialize' || !isPlainObject(configV)) continue;
+    for (const entryV of Object.values(configV)) {
+      rewriteBlockReferences(entryV, matchName, mode);
+    }
+  }
+}
+
+describe('rewriteBlockReferences', () => {
+  describe('clear', () => {
+    it('deletes a top-level object-owned block reference (base_neuron_set / recordings)', () => {
+      const entry = {
+        type: 'VirtualCombinedNeuronSet',
+        base_neuron_set: { block_name: 'Set A', block_dict_name: 'neuron_sets' },
+        other: 'keep',
+      };
+
+      rewriteBlockReferences(entry, 'Set A', { type: 'clear' });
+
+      expect(entry).toEqual({
+        type: 'VirtualCombinedNeuronSet',
+        other: 'keep',
+      });
+      expect('base_neuron_set' in entry).toBe(false);
+    });
+
+    it('nulls array-owned refs inside combination tuples without removing the operation', () => {
+      const entry = {
+        type: 'VirtualCombinedNeuronSet',
+        base_neuron_set: { block_name: 'Base', block_dict_name: 'neuron_sets' },
+        combined_with: [
+          [{ block_name: 'Set A', block_dict_name: 'neuron_sets' }, 'union'],
+          [{ block_name: 'Set B', block_dict_name: 'neuron_sets' }, 'intersect'],
+        ],
+      };
+
+      rewriteBlockReferences(entry, 'Set A', { type: 'clear' });
+
+      expect(entry.combined_with).toEqual([
+        [null, 'union'],
+        [{ block_name: 'Set B', block_dict_name: 'neuron_sets' }, 'intersect'],
+      ]);
+      expect(entry.base_neuron_set).toEqual({
+        block_name: 'Base',
+        block_dict_name: 'neuron_sets',
+      });
+    });
+
+    it('clears every matching nested ref when the same name appears more than once', () => {
+      const entry = {
+        combined_with: [
+          [{ block_name: 'Set A', block_dict_name: 'neuron_sets' }, 'union'],
+          [{ block_name: 'Set A', block_dict_name: 'neuron_sets' }, 'diff'],
+        ],
+      };
+
+      rewriteBlockReferences(entry, 'Set A', { type: 'clear' });
+
+      expect(entry.combined_with).toEqual([
+        [null, 'union'],
+        [null, 'diff'],
+      ]);
+    });
+
+    it('does not touch unrelated fields, primitives, or non-matching refs', () => {
+      const entry = {
+        type: 'Recording',
+        neuron_set: { block_name: 'Keep Me', block_dict_name: 'neuron_sets' },
+        property_filter: {
+          filter_dict: { mtype: ['L5_PC'] },
+        },
+        ids: [1, 2, 3],
+        label: 'Set A',
+      };
+
+      rewriteBlockReferences(entry, 'Set A', { type: 'clear' });
+
+      expect(entry).toEqual({
+        type: 'Recording',
+        neuron_set: { block_name: 'Keep Me', block_dict_name: 'neuron_sets' },
+        property_filter: {
+          filter_dict: { mtype: ['L5_PC'] },
+        },
+        ids: [1, 2, 3],
+        label: 'Set A',
+      });
+    });
+
+    it('leaves a dense array (no sparse holes) after clearing a combination ref', () => {
+      const combined_with: Array<[unknown, string]> = [
+        [{ block_name: 'Set A', block_dict_name: 'neuron_sets' }, 'union'],
+      ];
+
+      rewriteBlockReferences({ combined_with }, 'Set A', { type: 'clear' });
+
+      expect(combined_with.length).toBe(1);
+      expect(0 in combined_with).toBe(true);
+      expect(combined_with[0]).toEqual([null, 'union']);
+    });
+  });
+
+  describe('rename', () => {
+    it('renames a top-level object-owned block reference', () => {
+      const entry = {
+        neuron_set: { block_name: 'Old', block_dict_name: 'neuron_sets' },
+      };
+
+      rewriteBlockReferences(entry, 'Old', { type: 'rename', to: 'New' });
+
+      expect(entry.neuron_set.block_name).toBe('New');
+      expect(entry.neuron_set.block_dict_name).toBe('neuron_sets');
+    });
+
+    it('renames nested refs inside combination tuples', () => {
+      const entry = {
+        base_neuron_set: { block_name: 'Old', block_dict_name: 'neuron_sets' },
+        combined_with: [
+          [{ block_name: 'Old', block_dict_name: 'neuron_sets' }, 'union'],
+          [{ block_name: 'Other', block_dict_name: 'neuron_sets' }, 'diff'],
+        ],
+      };
+
+      rewriteBlockReferences(entry, 'Old', { type: 'rename', to: 'New' });
+
+      expect(entry.base_neuron_set.block_name).toBe('New');
+      expect(entry.combined_with).toEqual([
+        [{ block_name: 'New', block_dict_name: 'neuron_sets' }, 'union'],
+        [{ block_name: 'Other', block_dict_name: 'neuron_sets' }, 'diff'],
+      ]);
+    });
+  });
+
+  describe('walk scope', () => {
+    it('rewrites refs across multiple dictionary entries when given each entry', () => {
+      const config = {
+        neuron_sets: {
+          Combined: {
+            combined_with: [[{ block_name: 'Gone', block_dict_name: 'neuron_sets' }, 'union']],
+          },
+        },
+        recordings: {
+          R1: {
+            neuron_set: { block_name: 'Gone', block_dict_name: 'neuron_sets' },
+          },
+        },
+      };
+
+      for (const section of Object.values(config)) {
+        for (const entry of Object.values(section)) {
+          rewriteBlockReferences(entry, 'Gone', { type: 'clear' });
+        }
+      }
+
+      expect(config.neuron_sets.Combined.combined_with).toEqual([[null, 'union']]);
+      expect('neuron_set' in config.recordings.R1).toBe(false);
+    });
+
+    it('is a no-op for null, primitives, and empty structures', () => {
+      expect(() => rewriteBlockReferences(null, 'X', { type: 'clear' })).not.toThrow();
+      expect(() => rewriteBlockReferences('Set A', 'Set A', { type: 'clear' })).not.toThrow();
+      expect(() => rewriteBlockReferences(42, 'Set A', { type: 'clear' })).not.toThrow();
+      expect(() => rewriteBlockReferences({}, 'Set A', { type: 'clear' })).not.toThrow();
+      expect(() => rewriteBlockReferences([], 'Set A', { type: 'clear' })).not.toThrow();
+    });
+  });
+
+  describe('CircuitSimulationScanConfig shapes', () => {
+    it('clears BiophysicalCombinedNeuronSet.combined_with while preserving operators', () => {
+      const entry = {
+        type: 'BiophysicalCombinedNeuronSet',
+        base_neuron_set: blockRef('Layer 5'),
+        combined_with: [
+          [blockRef('Deleted Set'), 'union'],
+          [blockRef('Layer 6'), 'intersect'],
+          [blockRef('Deleted Set'), 'diff'],
+        ],
+      };
+
+      rewriteBlockReferences(entry, 'Deleted Set', { type: 'clear' });
+
+      expect(entry.base_neuron_set).toEqual(blockRef('Layer 5'));
+      expect(entry.combined_with).toEqual([
+        [null, 'union'],
+        [blockRef('Layer 6'), 'intersect'],
+        [null, 'diff'],
+      ]);
+    });
+
+    it('clears VirtualCombinedNeuronSet and PointCombinedNeuronSet the same way', () => {
+      for (const type of ['VirtualCombinedNeuronSet', 'PointCombinedNeuronSet'] as const) {
+        const entry = {
+          type,
+          base_neuron_set: blockRef('Keep'),
+          combined_with: [[blockRef('Gone'), 'union']],
+        };
+
+        rewriteBlockReferences(entry, 'Gone', { type: 'clear' });
+
+        expect(entry.combined_with).toEqual([[null, 'union']]);
+        expect(entry.base_neuron_set).toEqual(blockRef('Keep'));
+      }
+    });
+
+    it('clears CombinedNeuronSet (Any) refs that mix typed neuron-set references', () => {
+      const entry = {
+        type: 'CombinedNeuronSet',
+        base_neuron_set: blockRef('Any Base'),
+        combined_with: [
+          [
+            {
+              block_dict_name: 'neuron_sets',
+              block_name: 'Gone Virtual',
+              type: 'VirtualNeuronSetReference',
+            },
+            'union',
+          ],
+          [
+            {
+              block_dict_name: 'neuron_sets',
+              block_name: 'Keep Point',
+              type: 'PointNeuronSetReference',
+            },
+            'diff',
+          ],
+        ],
+      };
+
+      rewriteBlockReferences(entry, 'Gone Virtual', { type: 'clear' });
+
+      expect(entry.combined_with[0]).toEqual([null, 'union']);
+      expect(entry.combined_with[1]).toEqual([
+        {
+          block_dict_name: 'neuron_sets',
+          block_name: 'Keep Point',
+          type: 'PointNeuronSetReference',
+        },
+        'diff',
+      ]);
+    });
+
+    it('deletes base_neuron_set when the deleted name is the base (schema default fallback)', () => {
+      const entry = {
+        type: 'BiophysicalCombinedNeuronSet',
+        base_neuron_set: blockRef('Gone Base'),
+        combined_with: [[blockRef('Keep'), 'union']],
+      };
+
+      rewriteBlockReferences(entry, 'Gone Base', { type: 'clear' });
+
+      expect('base_neuron_set' in entry).toBe(false);
+      expect(entry.combined_with).toEqual([[blockRef('Keep'), 'union']]);
+    });
+
+    it('renames both base_neuron_set and combined_with refs for a CombinedNeuronSet', () => {
+      const entry = {
+        type: 'CombinedNeuronSet',
+        base_neuron_set: blockRef('Old Name'),
+        combined_with: [
+          [blockRef('Old Name'), 'union'],
+          [blockRef('Other'), 'intersect'],
+        ],
+      };
+
+      rewriteBlockReferences(entry, 'Old Name', { type: 'rename', to: 'New Name' });
+
+      expect(entry.base_neuron_set.block_name).toBe('New Name');
+      expect(entry.combined_with).toEqual([
+        [blockRef('New Name'), 'union'],
+        [blockRef('Other'), 'intersect'],
+      ]);
+    });
+
+    it('clears top-level refs in recordings / stimuli / synaptic_manipulations like the delete walk', () => {
+      const config = {
+        type: 'CircuitSimulationScanConfig',
+        initialize: {
+          type: 'CircuitSimulationScanConfig.Initialize',
+          // skipped by product walk — left intact here on purpose
+          node_set: {
+            block_name: 'Gone',
+            block_dict_name: 'neuron_sets',
+            type: 'BiophysicalNeuronSetReference',
+          },
+        },
+        neuron_sets: {
+          Combined: {
+            type: 'BiophysicalCombinedNeuronSet',
+            base_neuron_set: blockRef('Keep'),
+            combined_with: [[blockRef('Gone'), 'union']],
+          },
+        },
+        recordings: {
+          Soma: {
+            type: 'SomaVoltageRecording',
+            neuron_set: {
+              block_name: 'Gone',
+              block_dict_name: 'neuron_sets',
+              type: 'BiophysicalNeuronSetReference',
+            },
+            dt: 0.1,
+          },
+        },
+        stimuli: {
+          Clamp: {
+            type: 'ConstantCurrentClampSomaticStimulus',
+            neuron_set: {
+              block_name: 'Gone',
+              block_dict_name: 'neuron_sets',
+              type: 'BiophysicalNeuronSetReference',
+            },
+            timestamps: {
+              block_name: 'T0',
+              block_dict_name: 'timestamps',
+              type: 'TimestampsReference',
+            },
+          },
+        },
+        synaptic_manipulations: {
+          Disconnect: {
+            type: 'DisconnectSynapticManipulation',
+            presynaptic_neuron_set: {
+              block_name: 'Gone',
+              block_dict_name: 'neuron_sets',
+              type: 'VirtualNeuronSetReference',
+            },
+            postsynaptic_neuron_set: {
+              block_name: 'Keep',
+              block_dict_name: 'neuron_sets',
+              type: 'BiophysicalNeuronSetReference',
+            },
+          },
+        },
+        timestamps: {
+          T0: { type: 'SingleTimestamp', start_time: 0 },
+        },
+      };
+
+      rewriteConfigEntries(config, 'Gone', { type: 'clear' });
+
+      expect(config.neuron_sets.Combined.combined_with).toEqual([[null, 'union']]);
+      expect('neuron_set' in config.recordings.Soma).toBe(false);
+      expect('neuron_set' in config.stimuli.Clamp).toBe(false);
+      expect(config.stimuli.Clamp.timestamps).toEqual({
+        block_name: 'T0',
+        block_dict_name: 'timestamps',
+        type: 'TimestampsReference',
+      });
+      expect('presynaptic_neuron_set' in config.synaptic_manipulations.Disconnect).toBe(false);
+      expect(config.synaptic_manipulations.Disconnect.postsynaptic_neuron_set.block_name).toBe(
+        'Keep'
+      );
+      // initialize is intentionally not walked by the product delete path
+      expect(config.initialize.node_set.block_name).toBe('Gone');
+    });
+
+    it('renames nested combined_with refs across the config without touching initialize', () => {
+      const config = {
+        initialize: {
+          node_set: {
+            block_name: 'Old',
+            block_dict_name: 'neuron_sets',
+            type: 'BiophysicalNeuronSetReference',
+          },
+        },
+        neuron_sets: {
+          Combined: {
+            type: 'VirtualCombinedNeuronSet',
+            base_neuron_set: blockRef('Old'),
+            combined_with: [[blockRef('Old'), 'diff']],
+          },
+        },
+        recordings: {
+          R1: {
+            type: 'SomaVoltageRecording',
+            neuron_set: {
+              block_name: 'Old',
+              block_dict_name: 'neuron_sets',
+              type: 'BiophysicalNeuronSetReference',
+            },
+          },
+        },
+      };
+
+      rewriteConfigEntries(config, 'Old', { type: 'rename', to: 'New' });
+
+      expect(config.neuron_sets.Combined.base_neuron_set.block_name).toBe('New');
+      expect(config.neuron_sets.Combined.combined_with).toEqual([[blockRef('New'), 'diff']]);
+      expect(config.recordings.R1.neuron_set.block_name).toBe('New');
+      expect(config.initialize.node_set.block_name).toBe('Old');
+    });
+
+    it('does not treat property_filter / neuron_ids payloads as block references', () => {
+      const entry = {
+        type: 'BiophysicalPopulationPropertyNeuronSet',
+        population: 'L5',
+        property_filter: {
+          type: 'NeuronPropertyFilter',
+          filter_dict: { mtype: ['L5_PC'], layer: ['5'] },
+        },
+      };
+      const idEntry = {
+        type: 'BiophysicalPopulationIDNeuronSet',
+        population: 'L5',
+        neuron_ids: {
+          type: 'NamedTuple',
+          name: 'ids',
+          elements: [1, 2, 3],
+        },
+      };
+
+      rewriteBlockReferences(entry, 'L5_PC', { type: 'clear' });
+      rewriteBlockReferences(idEntry, 'ids', { type: 'clear' });
+
+      expect(entry.property_filter.filter_dict.mtype).toEqual(['L5_PC']);
+      expect(idEntry.neuron_ids).toEqual({
+        type: 'NamedTuple',
+        name: 'ids',
+        elements: [1, 2, 3],
+      });
+    });
+
+    it('accepts schema refs that omit block_dict_name (only block_name is required)', () => {
+      const entry = {
+        type: 'BiophysicalCombinedNeuronSet',
+        base_neuron_set: { block_name: 'Gone' },
+        combined_with: [[{ block_name: 'Gone' }, 'union']],
+      };
+
+      rewriteBlockReferences(entry, 'Gone', { type: 'clear' });
+
+      expect('base_neuron_set' in entry).toBe(false);
+      expect(entry.combined_with).toEqual([[null, 'union']]);
+    });
+  });
+});

--- a/src/__tests__/scan-config/rewrite-block-references.test.ts
+++ b/src/__tests__/scan-config/rewrite-block-references.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { rewriteBlockReferences } from '@/features/scan-config/components/rewrite-block-references';
+import {
+  RewriteBlockReferencesModeDict,
+  rewriteBlockReferences,
+} from '@/features/scan-config/components/rewrite-block-references';
 import { isPlainObject } from '@/features/scan-config/components/utils';
 
 /** Schema BlockReference shape used by `base_neuron_set` / `combined_with`. */
@@ -38,7 +41,7 @@ describe('rewriteBlockReferences', () => {
         other: 'keep',
       };
 
-      rewriteBlockReferences(entry, 'Set A', { type: 'clear' });
+      rewriteBlockReferences(entry, 'Set A', { type: RewriteBlockReferencesModeDict.Clear });
 
       expect(entry).toEqual({
         type: 'VirtualCombinedNeuronSet',
@@ -57,7 +60,7 @@ describe('rewriteBlockReferences', () => {
         ],
       };
 
-      rewriteBlockReferences(entry, 'Set A', { type: 'clear' });
+      rewriteBlockReferences(entry, 'Set A', { type: RewriteBlockReferencesModeDict.Clear });
 
       expect(entry.combined_with).toEqual([
         [null, 'union'],
@@ -77,7 +80,7 @@ describe('rewriteBlockReferences', () => {
         ],
       };
 
-      rewriteBlockReferences(entry, 'Set A', { type: 'clear' });
+      rewriteBlockReferences(entry, 'Set A', { type: RewriteBlockReferencesModeDict.Clear });
 
       expect(entry.combined_with).toEqual([
         [null, 'union'],
@@ -96,7 +99,7 @@ describe('rewriteBlockReferences', () => {
         label: 'Set A',
       };
 
-      rewriteBlockReferences(entry, 'Set A', { type: 'clear' });
+      rewriteBlockReferences(entry, 'Set A', { type: RewriteBlockReferencesModeDict.Clear });
 
       expect(entry).toEqual({
         type: 'Recording',
@@ -114,7 +117,9 @@ describe('rewriteBlockReferences', () => {
         [{ block_name: 'Set A', block_dict_name: 'neuron_sets' }, 'union'],
       ];
 
-      rewriteBlockReferences({ combined_with }, 'Set A', { type: 'clear' });
+      rewriteBlockReferences({ combined_with }, 'Set A', {
+        type: RewriteBlockReferencesModeDict.Clear,
+      });
 
       expect(combined_with.length).toBe(1);
       expect(0 in combined_with).toBe(true);
@@ -128,7 +133,10 @@ describe('rewriteBlockReferences', () => {
         neuron_set: { block_name: 'Old', block_dict_name: 'neuron_sets' },
       };
 
-      rewriteBlockReferences(entry, 'Old', { type: 'rename', to: 'New' });
+      rewriteBlockReferences(entry, 'Old', {
+        type: RewriteBlockReferencesModeDict.Rename,
+        to: 'New',
+      });
 
       expect(entry.neuron_set.block_name).toBe('New');
       expect(entry.neuron_set.block_dict_name).toBe('neuron_sets');
@@ -143,7 +151,10 @@ describe('rewriteBlockReferences', () => {
         ],
       };
 
-      rewriteBlockReferences(entry, 'Old', { type: 'rename', to: 'New' });
+      rewriteBlockReferences(entry, 'Old', {
+        type: RewriteBlockReferencesModeDict.Rename,
+        to: 'New',
+      });
 
       expect(entry.base_neuron_set.block_name).toBe('New');
       expect(entry.combined_with).toEqual([
@@ -170,7 +181,7 @@ describe('rewriteBlockReferences', () => {
 
       for (const section of Object.values(config)) {
         for (const entry of Object.values(section)) {
-          rewriteBlockReferences(entry, 'Gone', { type: 'clear' });
+          rewriteBlockReferences(entry, 'Gone', { type: RewriteBlockReferencesModeDict.Clear });
         }
       }
 
@@ -179,11 +190,21 @@ describe('rewriteBlockReferences', () => {
     });
 
     it('is a no-op for null, primitives, and empty structures', () => {
-      expect(() => rewriteBlockReferences(null, 'X', { type: 'clear' })).not.toThrow();
-      expect(() => rewriteBlockReferences('Set A', 'Set A', { type: 'clear' })).not.toThrow();
-      expect(() => rewriteBlockReferences(42, 'Set A', { type: 'clear' })).not.toThrow();
-      expect(() => rewriteBlockReferences({}, 'Set A', { type: 'clear' })).not.toThrow();
-      expect(() => rewriteBlockReferences([], 'Set A', { type: 'clear' })).not.toThrow();
+      expect(() =>
+        rewriteBlockReferences(null, 'X', { type: RewriteBlockReferencesModeDict.Clear })
+      ).not.toThrow();
+      expect(() =>
+        rewriteBlockReferences('Set A', 'Set A', { type: RewriteBlockReferencesModeDict.Clear })
+      ).not.toThrow();
+      expect(() =>
+        rewriteBlockReferences(42, 'Set A', { type: RewriteBlockReferencesModeDict.Clear })
+      ).not.toThrow();
+      expect(() =>
+        rewriteBlockReferences({}, 'Set A', { type: RewriteBlockReferencesModeDict.Clear })
+      ).not.toThrow();
+      expect(() =>
+        rewriteBlockReferences([], 'Set A', { type: RewriteBlockReferencesModeDict.Clear })
+      ).not.toThrow();
     });
   });
 
@@ -199,7 +220,7 @@ describe('rewriteBlockReferences', () => {
         ],
       };
 
-      rewriteBlockReferences(entry, 'Deleted Set', { type: 'clear' });
+      rewriteBlockReferences(entry, 'Deleted Set', { type: RewriteBlockReferencesModeDict.Clear });
 
       expect(entry.base_neuron_set).toEqual(blockRef('Layer 5'));
       expect(entry.combined_with).toEqual([
@@ -217,7 +238,7 @@ describe('rewriteBlockReferences', () => {
           combined_with: [[blockRef('Gone'), 'union']],
         };
 
-        rewriteBlockReferences(entry, 'Gone', { type: 'clear' });
+        rewriteBlockReferences(entry, 'Gone', { type: RewriteBlockReferencesModeDict.Clear });
 
         expect(entry.combined_with).toEqual([[null, 'union']]);
         expect(entry.base_neuron_set).toEqual(blockRef('Keep'));
@@ -248,7 +269,7 @@ describe('rewriteBlockReferences', () => {
         ],
       };
 
-      rewriteBlockReferences(entry, 'Gone Virtual', { type: 'clear' });
+      rewriteBlockReferences(entry, 'Gone Virtual', { type: RewriteBlockReferencesModeDict.Clear });
 
       expect(entry.combined_with[0]).toEqual([null, 'union']);
       expect(entry.combined_with[1]).toEqual([
@@ -268,7 +289,7 @@ describe('rewriteBlockReferences', () => {
         combined_with: [[blockRef('Keep'), 'union']],
       };
 
-      rewriteBlockReferences(entry, 'Gone Base', { type: 'clear' });
+      rewriteBlockReferences(entry, 'Gone Base', { type: RewriteBlockReferencesModeDict.Clear });
 
       expect('base_neuron_set' in entry).toBe(false);
       expect(entry.combined_with).toEqual([[blockRef('Keep'), 'union']]);
@@ -284,7 +305,10 @@ describe('rewriteBlockReferences', () => {
         ],
       };
 
-      rewriteBlockReferences(entry, 'Old Name', { type: 'rename', to: 'New Name' });
+      rewriteBlockReferences(entry, 'Old Name', {
+        type: RewriteBlockReferencesModeDict.Rename,
+        to: 'New Name',
+      });
 
       expect(entry.base_neuron_set.block_name).toBe('New Name');
       expect(entry.combined_with).toEqual([
@@ -358,7 +382,7 @@ describe('rewriteBlockReferences', () => {
         },
       };
 
-      rewriteConfigEntries(config, 'Gone', { type: 'clear' });
+      rewriteConfigEntries(config, 'Gone', { type: RewriteBlockReferencesModeDict.Clear });
 
       expect(config.neuron_sets.Combined.combined_with).toEqual([[null, 'union']]);
       expect('neuron_set' in config.recordings.Soma).toBe(false);
@@ -404,7 +428,10 @@ describe('rewriteBlockReferences', () => {
         },
       };
 
-      rewriteConfigEntries(config, 'Old', { type: 'rename', to: 'New' });
+      rewriteConfigEntries(config, 'Old', {
+        type: RewriteBlockReferencesModeDict.Rename,
+        to: 'New',
+      });
 
       expect(config.neuron_sets.Combined.base_neuron_set.block_name).toBe('New');
       expect(config.neuron_sets.Combined.combined_with).toEqual([[blockRef('New'), 'diff']]);
@@ -431,8 +458,8 @@ describe('rewriteBlockReferences', () => {
         },
       };
 
-      rewriteBlockReferences(entry, 'L5_PC', { type: 'clear' });
-      rewriteBlockReferences(idEntry, 'ids', { type: 'clear' });
+      rewriteBlockReferences(entry, 'L5_PC', { type: RewriteBlockReferencesModeDict.Clear });
+      rewriteBlockReferences(idEntry, 'ids', { type: RewriteBlockReferencesModeDict.Clear });
 
       expect(entry.property_filter.filter_dict.mtype).toEqual(['L5_PC']);
       expect(idEntry.neuron_ids).toEqual({
@@ -449,7 +476,7 @@ describe('rewriteBlockReferences', () => {
         combined_with: [[{ block_name: 'Gone' }, 'union']],
       };
 
-      rewriteBlockReferences(entry, 'Gone', { type: 'clear' });
+      rewriteBlockReferences(entry, 'Gone', { type: RewriteBlockReferencesModeDict.Clear });
 
       expect('base_neuron_set' in entry).toBe(false);
       expect(entry.combined_with).toEqual([[null, 'union']]);

--- a/src/features/scan-config/components/block-dictionary-entries.tsx
+++ b/src/features/scan-config/components/block-dictionary-entries.tsx
@@ -17,6 +17,7 @@ import { useEntryDiff } from '@/features/scan-config/hooks/use-entry-diff';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/molecules/tooltip';
 import { cn } from '@/utils/css-class';
 
+import { rewriteBlockReferences } from './rewrite-block-references';
 import { isPlainObject } from './utils';
 
 import type { ErrorObject } from 'ajv';
@@ -174,17 +175,9 @@ export default function BlockDictionaryEntries({
     Object.entries(newConfig).forEach(([configK, configV]) => {
       if (configK === 'initialize' || !isPlainObject(configV)) return;
 
-      // Evaluate items within sections (e.g., stimuli, recordings)
+      // Rename refs in section entries (incl. nested combination tuples)
       Object.values(configV).forEach((entryV) => {
-        if (!isPlainObject(entryV)) return;
-
-        // Evaluate fields within the specific object
-        Object.values(entryV).forEach((field) => {
-          if (!isPlainObject(field) || field.block_name !== selectedEntry) return;
-
-          // Update the block_name reference
-          field.block_name = newKey;
-        });
+        rewriteBlockReferences(entryV, selectedEntry, { type: 'rename', to: newKey });
       });
     });
 
@@ -377,20 +370,9 @@ export default function BlockDictionaryEntries({
                                       if (configK === 'initialize' || !isPlainObject(configV))
                                         return;
 
+                                      // Clear refs in section entries (incl. nested combination tuples)
                                       Object.values(configV).forEach((entryV) => {
-                                        if (!isPlainObject(entryV)) return;
-
-                                        Object.entries(entryV).forEach(([fieldK, field]) => {
-                                          if (
-                                            !isPlainObject(field) ||
-                                            typeof field.block_name !== 'string' ||
-                                            field.block_name !== subkey
-                                          ) {
-                                            return;
-                                          }
-
-                                          delete entryV[fieldK];
-                                        });
+                                        rewriteBlockReferences(entryV, subkey, { type: 'clear' });
                                       });
                                     });
 

--- a/src/features/scan-config/components/block-dictionary-entries.tsx
+++ b/src/features/scan-config/components/block-dictionary-entries.tsx
@@ -17,7 +17,7 @@ import { useEntryDiff } from '@/features/scan-config/hooks/use-entry-diff';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/molecules/tooltip';
 import { cn } from '@/utils/css-class';
 
-import { rewriteBlockReferences } from './rewrite-block-references';
+import { RewriteBlockReferencesModeDict, rewriteBlockReferences } from './rewrite-block-references';
 import { isPlainObject } from './utils';
 
 import type { ErrorObject } from 'ajv';
@@ -177,7 +177,10 @@ export default function BlockDictionaryEntries({
 
       // Rename refs in section entries (incl. nested combination tuples)
       Object.values(configV).forEach((entryV) => {
-        rewriteBlockReferences(entryV, selectedEntry, { type: 'rename', to: newKey });
+        rewriteBlockReferences(entryV, selectedEntry, {
+          type: RewriteBlockReferencesModeDict.Rename,
+          to: newKey,
+        });
       });
     });
 
@@ -372,7 +375,9 @@ export default function BlockDictionaryEntries({
 
                                       // Clear refs in section entries (incl. nested combination tuples)
                                       Object.values(configV).forEach((entryV) => {
-                                        rewriteBlockReferences(entryV, subkey, { type: 'clear' });
+                                        rewriteBlockReferences(entryV, subkey, {
+                                          type: RewriteBlockReferencesModeDict.Clear,
+                                        });
                                       });
                                     });
 

--- a/src/features/scan-config/components/rewrite-block-references.ts
+++ b/src/features/scan-config/components/rewrite-block-references.ts
@@ -9,7 +9,17 @@ function isBlockReference(value: unknown): value is { block_name: string } {
   return isPlainObject(value) && typeof value.block_name === 'string';
 }
 
-export type RewriteBlockReferencesMode = { type: 'clear' } | { type: 'rename'; to: string };
+export const RewriteBlockReferencesModeDict = {
+  Clear: 'clear',
+  Rename: 'rename',
+} as const;
+
+export type TRewriteBlockReferencesModeDict =
+  (typeof RewriteBlockReferencesModeDict)[keyof typeof RewriteBlockReferencesModeDict];
+
+export type RewriteBlockReferencesMode =
+  | { type: typeof RewriteBlockReferencesModeDict.Clear }
+  | { type: typeof RewriteBlockReferencesModeDict.Rename; to: string };
 
 /**
  * Walk a config subtree and rewrite every BlockReference whose `block_name`
@@ -34,7 +44,7 @@ export function rewriteBlockReferences(
     for (let i = 0; i < node.length; i += 1) {
       const item = node[i];
       if (isBlockReference(item) && item.block_name === matchName) {
-        if (mode.type === 'clear') {
+        if (mode.type === RewriteBlockReferencesModeDict.Clear) {
           node[i] = null;
         } else {
           item.block_name = mode.to;
@@ -51,7 +61,7 @@ export function rewriteBlockReferences(
   for (const key of Object.keys(node)) {
     const value = node[key];
     if (isBlockReference(value) && value.block_name === matchName) {
-      if (mode.type === 'clear') {
+      if (mode.type === RewriteBlockReferencesModeDict.Clear) {
         delete node[key];
       } else {
         value.block_name = mode.to;

--- a/src/features/scan-config/components/rewrite-block-references.ts
+++ b/src/features/scan-config/components/rewrite-block-references.ts
@@ -1,0 +1,63 @@
+import { isPlainObject } from '@/features/scan-config/components/utils';
+
+/**
+ * A block reference is a plain object with a string `block_name` (and usually
+ * `block_dict_name`). Used by `reference` fields and nested inside
+ * `combined_with` (`neuron_set_combination`) tuples: `[ref | null, operation]`.
+ */
+function isBlockReference(value: unknown): value is { block_name: string } {
+  return isPlainObject(value) && typeof value.block_name === 'string';
+}
+
+export type RewriteBlockReferencesMode = { type: 'clear' } | { type: 'rename'; to: string };
+
+/**
+ * Walk a config subtree and rewrite every BlockReference whose `block_name`
+ * matches `matchName`.
+ *
+ * Semantics mirror the historical shallow cleanup, extended for nested arrays:
+ * - object-owned ref + clear  → `delete parent[key]` (same as recordings /
+ *   `base_neuron_set` today — field falls back to schema default)
+ * - array-owned ref + clear   → set the slot to `null` (keeps combination
+ *   tuples as `[null, op]`, matching the UI "Default" value; never `delete`
+ *   an index — that would sparse-hole the array and break `[ref, op]` reads)
+ * - rename                    → mutate `block_name` in place
+ *
+ * Non-ref plain objects and arrays are recursed into. Primitives are ignored.
+ */
+export function rewriteBlockReferences(
+  node: unknown,
+  matchName: string,
+  mode: RewriteBlockReferencesMode
+): void {
+  if (Array.isArray(node)) {
+    for (let i = 0; i < node.length; i += 1) {
+      const item = node[i];
+      if (isBlockReference(item) && item.block_name === matchName) {
+        if (mode.type === 'clear') {
+          node[i] = null;
+        } else {
+          item.block_name = mode.to;
+        }
+      } else {
+        rewriteBlockReferences(item, matchName, mode);
+      }
+    }
+    return;
+  }
+
+  if (!isPlainObject(node)) return;
+
+  for (const key of Object.keys(node)) {
+    const value = node[key];
+    if (isBlockReference(value) && value.block_name === matchName) {
+      if (mode.type === 'clear') {
+        delete node[key];
+      } else {
+        value.block_name = mode.to;
+      }
+    } else {
+      rewriteBlockReferences(value, matchName, mode);
+    }
+  }
+}

--- a/src/features/scan-config/components/ui-elements/neuron-property-filter.tsx
+++ b/src/features/scan-config/components/ui-elements/neuron-property-filter.tsx
@@ -212,7 +212,12 @@ function PropertyValueSelector({
         )}
       </div>
       {expanded && (
-        <div className="flex flex-wrap gap-2 mt-1 text-sm border-gray-300 border-1 rounded-md p-3 bg-white">
+        <div
+          className={cn(
+            'flex flex-wrap gap-2 mt-1 text-sm rounded-md p-3 bg-white',
+            selected.length === 0 ? 'border-2 border-yellow-400' : 'border border-gray-300'
+          )}
+        >
           {displayValues.length === 0 && <span className="text-gray-400">No values available</span>}
           {displayValues.map((val) => {
             const isSelected = selected.includes(val);


### PR DESCRIPTION

- clear and rename nested `combined_with` block references when a neuron set is deleted or renamed, so stale names no longer break campaign generation.
- highlight empty neuron property filter value pickers with a yellow-400 border matching the left-menu warning icon.
- introduce `RewriteBlockReferencesModeDict` and use it consistently for clear/rename modes.
