### PR TITLE
fix(home): resolve Get Started workflow examples from an entity id

### DIFF
--- a/src/__tests__/workflows/entity-entry.test.ts
+++ b/src/__tests__/workflows/entity-entry.test.ts
@@ -1,0 +1,397 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit';
+import { TaskConfigType } from '@/api/entitycore/types/entities/task-config';
+import { EntityTypeDict } from '@/api/entitycore/types/entity-type';
+import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import { WorkflowActivityDictValue } from '@/constants';
+import {
+  brainRegionSimulationFlag,
+  extracellularRecordingArrayBuildFlag,
+  extractionActivityFlag,
+} from '@/features/feature-flags/flags';
+import {
+  readWorkflowSessionSelection,
+  WorkflowSessionSelectionMode,
+} from '@/features/scan-config/workflow/workflow-session-selection';
+import { ActivityRegistry } from '@/ui/segments/workflows/config/activities';
+import { resolveWorkflowConfigureHrefForEntity } from '@/ui/segments/workflows/config/entity-entry';
+
+import type { TCircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit';
+import type { TEntityTypeDict } from '@/api/entitycore/types/entity-type';
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import type { FeatureFlags } from '@/features/feature-flags/flags';
+import type { TActivityValue } from '@/ui/segments/workflows/config/types';
+
+const { getEntity, getCircuit, getSimulationCampaign, getTaskConfig } = vi.hoisted(() => ({
+  getEntity: vi.fn(),
+  getCircuit: vi.fn(),
+  getSimulationCampaign: vi.fn(),
+  getTaskConfig: vi.fn(),
+}));
+
+vi.mock('@/api/entitycore/queries/general/entity', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getEntity,
+}));
+vi.mock('@/api/entitycore/queries/model/circuit', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getCircuit,
+}));
+vi.mock('@/api/entitycore/queries/simulation/campaign', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getSimulationCampaign,
+}));
+vi.mock('@/api/entitycore/queries/task/task-config', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getTaskConfig,
+}));
+
+const workspace = { virtualLabId: 'lab-1', projectId: 'project-1' };
+
+/** every flag on, so flag-gated workflows are reachable in the table below */
+const allFlags = {
+  [extractionActivityFlag.key]: true,
+  [brainRegionSimulationFlag.key]: true,
+  [extracellularRecordingArrayBuildFlag.key]: true,
+} as FeatureFlags;
+
+const ENTITY_ID = 'entity-id';
+const INPUT_ID = 'input-id';
+
+type TFixture = {
+  /** the entity the link points at */
+  entity: { type: TEntityTypeDict; scale?: TCircuitScaleDictionary };
+  /** entity referenced by a simulation campaign, or by a task config's first input */
+  input?: { type: TEntityTypeDict; scale?: TCircuitScaleDictionary };
+  taskConfigType?: string;
+};
+
+type TCase = {
+  name: string;
+  fixture: TFixture;
+  /** workflow this entity must land in — also what the coverage guard counts */
+  covers: { activity: TActivityValue; targetType: TExtendedEntitiesTypeDict };
+  /** full expected href, `{session}` standing in for a generated `wf_*` id */
+  href: string;
+  /** entity the configure session must be seeded with, when the workflow browses one */
+  selects?: { type: TExtendedEntitiesTypeDict; id: string };
+  /** defaults to every flag on */
+  flags?: FeatureFlags;
+};
+
+const base = `/app/virtual-lab/${workspace.virtualLabId}/${workspace.projectId}/workflows`;
+const { build, simulate, extract, process } = WorkflowActivityDictValue;
+
+const cases: TCase[] = [
+  // source models: a new configure session, entity pre-selected ───
+  {
+    name: 'ME-model → single neuron (beta) simulation',
+    fixture: { entity: { type: EntityTypeDict.Memodel } },
+    covers: { activity: simulate, targetType: ExtendedEntitiesTypeDict.MemodelCircuitSimulation },
+    href: `${base}/simulate/configure/me-model-circuit-simulation/{session}?panel=configuration`,
+    selects: { type: ExtendedEntitiesTypeDict.MemodelCircuit, id: ENTITY_ID },
+  },
+  {
+    // static-type workflow: its editor picks the ion channel models itself, so the route carries
+    // no session id and no pre-selection
+    name: 'ion channel model → ion channel simulation',
+    fixture: { entity: { type: EntityTypeDict.IonChannelModel } },
+    covers: {
+      activity: simulate,
+      targetType: ExtendedEntitiesTypeDict.IonChannelModelSimulation,
+    },
+    href: `${base}/simulate/configure/ion-channel-model-simulation?panel=configuration`,
+  },
+  {
+    name: 'single-neuron circuit → synaptome (beta) simulation',
+    fixture: { entity: { type: EntityTypeDict.Circuit, scale: CircuitScaleDictionary.Single } },
+    covers: {
+      activity: simulate,
+      targetType: ExtendedEntitiesTypeDict.SingleNeuronCircuitSimulation,
+    },
+    href: `${base}/simulate/configure/single-neuron-circuit-simulation/{session}?panel=configuration`,
+    selects: { type: ExtendedEntitiesTypeDict.SingleNeuronCircuit, id: ENTITY_ID },
+  },
+  {
+    name: 'paired-neuron circuit → paired neurons simulation',
+    fixture: { entity: { type: EntityTypeDict.Circuit, scale: CircuitScaleDictionary.PairNeuron } },
+    covers: {
+      activity: simulate,
+      targetType: ExtendedEntitiesTypeDict.PairedNeuronCircuitSimulation,
+    },
+    href: `${base}/simulate/configure/paired-neuron-circuit-simulation/{session}?panel=configuration`,
+    selects: { type: ExtendedEntitiesTypeDict.PairedNeuronCircuit, id: ENTITY_ID },
+  },
+  {
+    name: 'small microcircuit → small microcircuit simulation',
+    fixture: {
+      entity: { type: EntityTypeDict.Circuit, scale: CircuitScaleDictionary.SmallMicrocircuit },
+    },
+    covers: {
+      activity: simulate,
+      targetType: ExtendedEntitiesTypeDict.SmallMicrocircuitSimulation,
+    },
+    href: `${base}/simulate/configure/small-microcircuit-simulation/{session}?panel=configuration`,
+    selects: { type: ExtendedEntitiesTypeDict.SmallMicrocircuit, id: ENTITY_ID },
+  },
+  {
+    name: 'microcircuit → microcircuit simulation',
+    fixture: {
+      entity: { type: EntityTypeDict.Circuit, scale: CircuitScaleDictionary.Microcircuit },
+    },
+    covers: { activity: simulate, targetType: ExtendedEntitiesTypeDict.MicrocircuitSimulation },
+    href: `${base}/simulate/configure/microcircuit-simulation/{session}?panel=configuration`,
+    selects: { type: ExtendedEntitiesTypeDict.Microcircuit, id: ENTITY_ID },
+  },
+  {
+    name: 'region circuit → brain region simulation',
+    fixture: { entity: { type: EntityTypeDict.Circuit, scale: CircuitScaleDictionary.Region } },
+    covers: { activity: simulate, targetType: ExtendedEntitiesTypeDict.RegionCircuitSimulation },
+    href: `${base}/simulate/configure/region-circuit-simulation/{session}?panel=configuration`,
+    selects: { type: ExtendedEntitiesTypeDict.BrainRegion, id: ENTITY_ID },
+  },
+  {
+    name: 'whole-brain circuit → whole brain simulation',
+    fixture: { entity: { type: EntityTypeDict.Circuit, scale: CircuitScaleDictionary.WholeBrain } },
+    covers: {
+      activity: simulate,
+      targetType: ExtendedEntitiesTypeDict.WholeBrainCircuitSimulation,
+    },
+    href: `${base}/simulate/configure/whole-brain-circuit-simulation/{session}?panel=configuration`,
+    selects: { type: ExtendedEntitiesTypeDict.WholeBrain, id: ENTITY_ID },
+  },
+  {
+    name: 'EM cell mesh → skeletonization',
+    fixture: { entity: { type: EntityTypeDict.EMCellMesh } },
+    covers: { activity: process, targetType: ExtendedEntitiesTypeDict.SkeletonizationCampaign },
+    href: `${base}/process/configure/skeletonization-campaign/{session}`,
+    selects: { type: ExtendedEntitiesTypeDict.EMCellMesh, id: ENTITY_ID },
+  },
+  {
+    // a circuit with no scale matches no simulation, so it falls to the activities that take a
+    // circuit whatever its scale — build before extract, following activity order
+    name: 'scale-less circuit → recording array build',
+    fixture: { entity: { type: EntityTypeDict.Circuit } },
+    covers: {
+      activity: build,
+      targetType: ExtendedEntitiesTypeDict.ExtracellularRecordingArrayCampaign,
+    },
+    href: `${base}/build/configure/extracellular-recording-array-campaign/{session}`,
+    selects: { type: ExtendedEntitiesTypeDict.Circuit, id: ENTITY_ID },
+  },
+  {
+    name: 'scale-less circuit → circuit extraction when only extraction is enabled',
+    fixture: { entity: { type: EntityTypeDict.Circuit } },
+    covers: { activity: extract, targetType: ExtendedEntitiesTypeDict.CircuitExtractionCampaign },
+    href: `${base}/extract/configure/circuit-extraction-campaign/{session}`,
+    selects: { type: ExtendedEntitiesTypeDict.Circuit, id: ENTITY_ID },
+    flags: { [extractionActivityFlag.key]: true } as FeatureFlags,
+  },
+
+  // legacy browse-first workflows: configure keyed by the entity itself ───
+  {
+    name: 'synaptome → single neuron synaptome simulation',
+    fixture: { entity: { type: EntityTypeDict.SingleNeuronSynaptome } },
+    covers: {
+      activity: simulate,
+      targetType: ExtendedEntitiesTypeDict.SingleNeuronSynaptomeSimulation,
+    },
+    href: `${base}/simulate/configure/single-neuron-synaptome/${ENTITY_ID}?panel=configuration&session={session}`,
+  },
+
+  // activity outputs: reopen the run that produced them ───
+  {
+    name: 'EM synapse mapping campaign reopens its own configuration',
+    fixture: { entity: { type: EntityTypeDict.EmSynapseMappingCampaign } },
+    covers: { activity: build, targetType: ExtendedEntitiesTypeDict.EmSynapseMappingCampaign },
+    href: `${base}/build/configure/em-synapse-mapping-campaign/{session}?origin=${ENTITY_ID}`,
+  },
+  {
+    name: 'ion channel modeling campaign falls back to its detail view',
+    fixture: { entity: { type: EntityTypeDict.IonChannelModelingCampaign } },
+    covers: { activity: build, targetType: ExtendedEntitiesTypeDict.IonChannelModelingCampaign },
+    href: `${base}/view/ion-channel-modeling-campaign/${ENTITY_ID}/overview`,
+  },
+  {
+    name: 'legacy single neuron simulation falls back to its detail view',
+    fixture: { entity: { type: EntityTypeDict.SingleNeuronSimulation } },
+    covers: { activity: simulate, targetType: ExtendedEntitiesTypeDict.SingleNeuronSimulation },
+    href: `${base}/view/single-neuron-simulation/${ENTITY_ID}/configuration`,
+  },
+
+  // simulation campaigns: resolved through the model they ran on ───
+  {
+    name: 'ME-model campaign → single neuron (beta) editor',
+    fixture: {
+      entity: { type: EntityTypeDict.SimulationCampaign },
+      input: { type: EntityTypeDict.Memodel },
+    },
+    covers: { activity: simulate, targetType: ExtendedEntitiesTypeDict.MemodelCircuitSimulation },
+    href: `${base}/simulate/configure/me-model-circuit-simulation/{session}?origin=${ENTITY_ID}`,
+  },
+  {
+    name: 'circuit campaign → editor matching the circuit scale',
+    fixture: {
+      entity: { type: EntityTypeDict.SimulationCampaign },
+      input: { type: EntityTypeDict.Circuit, scale: CircuitScaleDictionary.Microcircuit },
+    },
+    covers: { activity: simulate, targetType: ExtendedEntitiesTypeDict.MicrocircuitSimulation },
+    href: `${base}/simulate/configure/microcircuit-simulation/{session}?origin=${ENTITY_ID}`,
+  },
+  {
+    name: 'ion channel campaign → ion channel editor',
+    fixture: {
+      entity: { type: EntityTypeDict.SimulationCampaign },
+      input: { type: EntityTypeDict.IonChannelModel },
+    },
+    covers: {
+      activity: simulate,
+      targetType: ExtendedEntitiesTypeDict.IonChannelModelSimulation,
+    },
+    href: `${base}/simulate/configure/ion-channel-model-simulation?origin=${ENTITY_ID}`,
+  },
+
+  // task-config campaigns: matched through the workflow's task bindings ───
+  {
+    name: 'extraction task config → extract editor',
+    fixture: {
+      entity: { type: EntityTypeDict.TaskConfig },
+      input: { type: EntityTypeDict.Circuit },
+      taskConfigType: TaskConfigType.CircuitExtractionCampaign,
+    },
+    covers: { activity: extract, targetType: ExtendedEntitiesTypeDict.CircuitExtractionCampaign },
+    href: `${base}/extract/configure/circuit-extraction-campaign/{session}?origin=${ENTITY_ID}`,
+  },
+  {
+    name: 'skeletonization task config → process editor',
+    fixture: {
+      entity: { type: EntityTypeDict.TaskConfig },
+      input: { type: EntityTypeDict.EMCellMesh },
+      taskConfigType: TaskConfigType.SkeletonizationCampaign,
+    },
+    covers: { activity: process, targetType: ExtendedEntitiesTypeDict.SkeletonizationCampaign },
+    href: `${base}/process/configure/skeletonization-campaign/{session}?origin=${ENTITY_ID}`,
+  },
+  {
+    name: 'EM synapse mapping task config → build editor',
+    fixture: {
+      entity: { type: EntityTypeDict.TaskConfig },
+      input: { type: EntityTypeDict.Memodel },
+      taskConfigType: TaskConfigType.EmSynapseMappingCampaign,
+    },
+    covers: { activity: build, targetType: ExtendedEntitiesTypeDict.EmSynapseMappingCampaign },
+    href: `${base}/build/configure/em-synapse-mapping-campaign/{session}?origin=${ENTITY_ID}`,
+  },
+  {
+    name: 'recording-array task config → build editor',
+    fixture: {
+      entity: { type: EntityTypeDict.TaskConfig },
+      input: { type: EntityTypeDict.Circuit },
+      taskConfigType: TaskConfigType.ExtracellularRecordingWeightsCalculationCampaign,
+    },
+    covers: {
+      activity: build,
+      targetType: ExtendedEntitiesTypeDict.ExtracellularRecordingArrayCampaign,
+    },
+    href: `${base}/build/configure/extracellular-recording-array-campaign/{session}?origin=${ENTITY_ID}`,
+  },
+  {
+    name: 'circuit simulation task config picks the workflow matching its input scale',
+    fixture: {
+      entity: { type: EntityTypeDict.TaskConfig },
+      input: { type: EntityTypeDict.Circuit, scale: CircuitScaleDictionary.Microcircuit },
+      taskConfigType: TaskConfigType.CircuitSimulationCampaign,
+    },
+    covers: { activity: simulate, targetType: ExtendedEntitiesTypeDict.MicrocircuitSimulation },
+    href: `${base}/simulate/configure/microcircuit-simulation/{session}?origin=${ENTITY_ID}`,
+  },
+];
+
+/**
+ * workflows no entity id can reach, because the type they consume resolves to another workflow
+ * first: an ME-model opens the simulation editor, a synaptome likewise. Their build editors are
+ * reached from the workflows page, not from an entity link
+ */
+const UNREACHABLE_FROM_AN_ENTITY_ID: ReadonlySet<string> = new Set([
+  `${build}/${ExtendedEntitiesTypeDict.Memodel}`,
+  `${build}/${ExtendedEntitiesTypeDict.SingleNeuronSynaptome}`,
+]);
+
+function applyFixture(fixture: TFixture) {
+  getEntity.mockImplementation(async ({ id }: { id: string }) => {
+    const entity = id === ENTITY_ID ? fixture.entity : fixture.input;
+    return { id, type: entity?.type };
+  });
+  getCircuit.mockImplementation(async ({ id }: { id: string }) => {
+    const entity = id === ENTITY_ID ? fixture.entity : fixture.input;
+    return { id, scale: entity?.scale };
+  });
+  getSimulationCampaign.mockResolvedValue({ id: ENTITY_ID, entity_id: INPUT_ID });
+  getTaskConfig.mockResolvedValue({
+    id: ENTITY_ID,
+    task_config_type: fixture.taskConfigType,
+    inputs: fixture.input ? [{ id: INPUT_ID, type: fixture.input.type }] : [],
+  });
+}
+
+/** replaces the generated `wf_*` session id with `{session}` so hrefs compare literally */
+function normalizeSession(href: string): string {
+  return href.replace(/wf_[a-z0-9]+/, '{session}');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('resolveWorkflowConfigureHrefForEntity', () => {
+  it.each(cases)('$name', async ({ fixture, href, selects, flags }) => {
+    applyFixture(fixture);
+
+    const resolved = await resolveWorkflowConfigureHrefForEntity({
+      entityId: ENTITY_ID,
+      workspace,
+      flags: flags ?? allFlags,
+    });
+
+    expect(resolved).not.toBeNull();
+    expect(normalizeSession(resolved as string)).toBe(href);
+
+    if (selects) {
+      const sessionId = (resolved as string).match(/wf_[a-z0-9]+/)?.[0];
+      expect(readWorkflowSessionSelection(sessionId as string)).toEqual({
+        mode: WorkflowSessionSelectionMode.Single,
+        item: selects,
+      });
+    }
+  });
+
+  it('covers every workflow an entity id can reach', () => {
+    const covered = new Set(cases.map(({ covers }) => `${covers.activity}/${covers.targetType}`));
+
+    const uncovered = Object.values(ActivityRegistry).flatMap((activity) =>
+      activity.workflows
+        .filter((workflow) => !workflow.disabled)
+        .map((workflow) => `${activity.value}/${workflow.targetType}`)
+        .filter((key) => !covered.has(key) && !UNREACHABLE_FROM_AN_ENTITY_ID.has(key))
+    );
+
+    expect(uncovered).toEqual([]);
+  });
+
+  it('skips workflows the user has no feature flag for', async () => {
+    applyFixture({ entity: { type: EntityTypeDict.Circuit } });
+
+    await expect(
+      resolveWorkflowConfigureHrefForEntity({ entityId: ENTITY_ID, workspace })
+    ).resolves.toBeNull();
+  });
+
+  it('returns null when no workflow accepts the entity', async () => {
+    applyFixture({ entity: { type: EntityTypeDict.Subject } });
+
+    await expect(
+      resolveWorkflowConfigureHrefForEntity({ entityId: ENTITY_ID, workspace, flags: allFlags })
+    ).resolves.toBeNull();
+  });
+});

--- a/src/ui/segments/project/get-started/sections/get-started-card.tsx
+++ b/src/ui/segments/project/get-started/sections/get-started-card.tsx
@@ -7,12 +7,8 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useState } from 'react';
 
-import { getEntity } from '@/api/entitycore/queries/general/entity';
-import { getCircuit } from '@/api/entitycore/queries/model/circuit';
-import { getSimulationCampaign } from '@/api/entitycore/queries/simulation/campaign';
-import { EntityTypeDict } from '@/api/entitycore/types';
+import { useAppNotification } from '@/components/notification';
 import { config } from '@/config';
-import { WorkflowActivityDictValue } from '@/constants';
 import { useFlags } from '@/features/feature-flags';
 import { useWorkspace } from '@/ui/hooks/use-workspace';
 import { Skeleton } from '@/ui/molecules/skeleton';
@@ -21,14 +17,8 @@ import {
   type TProjectHomeGetStartedCard,
   type TProjectHomeResource,
 } from '@/ui/segments/project/get-started/query';
-import {
-  buildSimulateConfigureUrlFromDataViewEntity,
-  getWorkflow,
-  resolveSimulateSourceTypeFromDataView,
-} from '@/ui/segments/workflows/config';
-import { buildWorkflowActivityConfigurationHref } from '@/ui/segments/workflows/elements/workflow-activity-actions';
+import { resolveWorkflowConfigureHrefForEntity } from '@/ui/segments/workflows/config/entity-entry';
 
-import type { ICircuit } from '@/api/entitycore/types/entities/circuit';
 import type { WorkspaceContext } from '@/types/common';
 
 function CardMedia({ card }: { card: TProjectHomeGetStartedCard }) {
@@ -76,72 +66,6 @@ function resolveResourceEntityId(resource: TProjectHomeResource): string | null 
   return entityId?.trim() || null;
 }
 
-async function resolveSimulateSourceType(
-  entityId: string,
-  context?: WorkspaceContext
-): Promise<ReturnType<typeof resolveSimulateSourceTypeFromDataView>> {
-  const entity = await getEntity({ id: entityId, context });
-  let scale: ICircuit['scale'] | undefined;
-
-  if (entity.type === EntityTypeDict.Circuit) {
-    const circuit = await getCircuit({ id: entityId, context });
-    scale = circuit.scale;
-  }
-
-  return resolveSimulateSourceTypeFromDataView(entity.type, { scale });
-}
-
-async function resolveWorkflowHref({
-  entityId,
-  workspace,
-  flags,
-}: {
-  entityId: string;
-  workspace: WorkspaceContext;
-  flags: ReturnType<typeof useFlags>;
-}): Promise<string | null> {
-  const entity = await getEntity({ id: entityId });
-
-  // Example campaigns from Sanity → reopen configure with ?origin=
-  if (entity.type === EntityTypeDict.SimulationCampaign) {
-    const campaign = await getSimulationCampaign({ id: entityId });
-    const sourceType = await resolveSimulateSourceType(campaign.entity_id);
-    if (!sourceType) return null;
-
-    const workflow = getWorkflow({
-      activity: WorkflowActivityDictValue.simulate,
-      sourceType,
-    });
-    if (!workflow) return null;
-
-    return buildWorkflowActivityConfigurationHref({
-      activity: WorkflowActivityDictValue.simulate,
-      listEntityType: workflow.targetType,
-      workspace,
-      row: {
-        id: campaign.id,
-        type: EntityTypeDict.SimulationCampaign,
-        entity_id: campaign.entity_id,
-      },
-    });
-  }
-
-  // Source models → start a new simulate configure session
-  let scale: ICircuit['scale'] | undefined;
-  if (entity.type === EntityTypeDict.Circuit) {
-    const circuit = await getCircuit({ id: entityId });
-    scale = circuit.scale;
-  }
-
-  return buildSimulateConfigureUrlFromDataViewEntity({
-    workspace,
-    extendedType: entity.type,
-    entityId,
-    entity: { scale },
-    flags,
-  });
-}
-
 const ctaClassName =
   'flex w-full shrink-0 flex-row items-center justify-between rounded-[60px] border-2 border-white/20 bg-[#002766] px-6 py-2.5 text-xl font-semibold text-white no-underline shadow-[-8px_-8px_12px_0_rgba(255,255,255,0.92),6px_8px_12px_0_rgba(0,0,0,0.12)] transition-opacity hover:opacity-90';
 
@@ -174,6 +98,7 @@ function ResourceItem({
   flags: ReturnType<typeof useFlags>;
 }) {
   const router = useRouter();
+  const { error: notifyError } = useAppNotification();
   const [loading, setLoading] = useState(false);
   const entityId = resolveResourceEntityId(resource);
 
@@ -201,9 +126,23 @@ function ResourceItem({
     }
 
     setLoading(true);
-    void resolveWorkflowHref({ entityId, workspace, flags })
+    void resolveWorkflowConfigureHrefForEntity({ entityId, workspace, flags })
       .then((href) => {
-        if (href) router.push(href);
+        if (href) {
+          router.push(href);
+          return;
+        }
+
+        notifyError({
+          message: 'Example unavailable',
+          description: `No workflow configuration could be opened for "${resource.label}".`,
+        });
+      })
+      .catch(() => {
+        notifyError({
+          message: 'Example unavailable',
+          description: `"${resource.label}" could not be loaded. The example may not be public in this environment.`,
+        });
       })
       .finally(() => {
         setLoading(false);

--- a/src/ui/segments/workflows/config/entity-entry.ts
+++ b/src/ui/segments/workflows/config/entity-entry.ts
@@ -1,0 +1,413 @@
+import { getEntity } from '@/api/entitycore/queries/general/entity';
+import { getCircuit } from '@/api/entitycore/queries/model/circuit';
+import { getSimulationCampaign } from '@/api/entitycore/queries/simulation/campaign';
+import { getTaskConfig } from '@/api/entitycore/queries/task/task-config';
+import { EntityTypeDict } from '@/api/entitycore/types';
+import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import { WorkflowActivityDictValue } from '@/constants';
+import { ScanConfigOriginSearchParam } from '@/features/scan-config/helpers';
+import { resolveWorkflowTaskTypeBindings } from '@/features/scan-config/workflow/types';
+import { ActivityRegistry } from '@/ui/segments/workflows/config/activities';
+import { listActivities, listWorkflows } from '@/ui/segments/workflows/config/helpers';
+import {
+  buildConfigureUrlForEntity,
+  resolveSimulateSourceTypeFromDataView,
+} from '@/ui/segments/workflows/config/routes';
+import {
+  buildWorkflowActivityConfigurationHref,
+  buildWorkflowActivityDetailConfigurationHref,
+} from '@/ui/segments/workflows/elements/workflow-activity-actions';
+import {
+  PanelQueryParam,
+  WorkflowSimulatePanels,
+} from '@/ui/segments/workflows/simulate/single-neuron/shared/constant';
+
+import type { IEntity } from '@/api/entitycore/types/entities/entity';
+import type { TExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import type { FeatureFlags } from '@/features/feature-flags/flags';
+import type { WorkspaceContext } from '@/types/common';
+import type { IWorkflowDescriptor, TActivityValue } from '@/ui/segments/workflows/config/types';
+
+/**
+ * resolves an entity id to the workflow configuration editor that entity belongs to
+ *
+ * serves links that carry nothing but an id — the Get Started examples on the project home page —
+ * where the workflow, the activity, and the shape of the route all have to be inferred
+ *
+ * resolution order:
+ * 1. simulation campaign: the model it ran on gives the source type, which gives the workflow
+ * 2. task config: the workflow whose scan-config task bindings share its `<family>__*` type
+ * 3. activity output (a type the registry produces and never consumes): reopen its own run
+ * 4. source model: a new configure session with the entity pre-selected
+ *
+ * the first three reopen a stored configuration (`?origin=<id>`, or the entity's detail view for
+ * activities that have no scan-config editor), the fourth opens an empty one
+ *
+ * every decision is read from the workflow registry, so a workflow becomes resolvable as soon as
+ * it is registered — `entity-entry.test.ts` holds a coverage guard that fails until a newly
+ * registered workflow has a case
+ */
+
+type TWorkflowMatch = { activity: TActivityValue; workflow: IWorkflowDescriptor };
+
+/**
+ * workflows the user can open, simulate first
+ *
+ * simulate leads so entities several activities accept (an ME-model is both a build target and a
+ * simulation source) keep opening the simulation editor
+ *
+ * @param flags: the viewer's feature flags; omitted means flag-gated workflows are excluded
+ * @returns available workflows paired with the activity they belong to, in match order
+ */
+function availableWorkflows(flags?: FeatureFlags): TWorkflowMatch[] {
+  const activities = listActivities(flags).filter((activity) => !activity.disabled);
+
+  return [
+    ...activities.filter(({ value }) => value === WorkflowActivityDictValue.simulate),
+    ...activities.filter(({ value }) => value !== WorkflowActivityDictValue.simulate),
+  ].flatMap(({ value }) =>
+    listWorkflows({ activity: value, flags })
+      .filter((workflow) => !workflow.disabled)
+      .map((workflow) => ({ activity: value, workflow }))
+  );
+}
+
+/**
+ * first available workflow whose `sourceType`/`targetType` is one of the candidates
+ *
+ * candidates are in priority order, so a more specific type wins over the raw entity type before
+ * activity order is considered
+ *
+ * @param role: which side of the workflow the candidates are matched against — `sourceType` for an
+ *   entity fed into a workflow, `targetType` for one produced by it
+ * @param candidates: extended types to try, most specific first (see
+ *   {@link resolveEntityTypeCandidates})
+ * @returns the match, or `null` when no available workflow uses any candidate in that role
+ */
+function findWorkflowFor(
+  role: 'sourceType' | 'targetType',
+  candidates: TExtendedEntitiesTypeDict[],
+  flags?: FeatureFlags
+): TWorkflowMatch | null {
+  const available = availableWorkflows(flags);
+
+  for (const candidate of candidates) {
+    const match = available.find(({ workflow }) => workflow[role] === candidate);
+    if (match) return match;
+  }
+
+  return null;
+}
+
+/**
+ * true when the registry only ever *produces* this type, never consumes it
+ *
+ * that is what makes an entity an activity output (a campaign, a simulation result): it carries a
+ * stored configuration, so it reopens the editor on its own run instead of seeding a new one.
+ * ME-models are produced by build and consumed by simulate, so they are not outputs
+ *
+ * a `hasMultipleSources` workflow names its own campaign type as `sourceType` (its real inputs come
+ * from the scan-config schema), so it does not count as consuming that type
+ *
+ * asked of the whole registry, feature flags included, because this is what the type *is*, not
+ * what the current user can open
+ *
+ * @returns true when an entity of this type should reopen its own run instead of seeding a new one
+ */
+function isActivityOutputType(extendedType: TExtendedEntitiesTypeDict): boolean {
+  const workflows = Object.values(ActivityRegistry).flatMap((activity) => activity.workflows);
+
+  return (
+    workflows.some((workflow) => workflow.targetType === extendedType) &&
+    !workflows.some(
+      (workflow) => workflow.sourceType === extendedType && !workflow.hasMultipleSources
+    )
+  );
+}
+
+/**
+ * entitycore names task-config types `<family>__campaign` / `<family>__config`, and a workflow
+ * declares the config side in its scan-config `taskTypeBindings`, so the family is what links a
+ * campaign task config back to the workflow that wrote it
+ *
+ * @returns the family (`circuit_extraction` for `circuit_extraction__campaign`), or the type
+ *   unchanged when it does not follow the convention
+ */
+function taskConfigFamily(taskConfigType: string): string {
+  return taskConfigType.split('__')[0] ?? taskConfigType;
+}
+
+/**
+ * workflows that write a task config of this family, matched through their scan-config bindings
+ *
+ * bindings are resolved without an entity: the field that varies per entity (the obi-one task type)
+ * is not the one read here
+ *
+ * @returns every match, since a family can be shared — {@link pickWorkflowForTaskConfig} narrows it
+ */
+function findWorkflowsByTaskConfigType(
+  taskConfigType: string,
+  flags?: FeatureFlags
+): TWorkflowMatch[] {
+  const family = taskConfigFamily(taskConfigType);
+
+  return availableWorkflows(flags).filter(({ workflow }) => {
+    const bindings = resolveWorkflowTaskTypeBindings(
+      workflow.scanConfig?.definition.taskTypeBindings,
+      { entity: null }
+    );
+
+    return bindings ? taskConfigFamily(bindings.config) === family : false;
+  });
+}
+
+/**
+ * extended types an entity can be matched with, most specific first
+ *
+ * an entity's core type is not always the type workflows register: ME-models run through the
+ * single neuron (beta) workflow as `me_model_circuit`, and circuits carry their workflow identity
+ * in `scale` (a single-neuron circuit simulates through a different workflow than a microcircuit)
+ *
+ * the raw type is kept as a fallback so type-agnostic workflows (circuit extraction, recording
+ * arrays) still match
+ *
+ * @returns one or two extended types, most specific first; circuits cost one extra request because
+ *   their scale is not on the base entity
+ */
+async function resolveEntityTypeCandidates(
+  entity: IEntity,
+  context: WorkspaceContext
+): Promise<TExtendedEntitiesTypeDict[]> {
+  const extendedType = entity.type as TExtendedEntitiesTypeDict;
+  const scale =
+    extendedType === ExtendedEntitiesTypeDict.Circuit
+      ? (await getCircuit({ id: entity.id, context })).scale
+      : undefined;
+
+  const specific = resolveSimulateSourceTypeFromDataView(extendedType, { scale });
+
+  return specific && specific !== extendedType ? [specific, extendedType] : [extendedType];
+}
+
+/**
+ * reopens a stored configuration
+ *
+ * scan-config workflows get the editor with `?origin=<id>` so it loads the run's saved form,
+ * legacy ones have no such editor and fall back to the entity's detail view
+ *
+ * @param entityId: the run to reopen — a campaign, a task config, or another activity output
+ * @returns the href, or `null` when the target type has no detail view to fall back to
+ */
+function buildStoredConfigurationHref({
+  match,
+  workspace,
+  entityId,
+}: {
+  match: TWorkflowMatch;
+  workspace: WorkspaceContext;
+  entityId: string;
+}): string | null {
+  const { activity, workflow } = match;
+
+  if (!workflow.isScanConfig) {
+    return buildWorkflowActivityDetailConfigurationHref({
+      workspace,
+      listEntityType: workflow.targetType,
+      rowId: entityId,
+    });
+  }
+
+  return buildConfigureUrlForEntity({
+    activity,
+    targetType: workflow.targetType,
+    workspace,
+    entityId,
+    skipSelectionPersist: true,
+    query: { [ScanConfigOriginSearchParam]: entityId },
+  });
+}
+
+/**
+ * starts a new configure session with the entity pre-selected as the workflow input
+ *
+ * simulate also opens on the configuration panel, matching the simulate action on entity pages
+ *
+ * @param entityId: the model the session is seeded with; its type is the workflow's `sourceType`
+ * @returns the href — static-type workflows (ion channel simulation) get a route with no session
+ *   id and no pre-selection, because their editor chooses its own entities
+ */
+function buildNewConfigurationHref({
+  match,
+  workspace,
+  entityId,
+}: {
+  match: TWorkflowMatch;
+  workspace: WorkspaceContext;
+  entityId: string;
+}): string {
+  const { activity, workflow } = match;
+
+  return buildConfigureUrlForEntity({
+    activity,
+    targetType: workflow.targetType,
+    workspace,
+    entityId,
+    entityType: workflow.sourceType,
+    query:
+      activity === WorkflowActivityDictValue.simulate
+        ? { [PanelQueryParam]: WorkflowSimulatePanels.Configuration }
+        : {},
+  });
+}
+
+/**
+ * simulation campaigns identify their workflow through the model they ran on
+ * (an ME-model campaign is a single neuron (beta) simulation, a circuit campaign resolves by scale)
+ *
+ * @returns the configure href with `?origin=`, or `null` when the campaign has no model or that
+ *   model belongs to no available workflow
+ */
+async function resolveSimulationCampaignHref({
+  campaignId,
+  workspace,
+  flags,
+}: {
+  campaignId: string;
+  workspace: WorkspaceContext;
+  flags?: FeatureFlags;
+}): Promise<string | null> {
+  const campaign = await getSimulationCampaign({ id: campaignId, context: workspace });
+  if (!campaign.entity_id) return null;
+
+  const model = await getEntity({ id: campaign.entity_id, context: workspace });
+  const candidates = await resolveEntityTypeCandidates(model, workspace);
+  const match = findWorkflowFor('sourceType', candidates, flags);
+
+  if (!match) return null;
+
+  return buildWorkflowActivityConfigurationHref({
+    activity: match.activity,
+    listEntityType: match.workflow.targetType,
+    workspace,
+    row: {
+      id: campaign.id,
+      type: EntityTypeDict.SimulationCampaign,
+      entity_id: campaign.entity_id,
+    },
+  });
+}
+
+/**
+ * picks the workflow that ran, when a task family is shared
+ *
+ * every circuit simulation writes `circuit_simulation__config`, so the family alone cannot tell a
+ * microcircuit run from a paired-neuron one — the campaign's first input can, since its entity type
+ * is the workflow's source type
+ *
+ * @param matches: workflows sharing the task family, in match order
+ * @param inputId: the campaign's first input, fetched only when the family is ambiguous
+ * @returns the workflow whose source type the input matches, falling back to the first match
+ */
+async function pickWorkflowForTaskConfig({
+  matches,
+  inputId,
+  workspace,
+}: {
+  matches: TWorkflowMatch[];
+  inputId?: string;
+  workspace: WorkspaceContext;
+}): Promise<TWorkflowMatch | null> {
+  if (matches.length <= 1 || !inputId) return matches.at(0) ?? null;
+
+  const input = await getEntity({ id: inputId, context: workspace });
+  const candidates = await resolveEntityTypeCandidates(input, workspace);
+
+  return matches.find(({ workflow }) => candidates.includes(workflow.sourceType)) ?? matches[0];
+}
+
+/**
+ * task-config campaigns (extraction, skeletonization, EM synapse mapping, recording arrays, …)
+ *
+ * @returns the configure href with `?origin=`, or `null` when no available workflow declares this
+ *   task family — a `*__config` type, or one whose workflow is behind a feature flag
+ */
+async function resolveTaskConfigHref({
+  taskConfigId,
+  workspace,
+  flags,
+}: {
+  taskConfigId: string;
+  workspace: WorkspaceContext;
+  flags?: FeatureFlags;
+}): Promise<string | null> {
+  const taskConfig = await getTaskConfig({ id: taskConfigId, context: workspace });
+  const match = await pickWorkflowForTaskConfig({
+    matches: findWorkflowsByTaskConfigType(taskConfig.task_config_type, flags),
+    inputId: taskConfig.inputs?.at(0)?.id,
+    workspace,
+  });
+  if (!match) return null;
+
+  return buildWorkflowActivityConfigurationHref({
+    activity: match.activity,
+    listEntityType: match.workflow.targetType,
+    workspace,
+    row: {
+      id: taskConfig.id,
+      type: EntityTypeDict.TaskConfig,
+      inputs: taskConfig.inputs,
+      task_config_type: taskConfig.task_config_type,
+    },
+  });
+}
+
+/**
+ * resolves any entity id to the configuration editor of the workflow it belongs to
+ *
+ * the entity id is the only input: the entity's type decides whether the editor reopens a stored
+ * configuration (campaigns and task configs, via `?origin=`) or starts a new configure session
+ * with the entity pre-selected (source models)
+ *
+ * @param entityId: any entitycore id — a campaign, a task config, or a source model
+ * @param workspace: virtual lab and project the href is built for, and the context the entity is
+ *   read with; public entities resolve from any workspace
+ * @param flags: the viewer's feature flags, so a flag-gated workflow is never linked to
+ * @returns configure href, or `null` when no available workflow accepts the entity
+ *
+ * @example
+ * const href = await resolveWorkflowConfigureHrefForEntity({
+ *   entityId: 'a-simulation-campaign-id',
+ *   workspace: { virtualLabId, projectId },
+ *   flags,
+ * });
+ * // /app/virtual-lab/{lab}/{project}/workflows/simulate/configure/me-model-circuit-simulation/wf_…?origin=a-simulation-campaign-id
+ */
+export async function resolveWorkflowConfigureHrefForEntity({
+  entityId,
+  workspace,
+  flags,
+}: {
+  entityId: string;
+  workspace: WorkspaceContext;
+  flags?: FeatureFlags;
+}): Promise<string | null> {
+  const entity = await getEntity({ id: entityId, context: workspace });
+
+  if (entity.type === EntityTypeDict.SimulationCampaign) {
+    return resolveSimulationCampaignHref({ campaignId: entityId, workspace, flags });
+  }
+
+  if (entity.type === EntityTypeDict.TaskConfig) {
+    return resolveTaskConfigHref({ taskConfigId: entityId, workspace, flags });
+  }
+
+  const candidates = await resolveEntityTypeCandidates(entity, workspace);
+
+  const output = findWorkflowFor('targetType', candidates.filter(isActivityOutputType), flags);
+  if (output) return buildStoredConfigurationHref({ match: output, workspace, entityId });
+
+  const source = findWorkflowFor('sourceType', candidates, flags);
+  if (source) return buildNewConfigurationHref({ match: source, workspace, entityId });
+
+  return null;
+}

--- a/src/ui/segments/workflows/config/index.ts
+++ b/src/ui/segments/workflows/config/index.ts
@@ -1,4 +1,5 @@
 export { ActivityRegistry, ActivityValues } from './activities';
+export { resolveWorkflowConfigureHrefForEntity } from './entity-entry';
 export { EntityTypeCatalog } from './entity-types';
 export {
   getActivity,


### PR DESCRIPTION
add `resolveWorkflowConfigureHrefForEntity` which maps any entity id to the configuration editor of the workflow it belongs to:

  1. simulation campaign -> the model it ran on gives the source type
  2. task config -> the workflow sharing its `<family>__*` task bindings
  3. activity output -> reopen its own run via ?origin=
  4. source model -> a new configure session, entity pre-selected

every decision reads the workflow registry, so a newly registered workflow resolves without touching this file. Campaign links go through the same helper the activities table uses, so the two cannot drift.