### PR TITLE
Remove title prop from CodeBlock in file viewers

### DIFF
--- a/src/features/scan-config/components/file-viewer/code-viewer.tsx
+++ b/src/features/scan-config/components/file-viewer/code-viewer.tsx
@@ -81,7 +81,6 @@ export function CodeFileViewer({
 
   const fileName = assetPath?.split('/').at(-1) ?? asset.path.split('/').at(-1);
   const language = fileName?.split('.').at(-1) as BundledLanguage;
-  const filename = assetPath?.split('.').at(-1) ?? asset.path.split('/').pop() ?? 'file';
 
   const LARGE_FILE_CHAR_LIMIT = 10000;
   const isLargeFile = content.length > LARGE_FILE_CHAR_LIMIT;
@@ -93,7 +92,6 @@ export function CodeFileViewer({
       code={displayContent}
       language={language}
       showLineNumbers={!isLargeFile}
-      title={filename}
       className={cn(
         'secondary-scrollbar h-full overflow-auto [&_pre]:overflow-x-auto',
         '[&_pre]:whitespace-pre [&>div]:overflow-auto [&>div>div]:overflow-x-auto',

--- a/src/features/scan-config/components/file-viewer/code-viewer.tsx
+++ b/src/features/scan-config/components/file-viewer/code-viewer.tsx
@@ -100,7 +100,7 @@ export function CodeFileViewer({
     >
       <div className="bg-neutral-light flex items-center justify-between border-b border-gray-200 px-3 py-2">
         <div className="flex items-center gap-3">
-          <CodeBlockLanguageLabel />
+          <CodeBlockLanguageLabel title={fileName} />
 
           {isLargeFile && (
             <span className="rounded border border-amber-200 bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">

--- a/src/ui/molecules/code-blocks/index.tsx
+++ b/src/ui/molecules/code-blocks/index.tsx
@@ -145,11 +145,18 @@ export type CodeBlockCopyButtonProps = ComponentProps<typeof Button> & {
   iconClassName?: string;
 };
 
-export function CodeBlockLanguageLabel({ className }: { className?: string }): React.ReactElement {
+export function CodeBlockLanguageLabel({
+  className,
+  title,
+}: {
+  className?: string;
+  title?: string;
+}): React.ReactElement {
   const { language } = useContext(CodeBlockContext);
 
   return (
     <span
+      title={title}
       className={cn(
         'rounded-full border border-gray-300 px-4 py-1 text-xs',
         'font-medium tracking-wide text-gray-500 uppercase',

--- a/src/ui/segments/workflows/build/ion-channel-build/sections/file-viewer.tsx
+++ b/src/ui/segments/workflows/build/ion-channel-build/sections/file-viewer.tsx
@@ -91,13 +91,7 @@ export function FileViewer({
   }
 
   if (isJson || isMod) {
-    return (
-      <CodeFileViewer
-        url={presignedData.url}
-        filename={asset.path}
-        language={isJson ? 'json' : 'shellscript'}
-      />
-    );
+    return <CodeFileViewer url={presignedData.url} language={isJson ? 'json' : 'shellscript'} />;
   }
 
   return (
@@ -166,15 +160,7 @@ export function PDFViewer({ url, filename }: { url: string; filename: string }) 
   );
 }
 
-export function CodeFileViewer({
-  url,
-  filename,
-  language,
-}: {
-  url: string;
-  filename: string;
-  language: BundledLanguage;
-}) {
+export function CodeFileViewer({ url, language }: { url: string; language: BundledLanguage }) {
   const { data: content, isLoading } = useQuery({
     queryKey: ['file-content', url],
     queryFn: async () => {
@@ -216,7 +202,6 @@ export function CodeFileViewer({
         code={content}
         language={language}
         showLineNumbers
-        title={filename}
         className={cn(
           'secondary-scrollbar h-full overflow-auto [&_pre]:overflow-x-auto',
           '[&_pre]:whitespace-pre [&>div]:overflow-auto [&>div>div]:overflow-x-auto',

--- a/src/ui/segments/workflows/build/ion-channel-build/sections/file-viewer.tsx
+++ b/src/ui/segments/workflows/build/ion-channel-build/sections/file-viewer.tsx
@@ -7,7 +7,7 @@ import { Document, Page, pdfjs } from 'react-pdf';
 
 import { AssetContentType, AssetLabel } from '@/api/entitycore/types/shared/global';
 import { getEntityCorePresignedUrl } from '@/services/entity-download/pre-singed-url';
-import { CodeBlock, CodeBlockCopyButton } from '@/ui/molecules/code-blocks';
+import { CodeBlock, CodeBlockCopyButton, CodeBlockLanguageLabel } from '@/ui/molecules/code-blocks';
 import { Skeleton } from '@/ui/molecules/skeleton';
 import { keyBuilder } from '@/ui/use-query-keys/third-parties';
 import { cn } from '@/utils/css-class';
@@ -91,7 +91,13 @@ export function FileViewer({
   }
 
   if (isJson || isMod) {
-    return <CodeFileViewer url={presignedData.url} language={isJson ? 'json' : 'shellscript'} />;
+    return (
+      <CodeFileViewer
+        url={presignedData.url}
+        filename={asset.path}
+        language={isJson ? 'json' : 'shellscript'}
+      />
+    );
   }
 
   return (
@@ -160,7 +166,15 @@ export function PDFViewer({ url, filename }: { url: string; filename: string }) 
   );
 }
 
-export function CodeFileViewer({ url, language }: { url: string; language: BundledLanguage }) {
+export function CodeFileViewer({
+  url,
+  filename,
+  language,
+}: {
+  url: string;
+  filename: string;
+  language: BundledLanguage;
+}) {
   const { data: content, isLoading } = useQuery({
     queryKey: ['file-content', url],
     queryFn: async () => {
@@ -209,6 +223,7 @@ export function CodeFileViewer({ url, language }: { url: string; language: Bundl
         )}
       >
         <div className="bg-neutral-light flex items-center justify-between px-2 py-2">
+          <CodeBlockLanguageLabel title={filename} />
           <CodeBlockCopyButton
             onCopy={handleCopy}
             onError={() => {}}


### PR DESCRIPTION
Minor thing, but the other day while hovering over the file viewer I realized it was showing a tooltip with the file extension (e.g. "json"). I don't think this is the right behavior since it adds clutter and makes the file content less visible. 


This PR tries to fix that by removing the tooltip.

<img width="1222" height="442" alt="tooltip_bug" src="https://github.com/user-attachments/assets/848b0eb6-8bb2-4c0e-ad5f-42fa78e168f6" />
