### PR TITLE
fix(brain-atlas-viewer): stop non-mouse atlas previews hanging on load

### DIFF
--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/camera.ts
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/camera.ts
@@ -99,13 +99,14 @@ export function setCamera(
 
   const resetCamera = () => {
     context.animSchedule({
+      // `restTransformation` carries no zoom, and the interpolation keeps the
+      // current one when the destination omits it, so ask for 1 explicitly to
+      // undo whatever the user wheeled to.
       action: tgdActionCreateCameraInterpolation(context.camera, {
         ...restTransformation,
+        zoom: 1,
       }),
       duration: 0.5,
-      onEnd: () => {
-        controller.resetZoom();
-      },
     });
   };
 
@@ -122,9 +123,6 @@ export function setCamera(
       fovy: tgdCalcDegToRad(55),
       transfo: { ...restTransformation },
     });
-    // a new camera instance invalidates the orbit controller's zoom baseline.
-    // re-sync it to avoid the first wheel zoom causing a huge jump.
-    controller.resetZoom();
     context.paint();
   };
 

--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.test.ts
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.test.ts
@@ -80,13 +80,17 @@ vi.mock('@tolokoban/tgd', () => {
   };
 });
 
+// `satisfies CameraController` is the point of the annotation: this stub is why the
+// missing `resetZoom` was invisible to the suite, so make it fail to compile the day
+// the real interface changes shape.
 vi.mock('./camera', () => ({
-  setCamera: () => ({
-    resetCamera: () => undefined,
-    fitToBounds: () => {
-      if (h.fitToBoundsError) throw h.fitToBoundsError;
-    },
-  }),
+  setCamera: () =>
+    ({
+      resetCamera: () => undefined,
+      fitToBounds: () => {
+        if (h.fitToBoundsError) throw h.fitToBoundsError;
+      },
+    }) satisfies CameraController,
 }));
 
 vi.mock('./hooks', () => ({
@@ -114,6 +118,7 @@ import { Painter } from './painter';
 import { RegionMeshNotAvailableError } from './services/errors';
 import { getCachedBrainRegionMeshArrayBuffer } from './services/services';
 
+import type { CameraController } from './camera';
 import type { VisibleRegion } from './types';
 
 const region: VisibleRegion = {
@@ -132,6 +137,17 @@ async function waitForParse() {
 }
 
 /**
+ * Wait for the suspended GLB `parse`, settle it with `asset`, then release the
+ * handles so a following `setRegions` cycle can suspend on its own parse.
+ */
+async function settleParseWith(asset: unknown) {
+  await waitForParse();
+  h.resolveParse?.(asset);
+  h.resolveParse = null;
+  h.rejectParse = null;
+}
+
+/**
  * Arrange a started painter that is mid-mesh-load: it has dispatched listeners
  * wired up and a `setRegions` call in flight, suspended on the GLB `parse`.
  * Callers `await waitForParse()` then drive the teardown/resolve they're testing.
@@ -139,23 +155,27 @@ async function waitForParse() {
 function startMeshLoad() {
   const painter = new Painter('atlas-2', {} as never);
   const dispatched: unknown[] = [];
+  const loading: boolean[] = [];
   painter.eventError.addListener((message) => dispatched.push(message));
+  painter.eventLoading.addListener((value) => loading.push(value));
 
   painter.start({} as HTMLCanvasElement);
 
   // Mesh load starts; it suspends on the network fetch, then on `TgdDataGlb.parse`.
   const pending = painter.setRegions([region], 'access-token');
-  return { painter, dispatched, pending };
+  return { painter, dispatched, loading, pending };
 }
 
-describe('Painter.setRegions — context teardown race (issue #490)', () => {
-  beforeEach(() => {
-    h.resolveParse = null;
-    h.rejectParse = null;
-    h.xrayContexts.length = 0;
-    h.logError.mockClear();
-  });
+beforeEach(() => {
+  h.resolveParse = null;
+  h.rejectParse = null;
+  h.xrayContexts.length = 0;
+  h.logError.mockClear();
+  h.fitToBoundsError = null;
+  vi.mocked(getCachedBrainRegionMeshArrayBuffer).mockClear();
+});
 
+describe('Painter.setRegions — context teardown race (issue #490)', () => {
   it('does not use a deleted context or show a popup when a mesh load resolves after a restart', async () => {
     const { painter, dispatched, pending } = startMeshLoad();
     await waitForParse();
@@ -227,29 +247,14 @@ const assetWithBounds = {
 };
 
 describe('Painter.setRegions — camera auto-fit failure', () => {
-  beforeEach(() => {
-    h.resolveParse = null;
-    h.rejectParse = null;
-    h.xrayContexts.length = 0;
-    h.logError.mockClear();
-    h.fitToBoundsError = null;
-    vi.mocked(getCachedBrainRegionMeshArrayBuffer).mockClear();
-  });
-
   it('clears the loading flag and stays usable when the camera fails to fit the bounds', async () => {
     // Framing runs after every mesh is already in the scene, so a throw there must
     // not strand the viewer: the card keeps its canvas hidden behind the loading
     // placeholder for as long as `eventLoading` never reports false.
     h.fitToBoundsError = new Error('resetZoom is not a function');
 
-    const painter = new Painter('atlas-2', {} as never);
-    const loading: boolean[] = [];
-    painter.eventLoading.addListener((value) => loading.push(value));
-    painter.start({} as HTMLCanvasElement);
-
-    const pending = painter.setRegions([region], 'access-token');
-    await waitForParse();
-    h.resolveParse?.(assetWithBounds);
+    const { painter, loading, pending } = startMeshLoad();
+    await settleParseWith(assetWithBounds);
     await pending;
 
     expect(loading.at(-1)).toBe(false);
@@ -258,11 +263,9 @@ describe('Painter.setRegions — camera auto-fit failure', () => {
 
     // `isAddingRegions` must have been released too, otherwise the next call is
     // parked in the one-slot queue forever and the viewer can never recover.
-    h.resolveParse = null;
     vi.mocked(getCachedBrainRegionMeshArrayBuffer).mockClear();
     const next = painter.setRegions([{ ...region, id: 'cerebellum' }], 'access-token');
-    await waitForParse();
-    h.resolveParse?.(assetWithBounds);
+    await settleParseWith(assetWithBounds);
     await next;
 
     expect(getCachedBrainRegionMeshArrayBuffer).toHaveBeenCalledTimes(1);

--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.test.ts
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.test.ts
@@ -8,6 +8,8 @@ const h = vi.hoisted(() => ({
   rejectParse: null as null | ((reason: unknown) => void),
   xrayContexts: [] as Array<{ id: number; deleted: boolean }>,
   logError: vi.fn(),
+  /** When set, the camera's `fitToBounds` throws it. See the auto-fit failure test. */
+  fitToBoundsError: null as null | Error,
 }));
 
 // Fake the WebGL toolkit. `TgdDataGlb.parse` is suspended on a controllable
@@ -79,7 +81,12 @@ vi.mock('@tolokoban/tgd', () => {
 });
 
 vi.mock('./camera', () => ({
-  setCamera: () => ({ resetCamera: () => undefined, fitToBounds: () => undefined }),
+  setCamera: () => ({
+    resetCamera: () => undefined,
+    fitToBounds: () => {
+      if (h.fitToBoundsError) throw h.fitToBoundsError;
+    },
+  }),
 }));
 
 vi.mock('./hooks', () => ({
@@ -205,5 +212,60 @@ describe('Painter.setRegions — context teardown race (issue #490)', () => {
 
     expect(dispatched).toHaveLength(1);
     expect(h.logError).toHaveBeenCalled();
+  });
+});
+
+/**
+ * A parsed GLB whose POSITION accessor carries min/max, so `extractBoundsFromGltf`
+ * yields real bounds and `setRegions` goes on to auto-fit the camera.
+ */
+const assetWithBounds = {
+  getJson: () => ({
+    accessors: [{ min: [0, 0, 0], max: [1, 1, 1] }],
+    meshes: [{ primitives: [{ attributes: { POSITION: 0 } }] }],
+  }),
+};
+
+describe('Painter.setRegions — camera auto-fit failure', () => {
+  beforeEach(() => {
+    h.resolveParse = null;
+    h.rejectParse = null;
+    h.xrayContexts.length = 0;
+    h.logError.mockClear();
+    h.fitToBoundsError = null;
+    vi.mocked(getCachedBrainRegionMeshArrayBuffer).mockClear();
+  });
+
+  it('clears the loading flag and stays usable when the camera fails to fit the bounds', async () => {
+    // Framing runs after every mesh is already in the scene, so a throw there must
+    // not strand the viewer: the card keeps its canvas hidden behind the loading
+    // placeholder for as long as `eventLoading` never reports false.
+    h.fitToBoundsError = new Error('resetZoom is not a function');
+
+    const painter = new Painter('atlas-2', {} as never);
+    const loading: boolean[] = [];
+    painter.eventLoading.addListener((value) => loading.push(value));
+    painter.start({} as HTMLCanvasElement);
+
+    const pending = painter.setRegions([region], 'access-token');
+    await waitForParse();
+    h.resolveParse?.(assetWithBounds);
+    await pending;
+
+    expect(loading.at(-1)).toBe(false);
+    expect(painter.isLoading).toBe(false);
+    expect(h.logError).toHaveBeenCalled();
+
+    // `isAddingRegions` must have been released too, otherwise the next call is
+    // parked in the one-slot queue forever and the viewer can never recover.
+    h.resolveParse = null;
+    vi.mocked(getCachedBrainRegionMeshArrayBuffer).mockClear();
+    const next = painter.setRegions([{ ...region, id: 'cerebellum' }], 'access-token');
+    await waitForParse();
+    h.resolveParse?.(assetWithBounds);
+    await next;
+
+    expect(getCachedBrainRegionMeshArrayBuffer).toHaveBeenCalledTimes(1);
+    expect(painter.isLoading).toBe(false);
   });
 });

--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.tsx
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.tsx
@@ -201,71 +201,86 @@ export class Painter {
     this.loadingMesh = true;
     this.isAddingRegions = true;
     this.nextRegionsToAdd = null;
-    const shouldAutoFitCamera = !this.hasFittedCamera && this.AtlasID !== config.MOUSE_ATLAS__ID;
-    let mergedBounds: MeshBounds | null = null;
-    const regionsKeys = new Set(regions.map((region) => region.id));
-    const keysToRemove: string[] = [];
-    for (const key of this.regionPainters.keys()) {
-      if (!regionsKeys.has(key)) {
-        keysToRemove.push(key);
+    try {
+      const shouldAutoFitCamera = !this.hasFittedCamera && this.AtlasID !== config.MOUSE_ATLAS__ID;
+      let mergedBounds: MeshBounds | null = null;
+      const regionsKeys = new Set(regions.map((region) => region.id));
+      const keysToRemove: string[] = [];
+      for (const key of this.regionPainters.keys()) {
+        if (!regionsKeys.has(key)) {
+          keysToRemove.push(key);
+        }
+      }
+      for (const key of keysToRemove) {
+        const painter = this.regionPainters.get(key);
+        this.regionPainters.delete(key);
+        if (!painter) continue;
+
+        this.group?.remove(painter);
+        this.context?.paint();
+      }
+      for (const region of regions) {
+        try {
+          const data = await getCachedBrainRegionMeshArrayBuffer({
+            atlasId: this.AtlasID,
+            regionId: region.id,
+            queryClient: this.queryClient,
+          });
+          // Context was torn down / replaced while fetching. Abort silently and do
+          // NOT reset isAddingRegions/loadingMesh — a newer start()/setRegions owns
+          // that state now, which the guard on the finally below preserves.
+          if (contextVersion !== this.contextVersion) return;
+
+          const meshBounds = await this.addMesh(data, region, contextVersion);
+          // addMesh swallows its own errors and resolves null, so re-check here
+          // before falling through to the cleanup tail.
+          if (contextVersion !== this.contextVersion) return;
+
+          if (shouldAutoFitCamera && meshBounds) {
+            mergedBounds = this.mergeBounds(mergedBounds, meshBounds);
+          }
+        } catch (ex) {
+          // A stale request must never surface a popup on whatever tab the user has
+          // navigated to. Only genuine failures on the current context dispatch.
+          if (contextVersion !== this.contextVersion) return;
+
+          // The region simply has no mesh in this atlas (a selectable-but-non-volumetric
+          // region, e.g. "grooves"). Expected and benign — log it, skip the popup, and
+          // keep loading the remaining regions.
+          if (isMeshNotAvailableError(ex)) {
+            logError(`No 3D mesh available for region "${region.name}":`, ex);
+            continue;
+          }
+
+          logError(`Unable to load mesh for region "${region.name}":`, ex);
+          this.eventError.dispatch(
+            <>
+              <strong>{region.name}</strong>
+              <p>An error occurred while attempting to visualize the brain region mesh.</p>
+            </>
+          );
+        }
+      }
+      if (shouldAutoFitCamera && mergedBounds && this.cameraController) {
+        // Framing is cosmetic: if it fails, the meshes are already in the scene,
+        // so log and carry on rather than leaving the canvas hidden behind the
+        // loading placeholder forever.
+        try {
+          this.cameraController.fitToBounds(mergedBounds.min, mergedBounds.max);
+          this.hasFittedCamera = true;
+        } catch (ex) {
+          logError('Unable to fit the camera to the mesh bounds:', ex);
+        }
+      }
+    } finally {
+      // Only the current owner may clear these. On a stale context a newer
+      // start()/setRegions has taken over and must keep them set (cf. the early
+      // returns above and setPointCloud's guarded finally).
+      if (contextVersion === this.contextVersion) {
+        this.isAddingRegions = false;
+        this.loadingMesh = false;
       }
     }
-    for (const key of keysToRemove) {
-      const painter = this.regionPainters.get(key);
-      this.regionPainters.delete(key);
-      if (!painter) continue;
-
-      this.group?.remove(painter);
-      this.context?.paint();
-    }
-    for (const region of regions) {
-      try {
-        const data = await getCachedBrainRegionMeshArrayBuffer({
-          atlasId: this.AtlasID,
-          regionId: region.id,
-          queryClient: this.queryClient,
-        });
-        // Context was torn down / replaced while fetching. Abort silently and do
-        // NOT reset isAddingRegions/loadingMesh — a newer start()/setRegions owns
-        // that state now (cf. setPointCloud's guarded finally).
-        if (contextVersion !== this.contextVersion) return;
-
-        const meshBounds = await this.addMesh(data, region, contextVersion);
-        // addMesh swallows its own errors and resolves null, so re-check here
-        // before falling through to the cleanup tail.
-        if (contextVersion !== this.contextVersion) return;
-
-        if (shouldAutoFitCamera && meshBounds) {
-          mergedBounds = this.mergeBounds(mergedBounds, meshBounds);
-        }
-      } catch (ex) {
-        // A stale request must never surface a popup on whatever tab the user has
-        // navigated to. Only genuine failures on the current context dispatch.
-        if (contextVersion !== this.contextVersion) return;
-
-        // The region simply has no mesh in this atlas (a selectable-but-non-volumetric
-        // region, e.g. "grooves"). Expected and benign — log it, skip the popup, and
-        // keep loading the remaining regions.
-        if (isMeshNotAvailableError(ex)) {
-          logError(`No 3D mesh available for region "${region.name}":`, ex);
-          continue;
-        }
-
-        logError(`Unable to load mesh for region "${region.name}":`, ex);
-        this.eventError.dispatch(
-          <>
-            <strong>{region.name}</strong>
-            <p>An error occurred while attempting to visualize the brain region mesh.</p>
-          </>
-        );
-      }
-    }
-    if (shouldAutoFitCamera && mergedBounds && this.cameraController) {
-      this.cameraController.fitToBounds(mergedBounds.min, mergedBounds.max);
-      this.hasFittedCamera = true;
-    }
-    this.isAddingRegions = false;
-    this.loadingMesh = false;
     // Check if there is a waiting call.
     const nextRegionsToAdd = this.getNextRegionsToAdd();
     if (nextRegionsToAdd) {

--- a/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.tsx
+++ b/src/features/brain-atlas-viewer/brain-atlas-viewer-gltf/painter.tsx
@@ -262,12 +262,16 @@ export class Painter {
         }
       }
       if (shouldAutoFitCamera && mergedBounds && this.cameraController) {
-        // Framing is cosmetic: if it fails, the meshes are already in the scene,
-        // so log and carry on rather than leaving the canvas hidden behind the
-        // loading placeholder forever.
+        // Framing is cosmetic — the meshes are already in the scene — but it still
+        // needs its own catch: the guarded finally below releases the loading flags,
+        // yet a throw here would skip the queue drain that follows it and surface as
+        // an unhandled rejection at the fire-and-forget call sites.
+        // Count the attempt either way. A fit that throws will throw again on the
+        // same bounds, so retrying it on every selection change only repeats the
+        // failure and its log.
+        this.hasFittedCamera = true;
         try {
           this.cameraController.fitToBounds(mergedBounds.min, mergedBounds.max);
-          this.hasFittedCamera = true;
         } catch (ex) {
           logError('Unable to fit the camera to the mesh bounds:', ex);
         }


### PR DESCRIPTION
## Problem

On the Data page with **Species: "All"**, most of the 3D atlas previews never appear — they sit on the loading placeholder forever, with this in the console:

```
Uncaught (in promise) TypeError: s.resetZoom is not a function
    at Object.fitToBounds (camera.ts:127:16)
    at sP.setRegions (painter.tsx:264:29)
```

Reproduced on staging: Human, Rat, Fruit Fly, Cat, Longfin Squid and African Clawed Frog all hang. Mouse renders, and species with no atlas at all (American Bullfrog, Chinese Hamster) render because they fall back to a static image and never construct a `Painter`.

## Root cause

`TgdControllerCameraOrbit` has no `resetZoom()`. It does not exist in `@tolokoban/tgd` 2.2.0, the only version this repo has ever pinned — the sole trace of the name left in the package is a stale doc comment (`orbit.d.ts:130`) on a private field that is assigned once in the constructor and never read.

`fitToBounds` only runs for non-mouse atlases (`shouldAutoFitCamera` excludes `MOUSE_ATLAS__ID`), and the all-species grid is the only surface that mounts those, which is why the bug is invisible until you pick "All".

The hang is a second, separate defect that this merely exposed. `fitToBounds` was called outside any try/catch, and the two lines directly below it are the only place the happy path clears the loading flags. When it threw:

- `loadingMesh` stayed `true`, so `eventLoading` never dispatched `false`, and `species-atlas-preview.tsx` held the canvas at `opacity-0` behind the placeholder. The meshes were loaded and painted the whole time — just pinned invisible.
- `isAddingRegions` stayed `true`, so every later `setRegions` short-circuited into the one-slot `nextRegionsToAdd` queue and never ran. No watchdog exists, and the `ErrorBoundary` only catches render errors, so the card could never recover.

## Changes

**`camera.ts`** — dropped the call in `fitToBounds`; a fresh `TgdCameraPerspective` already starts at `zoom = 1` and the controller reads zoom live off `context.camera`, so the "zoom baseline" the old comment described doesn't exist in this version. In `resetCamera` the intent was real — `tgdActionCreateCameraInterpolation` keeps the current zoom when the destination omits it, so a zoomed-in user kept their zoom across a reset — so that one now passes `zoom: 1` in the interpolation destination and animates back with everything else. That also fixes the reset-camera button, which was throwing the same error from its `onEnd`.

**`painter.tsx`** — the flag reset moved into a `finally` guarded by `contextVersion === this.contextVersion`, which makes "the current owner always releases the flags" a property of the method rather than of one call site. The guard preserves the existing invariant: the stale-context early returns still hand that state to whichever newer `start()`/`setRegions` owns it, the same shape `setPointCloud` already uses.

`fitToBounds` additionally keeps its own `catch`. That isn't belt-and-braces — the `finally` releases the flags, but a throw would still skip the queue drain that runs after it and surface as an unhandled rejection at the fire-and-forget call sites. `hasFittedCamera` is set *before* the call so the attempt stays one-shot; leaving it unset on failure would re-run the whole framing path on every later selection change, repeating a deterministic throw and its log each time.

**`painter.test.ts`** — regression test for the loading-state fix: makes the mocked camera's `fitToBounds` throw, then asserts `eventLoading` still reports `false` and that a following `setRegions` actually executes rather than being parked in the queue. Verified it fails on the pre-fix `painter.tsx` and passes after. The `./camera` stub is now typed with `satisfies CameraController` — that stub is exactly why the missing `resetZoom` was invisible to the suite, so it should fail to compile the day the interface changes shape.
