### PR TITLE
feat(ion-channel-build): only show validation-passed recordings in trace selector

### DIFF
--- a/src/api/entitycore/types/entities/ion-channel-recording.ts
+++ b/src/api/entitycore/types/entities/ion-channel-recording.ts
@@ -45,6 +45,10 @@ export const RecordingTypeDictionary = Object.fromEntries(
   [K in keyof typeof RecordingType]: (typeof RecordingType)[K]['key'];
 };
 
+interface ValidationResultNestedFilter {
+  validation_result__passed: boolean;
+}
+
 export type IonChannelRecordingFilter = Partial<
   IDFilter &
     TimestampsFilter &
@@ -53,7 +57,8 @@ export type IonChannelRecordingFilter = Partial<
     PaginationFilter &
     SharedFilter &
     IRecordingFilter &
-    IlikeSearchFilter
+    IlikeSearchFilter &
+    ValidationResultNestedFilter
 >;
 
 interface IIonChannelRecordingBase extends EntityCoreIdentifiable, EntityCoreOwnership {

--- a/src/ui/segments/workflows/build/ion-channel-build/rjsf/theme/fields/ion-channel-recordings.tsx
+++ b/src/ui/segments/workflows/build/ion-channel-build/rjsf/theme/fields/ion-channel-recordings.tsx
@@ -246,6 +246,7 @@ function RecordingsArrayFieldContent({
             requireMiniDetailView={false}
             dataType={ExtendedEntitiesTypeDict.IonChannelRecording}
             scope={WorkspaceScope.BuildIonChannelModel}
+            extraQueryParams={{ validation_result__passed: true }}
             mainTableProps={{
               selectionType: isSingleMode ? 'radio' : 'checkbox',
               onRowsSelected: (rows: EntityCoreIdentifiableNamed[]) => {


### PR DESCRIPTION
## What

In **Build > Ion Channel**, the input trace selector now lists only `IonChannelRecording` entities whose linked `ValidationResult` passed.

Recordings missing Activation/Inactivation data fail validation and would error at build time, so they no longer appear as selectable input. This uses the new entitycore `validation_result__passed` read-many filter ([entitycore#666](https://github.com/openbraininstitute/entitycore/pull/666)).

## How

- `ion-channel-recordings.tsx` — pass `extraQueryParams={{ validation_result__passed: true }}` to `<BrowseEntityScope>`. It flows into both the `GET /ion-channel-recording` request and the React Query cache key.
- `ion-channel-recording.ts` — add the nested `validation_result__passed` param to `IonChannelRecordingFilter`.

Scoped to the build-workflow selector only via `extraQueryParams` — the shared `IonChannelRecording` domain config used by the general Explore/data-browse listing is untouched.

## Notes

- Forward-compatible: on any environment where entitycore#666 is not yet deployed, the param is a harmless no-op (FastAPI ignores unknown query params), so all recordings still show until the backend rolls out.
- Editing an existing campaign refetches the selected recording by id (`/ion-channel-recording/{id}`), which bypasses the read-many filter — no regression for existing selections.