### PR TITLE
feat(scan-config): clearer electrode colours, smaller markers,

### DIFF
--- a/src/__tests__/scan-config/electrode-locations-overlay.test.ts
+++ b/src/__tests__/scan-config/electrode-locations-overlay.test.ts
@@ -1,12 +1,21 @@
+import chroma from 'chroma-js';
 import { describe, expect, it } from 'vitest';
 
 import {
+  adaptColorToBackground,
+  CANVAS_DARK,
+  CANVAS_LIGHT,
+} from '@/features/scan-config/components/color-by/contrast';
+import {
   colorForElectrodeBlock,
   colorForElectrodeOrigin,
+  ELECTRODE_PALETTE,
   electrodeDictionaryToPlaceholderOverlays,
   electrodeSummaryToOverlays,
   hasElectrodeLocationsDictionary,
   mergeElectrodeOverlays,
+  resolveElectrodeScanSelection,
+  resolveScanIndex,
   seedElectrodeInitialOrigin,
 } from '@/features/scan-config/components/model-preview/electrode-locations-overlay';
 
@@ -188,5 +197,117 @@ describe('mergeElectrodeOverlays', () => {
     expect(ids.sort()).toEqual(['a', 'b']);
     const aElectrodes = merged.find((g) => g.id === 'a' && g.kind === 'electrodes');
     expect(Array.from(aElectrodes?.coordinates ?? [])).toEqual([9, 9, 9]);
+  });
+});
+
+describe('electrode colour assignment', () => {
+  it('maps the creation ordinal in the block name to a palette slot', () => {
+    expect(colorForElectrodeBlock('Electrode 0')).toBe(ELECTRODE_PALETTE[0]);
+    expect(colorForElectrodeBlock('Electrode 1')).toBe(ELECTRODE_PALETTE[1]);
+    expect(colorForElectrodeBlock('Electrode 2')).toBe(ELECTRODE_PALETTE[2]);
+  });
+
+  it('keeps existing colours when a block is added or removed', () => {
+    const before = ['Electrode 0', 'Electrode 1'].map(colorForElectrodeBlock);
+    colorForElectrodeBlock('Electrode 2');
+    expect(['Electrode 0', 'Electrode 1'].map(colorForElectrodeBlock)).toEqual(before);
+    // deleting "Electrode 0" must not renumber the survivors
+    expect(colorForElectrodeBlock('Electrode 1')).toBe(before[1]);
+  });
+
+  it('is pure — same name, same colour, no call-order dependency', () => {
+    expect(colorForElectrodeBlock('Electrode 3')).toBe(colorForElectrodeBlock('Electrode 3'));
+    expect(colorForElectrodeBlock('Electrode 3')).toBe(ELECTRODE_PALETTE[3]);
+  });
+
+  it('wraps past the end of the palette', () => {
+    expect(colorForElectrodeBlock(`Electrode ${ELECTRODE_PALETTE.length}`)).toBe(
+      ELECTRODE_PALETTE[0]
+    );
+  });
+
+  it('falls back to a stable hash for names with no ordinal', () => {
+    const first = colorForElectrodeBlock('renamed probe');
+    expect(ELECTRODE_PALETTE).toContain(first);
+    expect(colorForElectrodeBlock('renamed probe')).toBe(first);
+  });
+
+  it('gives the origin marker a visible variant of the block colour', () => {
+    for (const name of ['blue-block', 'black-block', 'orange-block']) {
+      const block = colorForElectrodeBlock(name);
+      const origin = colorForElectrodeOrigin(name);
+      expect(origin).not.toBe(block);
+      // never collapses to pure black, which would vanish against dark markers
+      expect(origin.toLowerCase()).not.toBe('#000000');
+    }
+  });
+});
+
+describe('resolveScanIndex', () => {
+  it('defaults to the first value when nothing is selected', () => {
+    expect(resolveScanIndex(undefined, 'probe', 'origin_x', 3)).toBe(0);
+    expect(resolveScanIndex({}, 'probe', 'origin_x', 3)).toBe(0);
+  });
+
+  it('returns the selected index when it is still in range', () => {
+    expect(resolveScanIndex({ probe: { origin_x: 2 } }, 'probe', 'origin_x', 3)).toBe(2);
+  });
+
+  it('falls back to the first value when the selection went stale', () => {
+    expect(resolveScanIndex({ probe: { origin_x: 5 } }, 'probe', 'origin_x', 2)).toBe(0);
+    expect(resolveScanIndex({ probe: { origin_x: -1 } }, 'probe', 'origin_x', 2)).toBe(0);
+  });
+});
+
+describe('resolveElectrodeScanSelection', () => {
+  it('collapses each sweep to its active value', () => {
+    const resolved = resolveElectrodeScanSelection(
+      { probe: { origin_x: [4100.223, 1100], origin_y: [0, 50], n_electrodes: 8 } },
+      { probe: { origin_x: 1 } }
+    );
+    expect(resolved).toEqual({ probe: { origin_x: 1100, origin_y: 0, n_electrodes: 8 } });
+  });
+
+  it('leaves blocks without sweeps untouched', () => {
+    const dictionary = { probe: { origin_x: 10, type: 'Linear' } };
+    expect(resolveElectrodeScanSelection(dictionary, {})).toEqual(dictionary);
+  });
+
+  it('ignores selections belonging to another block', () => {
+    const resolved = resolveElectrodeScanSelection(
+      { probe_a: { origin_x: [1, 2] }, probe_b: { origin_x: [7, 8] } },
+      { probe_b: { origin_x: 1 } }
+    );
+    expect(resolved).toEqual({ probe_a: { origin_x: 1 }, probe_b: { origin_x: 8 } });
+  });
+
+  it('passes non-dictionary input straight through', () => {
+    expect(resolveElectrodeScanSelection(null, {})).toBeNull();
+    expect(resolveElectrodeScanSelection([1, 2], {})).toEqual([1, 2]);
+  });
+});
+
+describe('electrode palette legibility', () => {
+  const CANVASES = [CANVAS_LIGHT, CANVAS_DARK];
+
+  it('clears the viewer contrast floor on both canvases once adapted', () => {
+    for (const background of CANVASES) {
+      for (const color of ELECTRODE_PALETTE) {
+        const adapted = adaptColorToBackground(color, background);
+        expect(chroma.contrast(adapted, background)).toBeGreaterThanOrEqual(3);
+      }
+    }
+  });
+
+  it('keeps every pair of adapted colours visually distinct', () => {
+    for (const background of CANVASES) {
+      const adapted = ELECTRODE_PALETTE.map((c) => adaptColorToBackground(c, background));
+      for (let i = 0; i < adapted.length; i++) {
+        for (let j = i + 1; j < adapted.length; j++) {
+          // deltaE > 10 reads as a different colour rather than a shade
+          expect(chroma.deltaE(adapted[i], adapted[j])).toBeGreaterThan(10);
+        }
+      }
+    }
   });
 });

--- a/src/__tests__/scan-config/parameter-sweep.spec.tsx
+++ b/src/__tests__/scan-config/parameter-sweep.spec.tsx
@@ -1,0 +1,146 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { getDefaultStore } from 'jotai';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearScanValueSelectionAtom,
+  scanValueSelectionAtom,
+} from '@/features/scan-config/components/model-preview/electrode-locations-overlay';
+import ParameterSweep, {
+  ScanValueSelectorProvider,
+  sweepSingleValue,
+} from '@/features/scan-config/components/ui-elements/parameter-sweep';
+
+function renderSweep(
+  value: (number | null)[],
+  { withScope = false }: { withScope?: boolean } = {},
+  onChange = vi.fn()
+) {
+  const sweep = (
+    <ParameterSweep
+      k="origin_x"
+      min={undefined}
+      max={undefined}
+      exclusiveMin={undefined}
+      exclusiveMax={undefined}
+      disabled={false}
+      value={value}
+      onChange={onChange}
+    />
+  );
+  render(
+    withScope ? (
+      <ScanValueSelectorProvider blockName="probe">{sweep}</ScanValueSelectorProvider>
+    ) : (
+      sweep
+    )
+  );
+  return { onChange };
+}
+
+// The selection atom is module-level, so one test's click would otherwise
+// survive into the next.
+beforeEach(() => {
+  getDefaultStore().set(clearScanValueSelectionAtom);
+});
+
+/** Active index recorded for the block/param the tests render. */
+function readSelection(): number | undefined {
+  return getDefaultStore().get(scanValueSelectionAtom).probe?.origin_x;
+}
+
+describe('ParameterSweep value selection', () => {
+  it('renders no eye outside a selector scope', () => {
+    renderSweep([4100.223, 1100]);
+    expect(screen.queryByRole('button', { name: /show value/i })).toBeNull();
+  });
+
+  it('renders one eye per value inside a scope, with the first active', () => {
+    renderSweep([4100.223, 1100, 250], { withScope: true });
+    const eyes = screen.getAllByRole('button', { name: /show value/i });
+    expect(eyes).toHaveLength(3);
+    expect(eyes.map((eye) => eye.getAttribute('aria-pressed'))).toEqual(['true', 'false', 'false']);
+  });
+
+  it('makes only the clicked value active', () => {
+    renderSweep([4100.223, 1100, 250], { withScope: true });
+    fireEvent.click(screen.getByRole('button', { name: 'Show value 2 in the preview' }));
+    const eyes = screen.getAllByRole('button', { name: /show value/i });
+    expect(eyes.map((eye) => eye.getAttribute('aria-pressed'))).toEqual(['false', 'true', 'false']);
+  });
+
+  it('offers no eye when the sweep holds a single value', () => {
+    renderSweep([4100.223], { withScope: true });
+    expect(screen.queryByRole('button', { name: /show value/i })).toBeNull();
+  });
+
+  it('activates the value that was just added', () => {
+    const { onChange } = renderSweep([4100.223, 1100], { withScope: true });
+    fireEvent.click(screen.getByRole('button', { name: 'Add a value' }));
+    expect(onChange).toHaveBeenCalledWith([4100.223, 1100, null]);
+    expect(readSelection()).toBe(2);
+  });
+
+  it('activates the second value when a single-value sweep grows', () => {
+    renderSweep([4100.223], { withScope: true });
+    fireEvent.click(screen.getByRole('button', { name: 'Add a value' }));
+    expect(readSelection()).toBe(1);
+  });
+
+  it('keeps the eye on the same value when an earlier one is removed', () => {
+    renderSweep([10, 20, 30], { withScope: true });
+    fireEvent.click(screen.getByRole('button', { name: 'Show value 3 in the preview' }));
+    // remove the first value → the active one slides down to index 1
+    fireEvent.click(screen.getAllByRole('button', { name: 'Remove this value' })[0]);
+    expect(readSelection()).toBe(1);
+  });
+
+  it('falls back to the first value when the active one is removed', () => {
+    renderSweep([10, 20, 30], { withScope: true });
+    fireEvent.click(screen.getByRole('button', { name: 'Show value 2 in the preview' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Remove this value' })[1]);
+    expect(readSelection()).toBe(0);
+  });
+});
+
+describe('ParameterSweep layout', () => {
+  it('leaves the collapse control to the field title row', () => {
+    renderSweep([4100.223, 1100]);
+    expect(screen.queryByRole('button', { name: 'Use a single value' })).toBeNull();
+  });
+
+  it('gives every row the same add/remove slots so the buttons line up', () => {
+    renderSweep([4100.223, 1100]);
+    const rows = [...document.querySelectorAll('.flex.w-full.items-center')];
+    expect(rows).toHaveLength(2);
+    // Only the last row shows "add", but both rows reserve the slot.
+    for (const row of rows) {
+      expect(row.querySelectorAll(':scope > span.size-6')).toHaveLength(2);
+    }
+    expect(
+      within(rows[0] as HTMLElement).queryByRole('button', { name: 'Add a value' })
+    ).toBeNull();
+    expect(
+      within(rows[1] as HTMLElement).getByRole('button', { name: 'Add a value' })
+    ).toBeTruthy();
+  });
+
+  it('orders the row controls eye, delete, then add', () => {
+    renderSweep([4100.223, 1100], { withScope: true });
+    const lastRow = [...document.querySelectorAll('.flex.w-full.items-center')].at(
+      -1
+    ) as HTMLElement;
+    const labels = [...lastRow.querySelectorAll('button')].map((b) => b.getAttribute('aria-label'));
+    expect(labels).toEqual(['Show value 2 in the preview', 'Remove this value', 'Add a value']);
+  });
+});
+
+describe('sweepSingleValue', () => {
+  it('collapses to the first usable value', () => {
+    expect(sweepSingleValue([4100.223, 1100])).toBe(4100.223);
+    expect(sweepSingleValue([null, 1100])).toBe(1100);
+    expect(sweepSingleValue([null, null])).toBeNull();
+    expect(sweepSingleValue(42)).toBe(42);
+    expect(sweepSingleValue(null)).toBeNull();
+  });
+});

--- a/src/__tests__/scan-config/resolve-enable-electrodes.test.ts
+++ b/src/__tests__/scan-config/resolve-enable-electrodes.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import { CircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit';
-import { resolveEnableElectrodes } from '@/features/scan-config/components/model-preview/resolve-enable-electrodes';
+import {
+  resolveEnableCellHover,
+  resolveEnableElectrodes,
+} from '@/features/scan-config/components/model-preview/resolve-enable-electrodes';
 
 describe('resolveEnableElectrodes', () => {
   it('is off when the feature flag is off', () => {
@@ -47,5 +50,26 @@ describe('resolveEnableElectrodes', () => {
       })
     ).toBe(true);
     expect(resolveEnableElectrodes({ featureEnabled: true, largeCircuit: true })).toBe(true);
+  });
+});
+
+describe('resolveEnableCellHover', () => {
+  it('turns hover off for single-scale circuits', () => {
+    expect(resolveEnableCellHover({ scale: CircuitScaleDictionary.Single })).toBe(false);
+  });
+
+  it('keeps hover on for every other scale', () => {
+    expect(resolveEnableCellHover({ scale: CircuitScaleDictionary.PairNeuron })).toBe(true);
+    expect(resolveEnableCellHover({ scale: CircuitScaleDictionary.SmallMicrocircuit })).toBe(true);
+    expect(resolveEnableCellHover({})).toBe(true);
+  });
+
+  it('never re-enables hover that domain policy switched off', () => {
+    expect(
+      resolveEnableCellHover({
+        domainCellHover: false,
+        scale: CircuitScaleDictionary.PairNeuron,
+      })
+    ).toBe(false);
   });
 });

--- a/src/__tests__/scan-config/viewer-config-defaults.test.ts
+++ b/src/__tests__/scan-config/viewer-config-defaults.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  DEFAULT_ELECTRODE_RADIUS,
   DEFAULT_NEURON_OPACITY,
   DEFAULT_VIEWER_CONFIG,
   ELECTRODE_FOCUSED_NEURON_OPACITY,
@@ -8,10 +9,11 @@ import {
 } from '@/features/scan-config/components/color-by/use-viewer-config';
 
 describe('resolveViewerConfigDefaults', () => {
-  it('uses full neuron opacity and electrode size 10 by default', () => {
+  it('uses full neuron opacity and the default electrode size', () => {
     expect(resolveViewerConfigDefaults()).toEqual(DEFAULT_VIEWER_CONFIG);
     expect(resolveViewerConfigDefaults().neuronOpacity).toBe(DEFAULT_NEURON_OPACITY);
-    expect(resolveViewerConfigDefaults().electrodeRadius).toBe(10);
+    expect(DEFAULT_ELECTRODE_RADIUS).toBe(5);
+    expect(resolveViewerConfigDefaults().electrodeRadius).toBe(DEFAULT_ELECTRODE_RADIUS);
   });
 
   it('applies host-provided neuron opacity without inferring context', () => {
@@ -19,6 +21,6 @@ describe('resolveViewerConfigDefaults', () => {
       defaultNeuronOpacity: ELECTRODE_FOCUSED_NEURON_OPACITY,
     });
     expect(defaults.neuronOpacity).toBe(0.2);
-    expect(defaults.electrodeRadius).toBe(10);
+    expect(defaults.electrodeRadius).toBe(DEFAULT_ELECTRODE_RADIUS);
   });
 });

--- a/src/features/scan-config/components/circuit-viz/circuit-viz.tsx
+++ b/src/features/scan-config/components/circuit-viz/circuit-viz.tsx
@@ -1,7 +1,8 @@
 import { useSetAtom } from 'jotai';
-import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { match } from 'ts-pattern';
 
+import { DEFAULT_ELECTRODE_RADIUS } from '@/features/scan-config/components/color-by/use-viewer-config';
 import { circuitSceneAnchorAtom } from '@/features/scan-config/components/model-preview/circuit-scene-anchor';
 import { useDownloadHandler } from '@/features/scan-config/components/model-preview/viewer-layout/hooks';
 import { VERTICAL_SCALEBAR } from '@/features/scan-config/components/shared/3d-viewer';
@@ -130,7 +131,7 @@ function CircuitVizView({
   onOverlayTransform,
   highlightedOverlayId = null,
   neuronOpacity,
-  electrodeRadius = 10,
+  electrodeRadius = DEFAULT_ELECTRODE_RADIUS,
   features,
   source,
   clearSequentialOnAxonToggle = false,
@@ -167,9 +168,33 @@ function CircuitVizView({
   // Empty highlightedCellIds → morphoviewer flat overlay stays black (ADD black
   // = no wash-out). Hosts pass features.cellHover from domain `viewer`.
   const [highlightedCellId, setHighlightedCellId] = useState('');
-  const handleCellHover = (cell: Cell | undefined): void => {
+  // Dragging an electrode must not leave a neuron lit under it. morphoviewer
+  // only reports overlay transforms once the gesture ends, so the drag is
+  // detected here from the pointer: press clears any highlight and suspends
+  // hover, release resumes it.
+  //
+  // A ref, not state: nothing renders from this flag, and morphoviewer
+  // re-subscribes whenever `onCellHover` changes identity — a stateful flag
+  // would rebuild the closure and churn that listener on every drag.
+  const draggingOverlayRef = useRef(false);
+  const handleCellHover = useCallback((cell: Cell | undefined): void => {
+    if (draggingOverlayRef.current) return;
     setHighlightedCellId(cell?.id ?? '');
+  }, []);
+  const suspendHoverHighlight = () => {
+    if (!overlaysInteractive) return;
+    draggingOverlayRef.current = true;
+    setHighlightedCellId('');
   };
+  const resumeHoverHighlight = () => {
+    draggingOverlayRef.current = false;
+  };
+  // Stable array identity: morphoviewer's `highlightedCellIds` setter bails out
+  // on reference equality, so a fresh array each render forces a repaint pass.
+  const highlightedCellIds = useMemo(
+    () => (enableCellHover ? [highlightedCellId] : []),
+    [enableCellHover, highlightedCellId]
+  );
 
   const prevAxonRef = useRef(showAxons);
   useEffect(() => {
@@ -214,7 +239,13 @@ function CircuitVizView({
   );
 
   return (
-    <div className="h-full w-full relative">
+    <div
+      className="h-full w-full relative"
+      onPointerDown={suspendHoverHighlight}
+      onPointerUp={resumeHoverHighlight}
+      onPointerCancel={resumeHoverHighlight}
+      onPointerLeave={resumeHoverHighlight}
+    >
       {cells.length > 0 && (
         <MorphoViewerSmallCircuit
           className={styles.morphoViewer}
@@ -224,7 +255,7 @@ function CircuitVizView({
           signals={signals}
           circuit={cells}
           onCellHover={enableCellHover ? handleCellHover : undefined}
-          highlightedCellIds={enableCellHover ? [highlightedCellId] : []}
+          highlightedCellIds={highlightedCellIds}
           loadCell={loadCell}
           controls={[]}
           onLoadProgress={setProgress}

--- a/src/features/scan-config/components/color-by/types.ts
+++ b/src/features/scan-config/components/color-by/types.ts
@@ -72,7 +72,7 @@ export interface ViewerConfig {
   showElectrodes: boolean;
   /**
    * World-space electrode marker radius (morphoviewer overlaysRadius).
-   * Default 10.
+   * Defaults to {@link DEFAULT_ELECTRODE_RADIUS}.
    */
   electrodeRadius: number;
   /** per-property, per-value color overrides chosen by the user */

--- a/src/features/scan-config/components/color-by/use-viewer-config.ts
+++ b/src/features/scan-config/components/color-by/use-viewer-config.ts
@@ -23,14 +23,22 @@ export const DEFAULT_NEURON_OPACITY = 1;
  */
 export const ELECTRODE_FOCUSED_NEURON_OPACITY = 0.2;
 
-/** Baseline viewer defaults (full neuron opacity, electrode size 10). */
+/**
+ * Electrode marker radius in world units — also the viewer-controls slider min.
+ *
+ * Why small: contacts read as a probe rather than a string of beads, and the
+ * per-pixel floor keeps them visible when the camera pulls back.
+ */
+export const DEFAULT_ELECTRODE_RADIUS = 5;
+
+/** Baseline viewer defaults (full neuron opacity, electrode size 5). */
 export const DEFAULT_VIEWER_CONFIG: ViewerConfig = {
   colorByProperty: null,
   backgroundColor: CANVAS_LIGHT,
   showAxons: false,
   neuronOpacity: DEFAULT_NEURON_OPACITY,
   showElectrodes: true,
-  electrodeRadius: 10,
+  electrodeRadius: DEFAULT_ELECTRODE_RADIUS,
   colorOverrides: {},
 };
 

--- a/src/features/scan-config/components/color-by/viewer-controls-menu.tsx
+++ b/src/features/scan-config/components/color-by/viewer-controls-menu.tsx
@@ -16,6 +16,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { AxonIcon } from '@/components/icons/Axon';
 import { SelectionBackground } from '@/components/icons/SelectionBackgroundThin';
+import { DEFAULT_ELECTRODE_RADIUS } from '@/features/scan-config/components/color-by/use-viewer-config';
 import { Popover, PopoverContent, PopoverTrigger } from '@/ui/molecules/popover';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/molecules/tooltip';
 import { cn } from '@/utils/css-class';
@@ -185,7 +186,7 @@ export function ViewerControlsMenu({
                 <span className="tabular-nums text-neutral-500">{electrodeRadius}</span>
               </div>
               <Slider
-                min={5}
+                min={DEFAULT_ELECTRODE_RADIUS}
                 max={80}
                 step={5}
                 value={electrodeRadius}

--- a/src/features/scan-config/components/model-preview/circuit-preview.tsx
+++ b/src/features/scan-config/components/model-preview/circuit-preview.tsx
@@ -1,5 +1,6 @@
 import { RiCloseLine } from '@remixicon/react';
 import { Image as AntdImage } from 'antd';
+import chroma from 'chroma-js';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 
 import { getAsset } from '@/api/entitycore/selectors/assets';
@@ -13,6 +14,7 @@ import CircuitViz, {
   resolveSmallCircuitLoaderKind,
 } from '@/features/scan-config/components/circuit-viz/circuit-viz';
 import { CircuitViewerChrome } from '@/features/scan-config/components/color-by/circuit-viewer-chrome';
+import { adaptColorToBackground } from '@/features/scan-config/components/color-by/contrast';
 import {
   type ViewerMode,
   ViewerModeDict,
@@ -163,8 +165,8 @@ export function CircuitPreview({
       ? selectedEntry
       : null;
   const styledOverlays = useMemo(
-    () => styleOverlaysForSelection(visibleOverlays, highlightedOverlayId),
-    [visibleOverlays, highlightedOverlayId]
+    () => styleOverlaysForSelection(visibleOverlays, highlightedOverlayId, config.backgroundColor),
+    [visibleOverlays, highlightedOverlayId, config.backgroundColor]
   );
   const overlaysInteractive = Boolean(
     enableElectrodes && setConfig && styledOverlays && styledOverlays.length > 0
@@ -422,32 +424,43 @@ export function CircuitImage({ className, circuit }: CircuitPreviewProps) {
 }
 
 /**
- * Emphasize the form-selected electrode; darken the others (fully opaque).
+ * Make every electrode legible on the current canvas, then recede the ones the
+ * form is not editing.
  *
- * Why opaque darkening (not alpha): electrodes must stay 100% opaque even when
- * neuron opacity is low — translucent rgba made the circuit show through markers.
+ * Why adapt at all: neuron colours already go through
+ * {@link adaptColorToBackground}; electrodes did not, so a near-black probe was
+ * invisible on the dark canvas and pale hues washed out on the light one. This
+ * runs unconditionally — colours must read even when nothing is selected.
+ *
+ * Why opaque throughout: electrodes stay 100% opaque even at low neuron
+ * opacity — translucent rgba let the circuit show through the markers.
  */
 function styleOverlaysForSelection(
   overlays: CircuitOverlayGroup[] | undefined,
-  selectedId: string | null
+  selectedId: string | null,
+  background: string
 ): CircuitOverlayGroup[] | undefined {
-  if (!overlays?.length || !selectedId) return overlays;
+  if (!overlays?.length) return overlays;
   return overlays.map((group) => {
-    if (group.id === selectedId) {
-      return { ...group, color: emphasizeColor(group.color) };
-    }
-    return { ...group, color: softenColor(group.color) };
+    const legible = forceOpaqueRgb(adaptColorToBackground(group.color, background));
+    if (!selectedId || group.id === selectedId) return { ...group, color: legible };
+    return { ...group, color: recedeColor(legible, background) };
   });
 }
 
-/** Selected electrode: keep full opaque RGB (no wash toward white). */
-function emphasizeColor(color: string): string {
-  return forceOpaqueRgb(color);
-}
-
-/** Non-selected electrodes: darken without introducing alpha. */
-function softenColor(color: string): string {
-  return mixTowardBlack(forceOpaqueRgb(color), 0.35);
+/**
+ * Non-selected electrodes: keep the hue, drop its intensity.
+ *
+ * Why not mix toward grey: at a 5-unit radius a greyed marker loses the one cue
+ * that says *which* probe it is. Desaturating and easing toward the background
+ * pushes it back without discarding its identity.
+ */
+function recedeColor(color: string, background: string): string {
+  try {
+    return chroma.mix(chroma(color).desaturate(1.4), background, 0.18, 'oklab').hex();
+  } catch {
+    return color;
+  }
 }
 
 /** Strip any CSS alpha so morphoviewer palette texels stay fully opaque. */
@@ -455,16 +468,6 @@ function forceOpaqueRgb(color: string): string {
   const rgb = parseCssColor(color);
   if (!rgb) return color;
   return `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
-}
-
-function mixTowardBlack(color: string, amount: number): string {
-  const rgb = parseCssColor(color);
-  if (!rgb) return color;
-  const t = Math.min(1, Math.max(0, amount));
-  const r = Math.round(rgb[0] * (1 - t));
-  const g = Math.round(rgb[1] * (1 - t));
-  const b = Math.round(rgb[2] * (1 - t));
-  return `rgb(${r}, ${g}, ${b})`;
 }
 
 /** Parse `#rgb` / `#rrggbb` / `rgb(...)` / `rgba(...)` into RGB channels. */

--- a/src/features/scan-config/components/model-preview/electrode-locations-overlay.ts
+++ b/src/features/scan-config/components/model-preview/electrode-locations-overlay.ts
@@ -1,7 +1,5 @@
-import {
-  categoricalColor,
-  MAX_DISTINCT_COLORS,
-} from '@/features/scan-config/components/color-by/palette';
+import chroma from 'chroma-js';
+import { atom } from 'jotai';
 
 import type {
   ElectrodeLocationPoint,
@@ -44,53 +42,88 @@ export interface CircuitOverlayGroup {
 }
 
 /**
- * Hash a block name into `[0, MAX_DISTINCT_COLORS)`.
+ * Neutral electrode palette, in assignment order.
  *
- * Why: `categoricalColor(index)` must be stable across sessions so the same
- * electrode name keeps the same colour without storing overrides.
+ * Why its own palette (not the circuit color-by one): electrodes are read
+ * against neurons, not against each other, so they need plain high-contrast
+ * hues rather than the pink / brown categorical set.
  *
- * @param name - Electrode dictionary entry name
- * @returns Palette index
+ * Why saturated: markers are small (see `DEFAULT_ELECTRODE_RADIUS`), and a
+ * few-pixel sphere only reads as "the blue probe" if its hue is unambiguous.
+ * Lightness is corrected per canvas by `adaptColorToBackground`, so these are
+ * chosen for hue separation and left to the contrast pass to place.
  */
-function hashBlockName(name: string): number {
+export const ELECTRODE_PALETTE: readonly string[] = [
+  '#1b6ef3', // blue
+  '#12a150', // green
+  '#e0293b', // red
+  '#12161c', // black
+  '#f2760a', // orange
+  '#8b3fd9', // purple
+  '#00a5b5', // teal
+  '#d62a9d', // magenta
+];
+
+/**
+ * Stable fallback slot for names with no creation index (renamed / AI-authored).
+ *
+ * FNV-1a: deterministic, so a renamed block keeps one colour across reloads.
+ */
+function hashName(name: string): number {
   let hash = 2166136261;
   for (let i = 0; i < name.length; i++) {
     hash ^= name.charCodeAt(i);
     hash = Math.imul(hash, 16777619);
   }
-  return Math.abs(hash) % MAX_DISTINCT_COLORS;
+  return Math.abs(hash) % ELECTRODE_PALETTE.length;
+}
+
+/**
+ * Palette slot for a block, derived purely from its name.
+ *
+ * How: `BlockDictionary` names new entries `"<Singular> <n>"` where `n` is the
+ * lowest free creation index, so that trailing number *is* a stable ordinal —
+ * block 0 is blue, block 1 green, and adding or deleting a block never
+ * renumbers the others. Names without one fall back to a hash.
+ *
+ * Why derived and not remembered: a module-level registry would mutate during
+ * render, which React Compiler and StrictMode both assume never happens, and it
+ * would hand two sessions different colours for the same config.
+ *
+ * Past `ELECTRODE_PALETTE.length` blocks, colours necessarily repeat.
+ */
+function electrodePaletteIndex(name: string): number {
+  const ordinal = /(\d+)\s*$/.exec(name);
+  if (ordinal) return Number(ordinal[1]) % ELECTRODE_PALETTE.length;
+  return hashName(name);
 }
 
 /**
  * Colour for electrode contact spheres of a named block.
  *
- * How: hash the name → Okabe–Ito / Tableau categorical palette.
- * Why: reuses the circuit color-by palette (colorblind-safer) and stays stable
- * per block name without per-user colour config.
- *
  * @param name - Electrode block name (`electrode_locations` key)
- * @returns CSS hex colour
+ * @returns CSS hex colour, stable for a given name in every session
  *
  * @example
- * colorForElectrodeBlock('probe_a') === colorForElectrodeBlock('probe_a');
+ * colorForElectrodeBlock('Electrode 0'); // → palette[0], blue
  */
 export function colorForElectrodeBlock(name: string): string {
-  return categoricalColor(hashBlockName(name));
+  return ELECTRODE_PALETTE[electrodePaletteIndex(name)];
 }
 
 /**
  * Colour for the origin marker of a named block.
  *
- * How: same hash as contacts, offset by ~⅓ of the palette.
- * Why: tip must contrast with contact spheres so the pivot is obvious in 3D.
+ * How: a lightness shift of the block colour — brighten dark hues, darken light
+ * ones. Why not a second palette entry: the pivot must read as *the same probe*
+ * while still standing out, and a fixed offset would clash with black.
  *
  * @param name - Electrode block name
- * @returns CSS hex colour distinct from {@link colorForElectrodeBlock}
+ * @returns CSS hex colour related to, but distinct from, the contact colour
  */
 export function colorForElectrodeOrigin(name: string): string {
-  return categoricalColor(
-    (hashBlockName(name) + Math.floor(MAX_DISTINCT_COLORS / 3)) % MAX_DISTINCT_COLORS
-  );
+  const base = chroma(colorForElectrodeBlock(name));
+  return base.luminance() < 0.2 ? base.brighten(2).hex() : base.darken(1.4).hex();
 }
 
 /**
@@ -422,4 +455,122 @@ export function seedElectrodeInitialOrigin(
     ...('origin_y' in initial ? { origin_y: roundCoord(anchor[1]) } : {}),
     ...('origin_z' in initial ? { origin_z: roundCoord(anchor[2]) } : {}),
   };
+}
+
+/**
+ * Active value index per swept parameter, keyed `blockName → paramKey → index`.
+ *
+ * Why this exists: a parameter sweep holds several values, but the circuit view
+ * can only draw one coordinate at a time. The eye toggles in the form write
+ * here; the electrode overlay pipeline reads it to pick which value to send to
+ * `block_dictionary_summary`.
+ */
+export type ScanValueSelection = Record<string, Record<string, number>>;
+
+/**
+ * Shared selection state.
+ *
+ * Why jotai: the eye lives deep in the form (`ParameterSweep`) while the reader
+ * is the viewer-side overlay hook — sibling subtrees with no common props.
+ *
+ * Lifetime: module-level, so it survives navigation. `clearScanValueSelection`
+ * is dispatched by the scan-config template when the workflow schema changes so
+ * one workflow's indices never leak into the next.
+ */
+export const scanValueSelectionAtom = atom<ScanValueSelection>({});
+
+/** Write-only: drop every selection (workflow switch / unmount). */
+export const clearScanValueSelectionAtom = atom(null, (_get, set) => {
+  set(scanValueSelectionAtom, {});
+});
+
+/** Write-only: mark `index` active for one parameter of one block. */
+export const selectScanValueAtom = atom(
+  null,
+  (get, set, { block, param, index }: { block: string; param: string; index: number }) => {
+    const current = get(scanValueSelectionAtom);
+    set(scanValueSelectionAtom, {
+      ...current,
+      [block]: { ...current[block], [param]: index },
+    });
+  }
+);
+
+/**
+ * Active index for a parameter, clamped into `length`.
+ *
+ * Why clamp: a stale index (values removed since it was chosen, or a same-named
+ * block in another workflow) must degrade to the first value, never to
+ * `undefined` reads downstream.
+ */
+export function resolveScanIndex(
+  selection: ScanValueSelection | undefined,
+  block: string,
+  param: string,
+  length: number
+): number {
+  const raw = selection?.[block]?.[param];
+  if (typeof raw !== 'number' || !Number.isInteger(raw) || raw < 0) return 0;
+  return raw < length ? raw : 0;
+}
+
+/** A sweep value: array entries may be null while the user is typing. */
+type SweepValue = (number | null)[];
+
+function isSweepArray(value: unknown): value is SweepValue {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((entry) => entry === null || typeof entry === 'number')
+  );
+}
+
+/**
+ * Collapse every swept parameter in an electrode dictionary to its active value.
+ *
+ * How: each `[a, b, c]` numeric parameter becomes the single selected scalar.
+ * Why: Obi-One's summary endpoint would otherwise expand the sweep, and the
+ * viewer must show exactly one coordinate.
+ *
+ * Assumption: inside an `electrode_locations` block, every numeric array is a
+ * parameter sweep. That holds for the blocks Obi-One exposes today (origin,
+ * rotation, spacing, count — all scalars until swept). A block type that ever
+ * gains a genuine numeric *vector* field would be collapsed wrongly here, so
+ * such a field must be excluded explicitly when it appears.
+ *
+ * @param dictionary - Live `config.electrode_locations`
+ * @param selection - Active indices from {@link scanValueSelectionAtom}
+ * @returns A dictionary with scalars in place of sweeps (input left untouched)
+ *
+ * @example
+ * resolveElectrodeScanSelection({ p: { origin_x: [10, 20] } }, { p: { origin_x: 1 } });
+ * // → { p: { origin_x: 20 } }
+ */
+export function resolveElectrodeScanSelection(
+  dictionary: unknown,
+  selection: ScanValueSelection | undefined
+): unknown {
+  if (!dictionary || typeof dictionary !== 'object' || Array.isArray(dictionary)) return dictionary;
+
+  const out: Record<string, unknown> = {};
+  for (const [blockName, rawBlock] of Object.entries(dictionary as Record<string, unknown>)) {
+    if (!rawBlock || typeof rawBlock !== 'object' || Array.isArray(rawBlock)) {
+      out[blockName] = rawBlock;
+      continue;
+    }
+
+    const block = rawBlock as Record<string, unknown>;
+    let changed = false;
+    const resolved: Record<string, unknown> = {};
+    for (const [paramKey, value] of Object.entries(block)) {
+      if (!isSweepArray(value)) {
+        resolved[paramKey] = value;
+        continue;
+      }
+      resolved[paramKey] = value[resolveScanIndex(selection, blockName, paramKey, value.length)];
+      changed = true;
+    }
+    out[blockName] = changed ? resolved : rawBlock;
+  }
+  return out;
 }

--- a/src/features/scan-config/components/model-preview/index.tsx
+++ b/src/features/scan-config/components/model-preview/index.tsx
@@ -8,7 +8,10 @@ import { CircuitScaleDictionary, type ICircuit } from '@/api/entitycore/types/en
 import { useFlag } from '@/features/feature-flags';
 import { electrodeOverlaysFlag } from '@/features/feature-flags/flags';
 import { CircuitPreview } from '@/features/scan-config/components/model-preview/circuit-preview';
-import { resolveEnableElectrodes } from '@/features/scan-config/components/model-preview/resolve-enable-electrodes';
+import {
+  resolveEnableCellHover,
+  resolveEnableElectrodes,
+} from '@/features/scan-config/components/model-preview/resolve-enable-electrodes';
 import { NeuronVisualizer } from '@/ui/segments/workflows/simulate/single-neuron/shared/steps/neuron-visualizer';
 
 import type { IEntityViewerFeatures } from '@/entity-configuration/domain/viewer-config';
@@ -56,6 +59,10 @@ export function ModelPreview({
 
   const featuresForSmall = (circuit: ICircuit): Partial<IEntityViewerFeatures> => ({
     ...viewerFeatures,
+    cellHover: resolveEnableCellHover({
+      domainCellHover: viewerFeatures?.cellHover,
+      scale: circuit.scale,
+    }),
     electrodes:
       domainElectrodes &&
       resolveEnableElectrodes({

--- a/src/features/scan-config/components/model-preview/large-circuit-preview/large-circuit-preview.tsx
+++ b/src/features/scan-config/components/model-preview/large-circuit-preview/large-circuit-preview.tsx
@@ -4,6 +4,7 @@ import { saveAs } from 'file-saver';
 import { useSetAtom } from 'jotai';
 import React from 'react';
 
+import { DEFAULT_ELECTRODE_RADIUS } from '@/features/scan-config/components/color-by/use-viewer-config';
 import { circuitSceneAnchorAtom } from '@/features/scan-config/components/model-preview/circuit-scene-anchor';
 import { VERTICAL_SCALEBAR } from '@/features/scan-config/components/shared/3d-viewer';
 import { VisualizationLoadingIndicator } from '@/features/scan-config/components/shared/visualization-loading-indicator';
@@ -71,7 +72,7 @@ export function LargeCircuitPreview({
   onOverlayTransform,
   highlightedOverlayId = null,
   neuronOpacity,
-  electrodeRadius = 10,
+  electrodeRadius = DEFAULT_ELECTRODE_RADIUS,
 }: LargeCircuitPreviewProps) {
   const debugMode = useMorphoViewerDebugMode();
   const somaRadius = useSomaRadius(circuit);

--- a/src/features/scan-config/components/model-preview/resolve-enable-electrodes.ts
+++ b/src/features/scan-config/components/model-preview/resolve-enable-electrodes.ts
@@ -30,3 +30,22 @@ export function resolveEnableElectrodes(options: {
   if (options.scale === CircuitScaleDictionary.Single) return false;
   return true;
 }
+
+/**
+ * Compose the cell-hover kill-switch for {@link CircuitPreview}.
+ *
+ * Single-scale circuits are one neuron: highlighting it on hover flashes the
+ * entire view and identifies nothing, so hover stays off there in every
+ * scan-config host (build and simulate alike). Domain policy still wins — an
+ * entity that already set `cellHover: false` is never turned back on.
+ *
+ * @param options.domainCellHover - Resolved `viewer.cellHover`; undefined → on
+ * @param options.scale - Circuit scale when known
+ */
+export function resolveEnableCellHover(options: {
+  domainCellHover?: boolean;
+  scale?: TCircuitScaleDictionary;
+}): boolean {
+  if (options.domainCellHover === false) return false;
+  return options.scale !== CircuitScaleDictionary.Single;
+}

--- a/src/features/scan-config/components/model-preview/use-electrode-locations-overlay.ts
+++ b/src/features/scan-config/components/model-preview/use-electrode-locations-overlay.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useAtomValue } from 'jotai';
 import { useEffect, useMemo, useState } from 'react';
 
 import { downloadAsset } from '@/api/entitycore/queries/assets';
@@ -25,6 +26,8 @@ import {
   electrodeSummaryToOverlays,
   hasElectrodeLocationsDictionary,
   mergeElectrodeOverlays,
+  resolveElectrodeScanSelection,
+  scanValueSelectionAtom,
 } from './electrode-locations-overlay';
 
 import type { Config } from '@/features/scan-config/types';
@@ -102,7 +105,14 @@ export function useElectrodeLocationsOverlay({ config, arrayEntity }: Options = 
   error: Error | null;
 } {
   const ctx = useWorkspace();
-  const liveDictionary = config?.[ELECTRODE_LOCATIONS_CONFIG_KEY];
+  const rawDictionary = config?.[ELECTRODE_LOCATIONS_CONFIG_KEY];
+  const scanSelection = useAtomValue(scanValueSelectionAtom);
+  // Only one coordinate of a sweep may be drawn, so collapse every swept
+  // parameter to its active value before it reaches the API or the placeholders.
+  const liveDictionary = useMemo(
+    () => resolveElectrodeScanSelection(rawDictionary, scanSelection),
+    [rawDictionary, scanSelection]
+  );
   const hasLive = hasElectrodeLocationsDictionary(liveDictionary);
 
   // Primitive query dep: serialize so deep edits invalidate without object identity.

--- a/src/features/scan-config/components/tooltip/tooltip.tsx
+++ b/src/features/scan-config/components/tooltip/tooltip.tsx
@@ -1,6 +1,6 @@
-import type React from 'react';
-
 import { classNames } from '@/util/utils';
+
+import type React from 'react';
 
 import styles from './tooltip.module.css';
 

--- a/src/features/scan-config/components/ui-blocks/block-dictionary.tsx
+++ b/src/features/scan-config/components/ui-blocks/block-dictionary.tsx
@@ -15,6 +15,7 @@ import {
   seedElectrodeInitialOrigin,
 } from '@/features/scan-config/components/model-preview/electrode-locations-overlay';
 import Block from '@/features/scan-config/components/ui-blocks/block';
+import { ScanValueSelectorProvider } from '@/features/scan-config/components/ui-elements/parameter-sweep';
 import { isPlainObject } from '@/features/scan-config/components/utils';
 import { useDiffPreview } from '@/features/scan-config/hooks/use-diff-preview-atom';
 import { useShowingDiffs } from '@/features/scan-config/hooks/use-showing-diffs';
@@ -116,7 +117,12 @@ export default function BlockDictionary({
     // the new/restored values instead of the current live values.
     const state = previewData ?? liveState ?? {};
 
-    return (
+    // Electrode sweeps drive a 3D preview that can only draw one coordinate, so
+    // their values get per-value eyes; other workflows render sweeps unchanged.
+    const offersScanValueSelection =
+      electrodeOverlaysEnabled && selectedRootElement === ELECTRODE_LOCATIONS_CONFIG_KEY;
+
+    const block = (
       <Block
         schema={schema}
         key={`${selectedRootElement}_${selectedEntry}`}
@@ -141,6 +147,12 @@ export default function BlockDictionary({
         selectedEntry={selectedEntry}
         errorPathPrefix={errorPathPrefix}
       />
+    );
+
+    return offersScanValueSelection ? (
+      <ScanValueSelectorProvider blockName={selectedEntry}>{block}</ScanValueSelectorProvider>
+    ) : (
+      block
     );
   }
 

--- a/src/features/scan-config/components/ui-blocks/block.tsx
+++ b/src/features/scan-config/components/ui-blocks/block.tsx
@@ -1,6 +1,11 @@
+import { RiCloseLine } from '@remixicon/react';
 import { isNil } from 'es-toolkit/compat';
 
 import { UIElementRender } from '@/features/scan-config/components/ui-elements';
+import {
+  SweepIconButton,
+  sweepSingleValue,
+} from '@/features/scan-config/components/ui-elements/parameter-sweep';
 import { resolveNeuronFilterProperties } from '@/features/scan-config/helpers';
 import { useBlockDiff } from '@/features/scan-config/hooks/use-block-diff';
 import {
@@ -103,6 +108,15 @@ export default function Block({
 
               const value = state[k];
               const fieldBorderClass = getFieldDiffClass(k);
+              // A sweep expanded into several values offers a way back to one
+              // value. It renders on this title row rather than inside the
+              // element so it sits level with the label instead of floating
+              // above the values card.
+              const canCollapseSweep =
+                !disabled &&
+                Array.isArray(value) &&
+                (blockElementSchema.ui_element === ScanConfigUIElementDict.FloatParameterSweep ||
+                  blockElementSchema.ui_element === ScanConfigUIElementDict.IntParameterSweep);
 
               return (
                 <div
@@ -122,6 +136,17 @@ export default function Block({
                     </div>
                     {blockElementSchema.units && (
                       <div className="text-lg text-gray-500">{blockElementSchema.units}</div>
+                    )}
+                    {canCollapseSweep && (
+                      <SweepIconButton
+                        label="Use a single value"
+                        className="ml-auto"
+                        onClick={() => {
+                          setState({ ...state, [k]: sweepSingleValue(value as (number | null)[]) });
+                        }}
+                      >
+                        <RiCloseLine className="size-3.5" />
+                      </SweepIconButton>
                     )}
                   </div>
 

--- a/src/features/scan-config/components/ui-elements/parameter-sweep.tsx
+++ b/src/features/scan-config/components/ui-elements/parameter-sweep.tsx
@@ -1,8 +1,90 @@
-import { CloseOutlined, PlusCircleOutlined } from '@ant-design/icons';
+import { RiAddLine, RiDeleteBinLine, RiEyeFill, RiEyeLine } from '@remixicon/react';
 import { InputNumber } from 'antd';
 import { isNil } from 'es-toolkit/compat';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { createContext, Fragment, type ReactNode, useContext, useMemo } from 'react';
 
+import {
+  resolveScanIndex,
+  scanValueSelectionAtom,
+  selectScanValueAtom,
+} from '@/features/scan-config/components/model-preview/electrode-locations-overlay';
 import { ScanConfigUIElementDict } from '@/features/scan-config/types';
+import { cn } from '@/utils/css-class';
+
+/**
+ * Marks the form subtree whose parameter sweeps may pick one active value.
+ *
+ * Why a context and not a prop: sweeps are rendered generically by
+ * `UIElementRender` for every workflow, several levels below the only component
+ * that knows they feed a 3D preview (the electrode block dictionary). Without a
+ * provider there is no eye, so every other workflow is untouched.
+ */
+const ScanValueSelectorContext = createContext<{ blockName: string } | null>(null);
+
+export function ScanValueSelectorProvider({
+  blockName,
+  children,
+}: {
+  blockName: string;
+  children: ReactNode;
+}) {
+  const value = useMemo(() => ({ blockName }), [blockName]);
+  return (
+    <ScanValueSelectorContext.Provider value={value}>{children}</ScanValueSelectorContext.Provider>
+  );
+}
+
+/**
+ * The scalar a sweep collapses to — its first usable value.
+ *
+ * Exported because the "back to a single value" control lives on the field's
+ * title row, which `Block` owns, not inside this component.
+ */
+export function sweepSingleValue(value: null | number | (number | null)[]): number | null {
+  if (Array.isArray(value)) return value.find((entry) => !isNil(entry)) ?? null;
+  return isNil(value) ? null : value;
+}
+
+/**
+ * Round icon control shared by every sweep action (add / remove / collapse / eye).
+ *
+ * Why one component: the icons sit next to inputs of varying width, so they need
+ * a fixed footprint and a permanent white pill to stay legible — styling them
+ * ad hoc drifted between rows.
+ */
+export function SweepIconButton({
+  label,
+  onClick,
+  pressed,
+  className,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  /** Set for toggles so screen readers announce the active value. */
+  pressed?: boolean;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={pressed}
+      title={label}
+      className={cn(
+        'inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-full',
+        'text-primary-8 bg-white ring-1 ring-neutral-200 transition-colors',
+        'hover:bg-primary-8 hover:text-white hover:ring-primary-8',
+        className
+      )}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}
 
 export default function ParameterSweep({
   value,
@@ -25,16 +107,38 @@ export default function ParameterSweep({
 }) {
   const mode: 'single' | 'multiple' = Array.isArray(value) ? 'multiple' : 'single';
 
-  const singleValue = (() => {
-    if (Array.isArray(value) && !isNil(value[0])) return value[0];
-    if (!Array.isArray(value) && !isNil(value)) return value;
-    return null;
-  })();
-
   const multipleValues = (() => {
     if (Array.isArray(value)) return value;
     return [value];
   })();
+
+  // Only sweeps inside a ScanValueSelectorProvider (today: electrode locations)
+  // offer per-value eyes; everywhere else this stays null and nothing renders.
+  const scope = useContext(ScanValueSelectorContext);
+  const selection = useAtomValue(scanValueSelectionAtom);
+  const setSelected = useSetAtom(selectScanValueAtom);
+  // Kept separate from `valueSelector`: the add/remove handlers must move the
+  // selection even when no eye is on screen yet (a one-value sweep gaining its
+  // second value renders its first eye and its selection in the same commit).
+  const selectValue = scope
+    ? (index: number) => setSelected({ block: scope.blockName, param: k, index })
+    : null;
+  const valueSelector =
+    scope && selectValue && multipleValues.length > 1
+      ? {
+          activeIndex: resolveScanIndex(selection, scope.blockName, k, multipleValues.length),
+          onSelect: selectValue,
+        }
+      : null;
+
+  /** Index that should stay active once the value at `removed` is gone. */
+  function activeIndexAfterRemoval(removed: number): number {
+    const active = resolveScanIndex(selection, scope?.blockName ?? '', k, multipleValues.length);
+    // Removing an earlier value shifts the active one down; removing the active
+    // value itself falls back to the first.
+    if (removed < active) return active - 1;
+    return removed === active ? 0 : active;
+  }
 
   function error(value: number): string | undefined {
     if (!isNil(min) && value < min) return `Value should be greater than or equal to ${min}`;
@@ -60,18 +164,22 @@ export default function ParameterSweep({
           onChange={(v) => {
             onChange(v);
           }}
-          className="w-full"
+          // room for the floating add button so long values never run under it
+          className="w-full [&_input]:pr-9"
         />
 
         {errorMessage && <span className="text-red-500">{errorMessage}</span>}
 
         {!disabled && (
-          <PlusCircleOutlined
-            className="text-primary-8! absolute top-[10px] right-[8px]"
+          <SweepIconButton
+            label="Scan over several values"
+            className="absolute top-1/2 right-2 -translate-y-1/2"
             onClick={() => {
               onChange(multipleValues);
             }}
-          />
+          >
+            <RiAddLine className="size-3.5" />
+          </SweepIconButton>
         )}
       </div>
     );
@@ -82,25 +190,21 @@ export default function ParameterSweep({
       <div
         data-scan-config-block-element={`${ScanConfigUIElementDict.FloatParameterSweep}_multiple`}
       >
-        {!disabled && (
-          <div className="mb-1 flex justify-end">
-            <CloseOutlined
-              className="text-primary-8!"
-              onClick={() => {
-                onChange(singleValue);
-              }}
-            />
-          </div>
-        )}
+        {/* No collapse control here: it renders on the field's title row (see
+            Block), which is the only way it can truly line up with the label. */}
         <div className="border-neutral-2 rounded-lg border bg-white p-3">
           <div className="flex flex-col gap-1">
             {multipleValues.map((v, i) => {
               const errorMessage = !isNil(v) ? error(v) : undefined;
+              const isLast = i === multipleValues.length - 1;
+              const canRemove = multipleValues.length >= 2;
+              const isActiveValue = valueSelector?.activeIndex === i;
               return (
-                <>
-                  {/* biome-ignore lint/suspicious/noArrayIndexKey: <i> */}
-                  <div className="flex w-full justify-between gap-1" key={k + i}>
+                // biome-ignore lint/suspicious/noArrayIndexKey: values are positional
+                <Fragment key={k + i}>
+                  <div className="flex w-full items-center gap-1.5">
                     <InputNumber
+                      className="min-w-0 flex-1"
                       status={v === null || errorMessage ? 'error' : undefined}
                       value={v}
                       disabled={disabled}
@@ -111,31 +215,68 @@ export default function ParameterSweep({
                       }}
                     />
 
+                    {valueSelector && (
+                      <SweepIconButton
+                        label={`Show value ${i + 1} in the preview`}
+                        pressed={isActiveValue}
+                        // Active reads as a solid blue pill; the rest stay grey
+                        // outlines so exactly one value looks selected.
+                        className={
+                          isActiveValue
+                            ? 'bg-primary-8 ring-primary-8 text-white hover:bg-primary-9 hover:text-white'
+                            : 'text-neutral-400'
+                        }
+                        onClick={() => valueSelector.onSelect(i)}
+                      >
+                        {isActiveValue ? (
+                          <RiEyeFill className="size-3.5" />
+                        ) : (
+                          <RiEyeLine className="size-3.5" />
+                        )}
+                      </SweepIconButton>
+                    )}
+
+                    {/* Fixed column order — eye, delete, add — with reserved
+                        slots so add stays pinned right on every row even though
+                        only the last row can use it. */}
                     {!disabled && (
-                      <div className="flex gap-1">
-                        {i === multipleValues.length - 1 && (
-                          <PlusCircleOutlined
-                            className="text-primary-8!"
-                            onClick={() => {
-                              onChange([...multipleValues, null]);
-                            }}
-                          />
-                        )}
-                        {multipleValues.length >= 2 && (
-                          <CloseOutlined
-                            className="text-primary-8!"
-                            onClick={() => {
-                              const updated = [...multipleValues];
-                              updated.splice(i, 1);
-                              onChange(updated);
-                            }}
-                          />
-                        )}
-                      </div>
+                      <>
+                        <span className="flex size-6 shrink-0 items-center justify-center">
+                          {canRemove && (
+                            <SweepIconButton
+                              label="Remove this value"
+                              onClick={() => {
+                                const updated = [...multipleValues];
+                                updated.splice(i, 1);
+                                // Keep the eye on the same value it was on.
+                                selectValue?.(activeIndexAfterRemoval(i));
+                                onChange(updated);
+                              }}
+                            >
+                              <RiDeleteBinLine className="size-3.5" />
+                            </SweepIconButton>
+                          )}
+                        </span>
+                        <span className="flex size-6 shrink-0 items-center justify-center">
+                          {isLast && (
+                            <SweepIconButton
+                              label="Add a value"
+                              onClick={() => {
+                                // The value you just added is the one you want
+                                // to see, so it becomes the active coordinate.
+                                selectValue?.(multipleValues.length);
+                                onChange([...multipleValues, null]);
+                              }}
+                            >
+                              <RiAddLine className="size-3.5" />
+                            </SweepIconButton>
+                          )}
+                        </span>
+                      </>
                     )}
                   </div>
                   {errorMessage && <span className="text-red-500">{errorMessage}</span>}
-                </>
+                </Fragment>
               );
             })}
           </div>

--- a/src/features/scan-config/template.tsx
+++ b/src/features/scan-config/template.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/features/scan-config/bridge/main-overlay-context';
 import { useEntries } from '@/features/scan-config/components/hooks';
 import { useConfig } from '@/features/scan-config/components/hooks/schema';
+import { clearScanValueSelectionAtom } from '@/features/scan-config/components/model-preview/electrode-locations-overlay';
 import TabsSelector from '@/features/scan-config/components/tabs-selector';
 import { Left, Middle, Right } from '@/features/scan-config/components/ui-columns';
 import {
@@ -129,6 +130,7 @@ function ScanConfigTemplateContent({
   const isCampaignIdChanged = previousCampaignId !== campaignId;
 
   const clearDiffState = useSetAtom(clearDiffStateAtom);
+  const clearScanValueSelection = useSetAtom(clearScanValueSelectionAtom);
   const previousSchemaName = usePrevious(schemaName);
   useEffect(() => {
     // reset the global sidebar expansion/highlight state back to its idle default ("Info")
@@ -137,8 +139,19 @@ function ScanConfigTemplateContent({
     if (previousSchemaName !== undefined && previousSchemaName !== schemaName) {
       setTab(defaultTab);
       setSelectedRootElement(firstRoot ?? '');
+      // Selections live in module state that outlives the route and are keyed
+      // by block name, which repeats across workflows. Drop them so the next
+      // workflow starts on each sweep's first value.
+      clearScanValueSelection();
     }
-  }, [schemaName, clearDiffState, previousSchemaName, defaultTab, firstRoot]);
+  }, [
+    schemaName,
+    clearDiffState,
+    clearScanValueSelection,
+    previousSchemaName,
+    defaultTab,
+    firstRoot,
+  ]);
 
   useAgentState(
     aiEnabled


### PR DESCRIPTION

electrode display follow-ups on the extracellular locations preview:

- default marker radius 5 (was 10), sourced from one DEFAULT_ELECTRODE_RADIUS constant that also drives the viewer-controls slider floor.
- replace the hashed color-by palette with a dedicated neutral electrode palette (blue/green/red/black/orange/purple/teal/magenta). Slots derive purely from the block's creation ordinal, so adding or removing a probe never recolours the others and colours survive a reload.
- run electrode colors through `adaptColorToBackground` like neuron colours, so a near-black probe stays visible on the dark canvas. Unselected probes now desaturate instead of washing to grey, keeping hue identity at small radii.
- clear the neuron hover highlight while an electrode is being dragged, and disable cell hover entirely for single-scale circuits (simulate included).
- parameter sweeps in electrode blocks get a per-value eye: exactly one coordinate is sent to block_dictionary_summary and drawn. A newly added value becomes active; removing a value keeps the eye on its own value.
- restyle the sweep controls with remixicon pills (eye, delete, add) in fixed columns, and move the collapse control onto the field title row so it lines up with the label.