### PR TITLE
Update ME-model Simulate link to point to beta simulation workflow

### DIFF
--- a/src/ui/segments/workflows/config/routes.test.ts
+++ b/src/ui/segments/workflows/config/routes.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { CircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit';
+import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import {
+  readWorkflowSessionSelection,
+  WorkflowSessionSelectionMode,
+} from '@/features/scan-config/workflow/workflow-session-selection';
+
+import {
+  buildSimulateConfigureUrlFromDataViewEntity,
+  resolveSimulateSourceTypeFromDataView,
+} from './routes';
+
+const workspace = { virtualLabId: 'lab-1', projectId: 'project-1' };
+
+describe('resolveSimulateSourceTypeFromDataView', () => {
+  it('maps ME-models to the beta scan-config source type', () => {
+    expect(resolveSimulateSourceTypeFromDataView(ExtendedEntitiesTypeDict.Memodel, {})).toBe(
+      ExtendedEntitiesTypeDict.MemodelCircuit
+    );
+  });
+
+  it('maps circuits to a source type by scale', () => {
+    expect(
+      resolveSimulateSourceTypeFromDataView(ExtendedEntitiesTypeDict.Circuit, {
+        scale: CircuitScaleDictionary.SmallMicrocircuit,
+      })
+    ).toBe(ExtendedEntitiesTypeDict.SmallMicrocircuit);
+  });
+
+  it('passes other source types through unchanged', () => {
+    expect(
+      resolveSimulateSourceTypeFromDataView(ExtendedEntitiesTypeDict.SingleNeuronSynaptome, {})
+    ).toBe(ExtendedEntitiesTypeDict.SingleNeuronSynaptome);
+  });
+});
+
+describe('buildSimulateConfigureUrlFromDataViewEntity', () => {
+  it('sends ME-models to the beta simulation configure route with the model pre-selected', () => {
+    const href = buildSimulateConfigureUrlFromDataViewEntity({
+      workspace,
+      extendedType: ExtendedEntitiesTypeDict.Memodel,
+      entityId: 'me-model-id',
+      entity: {},
+    });
+
+    const match = href?.match(
+      /\/workflows\/simulate\/configure\/me-model-circuit-simulation\/(wf_[a-z0-9]{10})\?/
+    );
+    expect(match).not.toBeNull();
+
+    expect(readWorkflowSessionSelection(match?.[1] as string)).toEqual({
+      mode: WorkflowSessionSelectionMode.Single,
+      item: { type: ExtendedEntitiesTypeDict.MemodelCircuit, id: 'me-model-id' },
+    });
+  });
+});

--- a/src/ui/segments/workflows/config/routes.ts
+++ b/src/ui/segments/workflows/config/routes.ts
@@ -325,6 +325,11 @@ export function resolveSimulateSourceTypeFromDataView(
     return getSimulateCircuitSourceTypeByScale(entity.scale);
   }
 
+  // ME-models simulate through the beta scan-config workflow, not the legacy browse-first one
+  if (extendedType === ExtendedEntitiesTypeDict.Memodel) {
+    return ExtendedEntitiesTypeDict.MemodelCircuit;
+  }
+
   return extendedType;
 }
 


### PR DESCRIPTION
## Description

Relates to openbraininstitute/prod-singlecell-simulation#286

The `Simulate` action in the ME-model detail view previously opened the legacy single-neuron simulation workflow (`workflows/simulate/configure/memodel/{id}`). It now opens the beta scan-config workflow ("Single neuron (beta) simulation") with the clicked ME-model pre-selected.

## Changes

- `resolveSimulateSourceTypeFromDataView` (`src/ui/segments/workflows/config/routes.ts`) now maps `Memodel → MemodelCircuit`, alongside the existing circuit-by-scale mapping. The existing scan-config machinery does the rest: the link resolves to `.../workflows/simulate/configure/me-model-circuit-simulation/{wf_id}` and persists the model as a single-item session selection — the same path circuit detail pages already use.
- New unit tests (`routes.test.ts`) covering the ME-model mapping, circuit-by-scale mapping, passthrough types, and the full URL build including the session-selection persistence.

The legacy Single Neuron workflow stays reachable from Workflows → Simulation (its "(legacy)" rename is handled separately in openbraininstitute/prod-virtual-lab#359). The mini-detail-view "Use model" button is untouched — it lives inside workflow browse pages where the workflow is already chosen.
