### PR TITLE
chore(entitycore): align created_by/updated_by types with PlatformUser split

### DIFF
--- a/src/api/entitycore/types/entities/agent.ts
+++ b/src/api/entitycore/types/entities/agent.ts
@@ -6,17 +6,11 @@ import type {
   PrefLabelFilter,
 } from '@/api/entitycore/types/shared/request';
 
-type KeycloakIdentifierFilter = {
-  sub_id: string | null;
-  sub_id__in: string | null;
-};
-
 export interface IPersonFilter
   extends PaginationFilter,
     OwnershipFilter,
     PrefLabelFilter,
-    PersonNameFilter,
-    KeycloakIdentifierFilter {}
+    PersonNameFilter {}
 
 export interface IOrganizationFilter
   extends PaginationFilter,

--- a/src/api/entitycore/types/shared/global.ts
+++ b/src/api/entitycore/types/shared/global.ts
@@ -32,8 +32,8 @@ export interface IEntityLifecycleStatus {
 }
 
 export type EntityCoreOwnership = {
-  created_by: IPerson | null;
-  updated_by: IPerson | null;
+  created_by: IPlatformUser | null;
+  updated_by: IPlatformUser | null;
 };
 
 export interface EntityCoreIdentifiableNamed extends EntityCoreIdentifiable {
@@ -188,6 +188,15 @@ export interface IOrganization extends Timestamps, EntityCoreIdentifiable {
 
 export interface IPerson extends Timestamps, EntityCoreIdentifiable {
   type: 'person';
+  given_name: string | null;
+  family_name: string | null;
+  pref_label: string;
+}
+
+// The platform user that created/updated an entity, keyed by Keycloak sub id. Not an Agent:
+// a platform user need not be a contributor, and a contributor need not have an account.
+export interface IPlatformUser extends Timestamps {
+  id: string; // Keycloak sub id
   given_name: string | null;
   family_name: string | null;
   pref_label: string;

--- a/src/api/entitycore/types/shared/request.ts
+++ b/src/api/entitycore/types/shared/request.ts
@@ -146,28 +146,22 @@ export interface OwnershipFilter {
   created_by__pref_label?: string | null;
   created_by__pref_label__in?: string[] | null;
   created_by__pref_label__ilike?: string | null;
-  created_by__id?: string | null; // UUID
-  created_by__id__in?: string[] | null;
-  created_by__type?: string | null;
+  created_by__id?: string | null; // Keycloak sub id
+  created_by__id__in?: string[] | null; // Keycloak sub ids
   created_by__given_name?: string | null;
   created_by__given_name__ilike?: string | null;
   created_by__family_name?: string | null;
   created_by__family_name__ilike?: string | null;
-  created_by__sub_id?: string | null; // UUID
-  created_by__sub_id_in?: string[] | null;
   // Updated by
   updated_by__pref_label?: string | null;
   updated_by__pref_label__in?: string[] | null;
   updated_by__pref_label__ilike?: string | null;
-  updated_by__id?: string | null; // UUID
-  updated_by__id_in?: string[] | null;
-  updated_by__type?: string | null;
+  updated_by__id?: string | null; // Keycloak sub id
+  updated_by__id__in?: string[] | null; // Keycloak sub ids
   updated_by__given_name?: string | null;
   updated_by__given_name__ilike?: string | null;
   updated_by__family_name?: string | null;
   updated_by__family_name__ilike?: string | null;
-  updated_by__sub_id?: string | null; // UUID
-  updated_by__sub_id__in?: string[] | null;
   // Order by
   created_by__order_by?: string | null;
   updated_by__order_by?: string | null;

--- a/src/api/entitycore/types/shared/request.ts
+++ b/src/api/entitycore/types/shared/request.ts
@@ -148,20 +148,12 @@ export interface OwnershipFilter {
   created_by__pref_label__ilike?: string | null;
   created_by__id?: string | null; // Keycloak sub id
   created_by__id__in?: string[] | null; // Keycloak sub ids
-  created_by__given_name?: string | null;
-  created_by__given_name__ilike?: string | null;
-  created_by__family_name?: string | null;
-  created_by__family_name__ilike?: string | null;
   // Updated by
   updated_by__pref_label?: string | null;
   updated_by__pref_label__in?: string[] | null;
   updated_by__pref_label__ilike?: string | null;
   updated_by__id?: string | null; // Keycloak sub id
   updated_by__id__in?: string[] | null; // Keycloak sub ids
-  updated_by__given_name?: string | null;
-  updated_by__given_name__ilike?: string | null;
-  updated_by__family_name?: string | null;
-  updated_by__family_name__ilike?: string | null;
   // Order by
   created_by__order_by?: string | null;
   updated_by__order_by?: string | null;


### PR DESCRIPTION
Adapts our entity-core type declarations to [entitycore#686](https://github.com/openbraininstitute/entitycore/pull/686), which splits the platform user out of the `Person` contributor agent. `created_by`/`updated_by` now return a `NestedPlatformUserRead`: no `type`/`orcid`/`sub_id`, and `id` is the Keycloak sub rather than the agent id.

## No runtime change is needed

I swept every consumer of `created_by`/`updated_by`/`sub_id` before writing this. Against the four breaking changes in #686:

- **Filter rename `created_by__sub_id` → `created_by__id`.** We send neither. The only ownership constraint we emit is `created_by__pref_label__in` (`fields-defs/common.tsx:674`), which is unchanged. The "Created by" checklist also builds its filter value from the facet `label`, not the facet `id` (`create-filter-item-component.tsx:72-78`), so #686's wholesale remapping of created_by ids can't invalidate URL state or a saved filter.
- **Payload drops `type`/`orcid`/`sub_id`.** The only property read off these objects anywhere is `pref_label` — 5 call sites. There's no zod validation of entity-core response bodies, so the narrower payload can't fail a schema check.
- **Facet `type` becomes `"created_by"`/`"updated_by"` instead of `"person"`.** The only place facet `type` is branched on tests for `mtype`/`etype` (`default-checklist.tsx:43`); no `person` branch exists. The facet *keys* stay `created_by`/`updated_by`, which is what the filter panel looks up.
- **`sub_id` removed from `Person`.** Our `IPerson` never declared it, and `getPersons` is only called with `pref_label__ilike`.

Sorting also survives: #686 switches the `created_by`/`updated_by` aliases from `Person` to `PlatformUser` in every service file while keeping the alias *names*, and `PlatformUser` carries `pref_label`, so `order_by=created_by__pref_label` still resolves.

So this PR is purely the type declarations that still described the old payload.

## Changes

- add `IPlatformUser` and point `EntityCoreOwnership` at it. `IPerson` and the `Agent` union are deliberately untouched — contributions are unchanged by #686, and `Person.id` is still the agent id that `Contribution.agent_id` needs.
- drop the `sub_id` and `type` params from `OwnershipFilter` (gone from the platform user filter) and note that `*__id` now takes a Keycloak sub id.
- drop `KeycloakIdentifierFilter` from `IPersonFilter`.

Two typos went out with the removed params: `created_by__sub_id_in` and `updated_by__id_in` were both missing an underscore before `in`, so neither ever matched a real query param.

## Sequencing

None required. entitycore#686 is still open, the old filter keys keep working through its deprecation window, and nothing we send is affected either way — so this can merge before or after #686 deploys.

## Testing

- Vitest: 537 passed, 3 skipped.
- `tsc --noEmit`: 238 errors before and after, identical sets (the repo has a pre-existing non-zero baseline), so zero delta.
- Biome clean on all three files.

## Out of scope

Two pieces of pre-existing dead code I noticed while sweeping, deliberately left for a separate PR so this one stays a clean compatibility change: `DisplayLabel`'s `case 'createdBy'` in `features/listing-filter-panel/checklist/option.tsx:12-21` can never fire (field keys are snake_case; it's a Nexus-era leftover for URL-shaped agent ids), and `EntityCoreFields.UpdatedBy` is referenced by zero view-defs, so the "Updated by" column and filter are unreachable from every listing.