### PR TITLE
Support notebook links in Get Started card

### DIFF
--- a/src/ui/segments/project/get-started/sections/get-started-card.tsx
+++ b/src/ui/segments/project/get-started/sections/get-started-card.tsx
@@ -188,6 +188,13 @@ function ResourceItem({
   const onClick = () => {
     if (loading) return;
 
+    if (resource.entityType === ProjectHomeResourceEntityTypeDict.Notebook) {
+      router.push(
+        `${config.ROOT_ROUTE}/${workspace.virtualLabId}/${workspace.projectId}/notebooks/view/analysis-notebook-template/${entityId}/overview`
+      );
+      return;
+    }
+
     if (resource.entityType !== ProjectHomeResourceEntityTypeDict.Workflow) {
       router.push(`/app/entity/${entityId}`);
       return;


### PR DESCRIPTION
## Summary
Support notebook resource links in the project **Get Started** card.

- When a Get Started resource has `entityType === Notebook`, clicking it now navigates to the notebook's analysis-notebook-template overview page:
  `${ROOT_ROUTE}/{virtualLabId}/{projectId}/notebooks/view/analysis-notebook-template/{entityId}/overview`
- Previously these fell through to the generic `/app/entity/{entityId}` route.

[Warp conversation](https://app.warp.dev/conversation/dcf11d0a-b1c9-4e75-abac-db08a95ef4ac)

Co-Authored-By: Oz <oz-agent@warp.dev>
