### PR TITLE
Label an unset block reference by its role

### DIFF
--- a/src/__tests__/scan-config/resolve-default-reference-label.test.ts
+++ b/src/__tests__/scan-config/resolve-default-reference-label.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveDefaultReferenceLabel } from '@/features/scan-config/components/ui-elements/resolve-default-reference-label';
+
+/** the Brian2 case the by-type labels cannot express: two roles, one reference type */
+const BRIAN2_SCHEMA = {
+  reference_tag_defaults: {
+    stimulus_target: 'Default: Sugar gustatory receptor neurons',
+    simulation_target: 'Default: All Point Neurons',
+  },
+  default_block_reference_labels: {
+    PointNeuronSetReference: 'Default: Sugar gustatory receptor neurons',
+  },
+};
+
+describe('resolveDefaultReferenceLabel', () => {
+  it('prefers the label for the field’s role', () => {
+    expect(
+      resolveDefaultReferenceLabel(
+        { reference_tag: 'simulation_target', reference_types: ['PointNeuronSetReference'] },
+        BRIAN2_SCHEMA
+      )
+    ).toBe('Default: All Point Neurons');
+  });
+
+  it('distinguishes two fields that share a reference type', () => {
+    const stimulus = resolveDefaultReferenceLabel(
+      { reference_tag: 'stimulus_target', reference_types: ['PointNeuronSetReference'] },
+      BRIAN2_SCHEMA
+    );
+    const simulation = resolveDefaultReferenceLabel(
+      { reference_tag: 'simulation_target', reference_types: ['PointNeuronSetReference'] },
+      BRIAN2_SCHEMA
+    );
+
+    expect(stimulus).not.toBe(simulation);
+  });
+
+  it('falls back to the reference type when the schema has no tag defaults', () => {
+    expect(
+      resolveDefaultReferenceLabel(
+        { reference_tag: 'simulation_target', reference_types: ['PointNeuronSetReference'] },
+        { default_block_reference_labels: BRIAN2_SCHEMA.default_block_reference_labels }
+      )
+    ).toBe('Default: Sugar gustatory receptor neurons');
+  });
+
+  it('falls back when the field carries no tag at all', () => {
+    expect(
+      resolveDefaultReferenceLabel({ reference_types: ['PointNeuronSetReference'] }, BRIAN2_SCHEMA)
+    ).toBe('Default: Sugar gustatory receptor neurons');
+  });
+
+  it('falls back when the tag is one the schema does not name', () => {
+    expect(
+      resolveDefaultReferenceLabel(
+        { reference_tag: 'a_role_added_later', reference_types: ['PointNeuronSetReference'] },
+        BRIAN2_SCHEMA
+      )
+    ).toBe('Default: Sugar gustatory receptor neurons');
+  });
+
+  it('takes the first accepted reference type that carries a label', () => {
+    expect(
+      resolveDefaultReferenceLabel(
+        { reference_types: ['UnlabelledReference', 'BiophysicalNeuronSetReference'] },
+        { default_block_reference_labels: { BiophysicalNeuronSetReference: 'Default: All Bio' } }
+      )
+    ).toBe('Default: All Bio');
+  });
+
+  it('falls back to a generic label when nothing names a default', () => {
+    expect(resolveDefaultReferenceLabel({ reference_types: ['PointNeuronSetReference'] }, {})).toBe(
+      'Default'
+    );
+  });
+
+  it('ignores an empty label rather than showing a blank option', () => {
+    expect(
+      resolveDefaultReferenceLabel(
+        { reference_tag: 'simulation_target', reference_types: ['PointNeuronSetReference'] },
+        {
+          reference_tag_defaults: { simulation_target: '' },
+          default_block_reference_labels: { PointNeuronSetReference: 'Default: All Point Neurons' },
+        }
+      )
+    ).toBe('Default: All Point Neurons');
+  });
+});

--- a/src/__tests__/scan-config/resolve-default-reference-label.test.ts
+++ b/src/__tests__/scan-config/resolve-default-reference-label.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveDefaultReferenceLabel } from '@/features/scan-config/components/ui-elements/resolve-default-reference-label';
+import { findDefaultReferenceLabel } from '@/features/scan-config/components/ui-elements/resolve-default-reference-label';
 
 /** the Brian2 case the by-type labels cannot express: two roles, one reference type */
 const BRIAN2_SCHEMA = {
@@ -13,10 +13,10 @@ const BRIAN2_SCHEMA = {
   },
 };
 
-describe('resolveDefaultReferenceLabel', () => {
+describe('findDefaultReferenceLabel', () => {
   it('prefers the label for the field’s role', () => {
     expect(
-      resolveDefaultReferenceLabel(
+      findDefaultReferenceLabel(
         { reference_tag: 'simulation_target', reference_types: ['PointNeuronSetReference'] },
         BRIAN2_SCHEMA
       )
@@ -24,11 +24,11 @@ describe('resolveDefaultReferenceLabel', () => {
   });
 
   it('distinguishes two fields that share a reference type', () => {
-    const stimulus = resolveDefaultReferenceLabel(
+    const stimulus = findDefaultReferenceLabel(
       { reference_tag: 'stimulus_target', reference_types: ['PointNeuronSetReference'] },
       BRIAN2_SCHEMA
     );
-    const simulation = resolveDefaultReferenceLabel(
+    const simulation = findDefaultReferenceLabel(
       { reference_tag: 'simulation_target', reference_types: ['PointNeuronSetReference'] },
       BRIAN2_SCHEMA
     );
@@ -38,7 +38,7 @@ describe('resolveDefaultReferenceLabel', () => {
 
   it('falls back to the reference type when the schema has no tag defaults', () => {
     expect(
-      resolveDefaultReferenceLabel(
+      findDefaultReferenceLabel(
         { reference_tag: 'simulation_target', reference_types: ['PointNeuronSetReference'] },
         { default_block_reference_labels: BRIAN2_SCHEMA.default_block_reference_labels }
       )
@@ -47,13 +47,13 @@ describe('resolveDefaultReferenceLabel', () => {
 
   it('falls back when the field carries no tag at all', () => {
     expect(
-      resolveDefaultReferenceLabel({ reference_types: ['PointNeuronSetReference'] }, BRIAN2_SCHEMA)
+      findDefaultReferenceLabel({ reference_types: ['PointNeuronSetReference'] }, BRIAN2_SCHEMA)
     ).toBe('Default: Sugar gustatory receptor neurons');
   });
 
   it('falls back when the tag is one the schema does not name', () => {
     expect(
-      resolveDefaultReferenceLabel(
+      findDefaultReferenceLabel(
         { reference_tag: 'a_role_added_later', reference_types: ['PointNeuronSetReference'] },
         BRIAN2_SCHEMA
       )
@@ -62,22 +62,31 @@ describe('resolveDefaultReferenceLabel', () => {
 
   it('takes the first accepted reference type that carries a label', () => {
     expect(
-      resolveDefaultReferenceLabel(
+      findDefaultReferenceLabel(
         { reference_types: ['UnlabelledReference', 'BiophysicalNeuronSetReference'] },
         { default_block_reference_labels: { BiophysicalNeuronSetReference: 'Default: All Bio' } }
       )
     ).toBe('Default: All Bio');
   });
 
-  it('falls back to a generic label when nothing names a default', () => {
-    expect(resolveDefaultReferenceLabel({ reference_types: ['PointNeuronSetReference'] }, {})).toBe(
-      'Default'
+  it('names nothing when neither source has an entry, so the field is hidden', () => {
+    expect(findDefaultReferenceLabel({ reference_types: ['PointNeuronSetReference'] }, {})).toBe(
+      undefined
     );
+  });
+
+  it('is enough on its own, with no by-type map present at all', () => {
+    expect(
+      findDefaultReferenceLabel(
+        { reference_tag: 'simulation_target', reference_types: ['PointNeuronSetReference'] },
+        { reference_tag_defaults: { simulation_target: 'Default: All Point Neurons' } }
+      )
+    ).toBe('Default: All Point Neurons');
   });
 
   it('ignores an empty label rather than showing a blank option', () => {
     expect(
-      resolveDefaultReferenceLabel(
+      findDefaultReferenceLabel(
         { reference_tag: 'simulation_target', reference_types: ['PointNeuronSetReference'] },
         {
           reference_tag_defaults: { simulation_target: '' },

--- a/src/features/scan-config/components/ui-blocks/block.tsx
+++ b/src/features/scan-config/components/ui-blocks/block.tsx
@@ -6,6 +6,7 @@ import {
   SweepIconButton,
   sweepSingleValue,
 } from '@/features/scan-config/components/ui-elements/parameter-sweep';
+import { findDefaultReferenceLabel } from '@/features/scan-config/components/ui-elements/resolve-default-reference-label';
 import { resolveNeuronFilterProperties } from '@/features/scan-config/helpers';
 import { useBlockDiff } from '@/features/scan-config/hooks/use-block-diff';
 import {
@@ -97,9 +98,7 @@ export default function Block({
                 !isType(paramSchema) &&
                 !paramSchema.ui_hidden &&
                 (paramSchema.ui_element !== ScanConfigUIElementDict.Reference ||
-                  paramSchema.reference_types.some(
-                    (refType) => !!schema.default_block_reference_labels?.[refType]
-                  ))
+                  !!findDefaultReferenceLabel(paramSchema, schema))
             )
             .map(([k, blockElementSchema]) => {
               if (isType(blockElementSchema)) return null;

--- a/src/features/scan-config/components/ui-elements/neuron-set-combination.tsx
+++ b/src/features/scan-config/components/ui-elements/neuron-set-combination.tsx
@@ -50,9 +50,12 @@ export function NeuronSetCombination({
   selfName?: string;
 }) {
   // synthetic reference schema so we can reuse the existing `Reference` picker for each row.
-  // `Reference` only reads `reference_types`; `anyOf` is an unused placeholder for the type cast.
+  // `Reference` reads `reference_types` and `reference_tag`; `anyOf` is an unused placeholder for
+  // the type cast. the tag is carried over so each row's default option is labelled with what an
+  // unset operand actually resolves to, which differs by the combined set's population type.
   const referenceSchema = {
     reference_types: paramSchema.reference_types,
+    reference_tag: paramSchema.reference_tag,
     anyOf: [],
   } as unknown as ReferenceSchema;
 

--- a/src/features/scan-config/components/ui-elements/reference.tsx
+++ b/src/features/scan-config/components/ui-elements/reference.tsx
@@ -10,7 +10,7 @@ import {
   useBlockTypeToConfigKey,
   useReferenceTypeDict,
 } from '../hooks/schema';
-import { resolveDefaultReferenceLabel } from './resolve-default-reference-label';
+import { findDefaultReferenceLabel } from './resolve-default-reference-label';
 
 import type { Config, ConfigSchema } from '@/features/scan-config/types';
 
@@ -33,8 +33,9 @@ const DEFAULT_SENTINEL = '__default_as_null__';
  *
  * the default option is labelled with the block the backend resolves this field to when it is left
  * unset: the schema's `reference_tag_defaults` keyed by the field's own `reference_tag`, falling
- * back to `default_block_reference_labels` keyed by reference type. visibility still keys off the
- * latter, which doubles as the declaration of which reference types a config supports.
+ * back to `default_block_reference_labels` keyed by reference type. either source is enough on
+ * its own; a field the schema names no default for is hidden, since its default option would
+ * have no label.
  *
  * @param schema           the full scan-config schema (source of the reference/variant lookups)
  * @param referenceSchema  the field's own schema; only `reference_types` is read
@@ -43,7 +44,7 @@ const DEFAULT_SENTINEL = '__default_as_null__';
  * @param onChange         called with `(block_name, block_dict_name)` — both `null` for default
  * @param disabled         disables the select
  * @param omit             block names to hide (e.g. a combined set excluding itself)
- * @returns the select, or `null` when the field is hidden (no reference type has a default label)
+ * @returns the select, or `null` when the field is hidden (the schema names no default for it)
  *
  * @example
  * // combined (Virtual): reference_types = ["VirtualNeuronSetReference"]
@@ -116,12 +117,11 @@ export default function Reference({
     if (configKey) matchingConfigKeys.add(configKey);
   }
 
-  // check visibility: at least one reference type must have a default label
-  const hasDefaultLabel = referenceSchema.reference_types.some(
-    (refType) => schema?.default_block_reference_labels?.[refType]
-  );
+  // the field is renderable only if the schema names what its default resolves to, from either
+  // source: its role (`reference_tag_defaults`) or, failing that, its reference type.
+  const defaultLabel = schema ? findDefaultReferenceLabel(referenceSchema, schema) : undefined;
 
-  if (!schema || !hasDefaultLabel) return null;
+  if (!schema || !defaultLabel) return null;
 
   // build dropdown options from all matching dictionaries
   const options: Array<{ label: string; value: string }> = [];
@@ -143,9 +143,6 @@ export default function Reference({
       options.push({ label: k, value: k });
     }
   }
-
-  // label the default option with the name the backend will actually resolve this field to
-  const defaultLabel = resolveDefaultReferenceLabel(referenceSchema, schema);
 
   options.unshift({
     label: defaultLabel,

--- a/src/features/scan-config/components/ui-elements/reference.tsx
+++ b/src/features/scan-config/components/ui-elements/reference.tsx
@@ -10,6 +10,7 @@ import {
   useBlockTypeToConfigKey,
   useReferenceTypeDict,
 } from '../hooks/schema';
+import { resolveDefaultReferenceLabel } from './resolve-default-reference-label';
 
 import type { Config, ConfigSchema } from '@/features/scan-config/types';
 
@@ -29,6 +30,11 @@ const DEFAULT_SENTINEL = '__default_as_null__';
  *
  * `reference_types` are reference-class names (e.g. `BiophysicalNeuronSetReference`), not entry
  * `type`s (e.g. `BiophysicalPopulationNeuronSet`); `allowed_block_types` is the bridge between them
+ *
+ * the default option is labelled with the block the backend resolves this field to when it is left
+ * unset: the schema's `reference_tag_defaults` keyed by the field's own `reference_tag`, falling
+ * back to `default_block_reference_labels` keyed by reference type. visibility still keys off the
+ * latter, which doubles as the declaration of which reference types a config supports.
  *
  * @param schema           the full scan-config schema (source of the reference/variant lookups)
  * @param referenceSchema  the field's own schema; only `reference_types` is read
@@ -138,11 +144,8 @@ export default function Reference({
     }
   }
 
-  // find the first available default label across accepted reference types
-  const defaultLabel =
-    referenceSchema.reference_types
-      .map((refType) => schema.default_block_reference_labels?.[refType])
-      .find(Boolean) ?? 'Default';
+  // label the default option with the name the backend will actually resolve this field to
+  const defaultLabel = resolveDefaultReferenceLabel(referenceSchema, schema);
 
   options.unshift({
     label: defaultLabel,

--- a/src/features/scan-config/components/ui-elements/resolve-default-reference-label.ts
+++ b/src/features/scan-config/components/ui-elements/resolve-default-reference-label.ts
@@ -1,0 +1,44 @@
+/** label shown for a reference the user has not set, when the schema names no default */
+export const FALLBACK_DEFAULT_REFERENCE_LABEL = 'Default';
+
+type ReferenceFieldSchema = {
+  /** the role this field plays, e.g. `stimulus_target` */
+  reference_tag?: string;
+  /** the reference classes this field accepts, e.g. `PointNeuronSetReference` */
+  reference_types: Array<string>;
+};
+
+type DefaultsSchema = {
+  /** default block name per role; the precise answer, absent on older schemas */
+  reference_tag_defaults?: Record<string, string>;
+  /** default block name per reference type; also declares which types a config supports */
+  default_block_reference_labels?: Record<string, string>;
+};
+
+/**
+ * the name of the block the backend resolves a reference field to when it is left unset.
+ *
+ * prefers the field's role (`reference_tag`) over its reference type, because a type can be
+ * shared by fields that mean different things: in a Brian2 simulation an untargeted stimulus
+ * drives the `sugar` node set while the simulation itself runs every point neuron, and both
+ * fields are `PointNeuronSetReference`. keyed by type the schema can only carry one of those
+ * answers; keyed by role it carries both.
+ *
+ * falls back to the by-type labels so schemas published before the tags existed still show a
+ * sensible label, then to a generic one.
+ */
+export function resolveDefaultReferenceLabel(
+  referenceSchema: ReferenceFieldSchema,
+  schema: DefaultsSchema
+): string {
+  const byTag = referenceSchema.reference_tag
+    ? schema.reference_tag_defaults?.[referenceSchema.reference_tag]
+    : undefined;
+  if (byTag) return byTag;
+
+  const byType = referenceSchema.reference_types
+    .map((referenceType) => schema.default_block_reference_labels?.[referenceType])
+    .find(Boolean);
+
+  return byType ?? FALLBACK_DEFAULT_REFERENCE_LABEL;
+}

--- a/src/features/scan-config/components/ui-elements/resolve-default-reference-label.ts
+++ b/src/features/scan-config/components/ui-elements/resolve-default-reference-label.ts
@@ -1,6 +1,3 @@
-/** label shown for a reference the user has not set, when the schema names no default */
-export const FALLBACK_DEFAULT_REFERENCE_LABEL = 'Default';
-
 type ReferenceFieldSchema = {
   /** the role this field plays, e.g. `stimulus_target` */
   reference_tag?: string;
@@ -11,12 +8,13 @@ type ReferenceFieldSchema = {
 type DefaultsSchema = {
   /** default block name per role; the precise answer, absent on older schemas */
   reference_tag_defaults?: Record<string, string>;
-  /** default block name per reference type; also declares which types a config supports */
+  /** default block name per reference type; the older, less precise source */
   default_block_reference_labels?: Record<string, string>;
 };
 
 /**
- * the name of the block the backend resolves a reference field to when it is left unset.
+ * the name of the block the backend resolves a reference field to when it is left unset, or
+ * `undefined` when the schema names no default for it.
  *
  * prefers the field's role (`reference_tag`) over its reference type, because a type can be
  * shared by fields that mean different things: in a Brian2 simulation an untargeted stimulus
@@ -25,20 +23,22 @@ type DefaultsSchema = {
  * answers; keyed by role it carries both.
  *
  * falls back to the by-type labels so schemas published before the tags existed still show a
- * sensible label, then to a generic one.
+ * label. either source is sufficient on its own — a config that names its defaults by role need
+ * not also list them by type.
+ *
+ * a field with no default from either source is not renderable: the picker has no label for its
+ * default option, so callers hide it.
  */
-export function resolveDefaultReferenceLabel(
+export function findDefaultReferenceLabel(
   referenceSchema: ReferenceFieldSchema,
   schema: DefaultsSchema
-): string {
+): string | undefined {
   const byTag = referenceSchema.reference_tag
     ? schema.reference_tag_defaults?.[referenceSchema.reference_tag]
     : undefined;
   if (byTag) return byTag;
 
-  const byType = referenceSchema.reference_types
+  return referenceSchema.reference_types
     .map((referenceType) => schema.default_block_reference_labels?.[referenceType])
     .find(Boolean);
-
-  return byType ?? FALLBACK_DEFAULT_REFERENCE_LABEL;
 }

--- a/src/features/scan-config/types.ts
+++ b/src/features/scan-config/types.ts
@@ -430,7 +430,8 @@ export interface IBlockDictionary extends TRootElement {
 
 export type ConfigSchema = {
   additionalProperties: false;
-  default_block_reference_labels: Record<string, string>;
+  /** optional: a config that names its defaults by reference tag need not also list them here */
+  default_block_reference_labels?: Record<string, string>;
   /**
    * the name each unset reference resolves to, keyed by the field's `reference_tag`. preferred
    * over `default_block_reference_labels`, which is keyed by reference type and so cannot

--- a/src/features/scan-config/types.ts
+++ b/src/features/scan-config/types.ts
@@ -219,6 +219,11 @@ export interface IntParameterSweep extends TBlockElement {
 export interface Reference extends TBlockElement {
   ui_element: typeof ScanConfigUIElementDict.Reference;
   reference_types: Array<string>;
+  /**
+   * the role this reference plays, e.g. `stimulus_target`. looked up in the config schema's
+   * `reference_tag_defaults` to label the default option. absent on older schemas.
+   */
+  reference_tag?: string;
   anyOf?: Array<
     | {
         title?: string;
@@ -352,6 +357,8 @@ export interface NeuronPropertyFilter extends TBlockElement {
 export interface NeuronSetCombination extends TBlockElement {
   ui_element: typeof ScanConfigUIElementDict.NeuronSetCombination;
   reference_types: Array<string>;
+  /** the role each operand plays; see `Reference.reference_tag` */
+  reference_tag?: string;
 }
 
 export interface IBlockUnion extends TRootElement {
@@ -424,6 +431,14 @@ export interface IBlockDictionary extends TRootElement {
 export type ConfigSchema = {
   additionalProperties: false;
   default_block_reference_labels: Record<string, string>;
+  /**
+   * the name each unset reference resolves to, keyed by the field's `reference_tag`. preferred
+   * over `default_block_reference_labels`, which is keyed by reference type and so cannot
+   * distinguish two fields of the same type that mean different things (a Brian2 stimulus target
+   * defaults to the `sugar` node set, while the simulation itself runs all point neurons -- both
+   * are PointNeuronSetReference). absent on older schemas.
+   */
+  reference_tag_defaults?: Record<string, string>;
   description: string;
   group_order: string[];
   properties: Record<string, IBlockSingle | IBlockDictionary | IRootBlockUnion> & {


### PR DESCRIPTION
Just to test the desired functionality with obi-one. No idea if the code is total bs

Pairs with openbraininstitute/obi-one#947, which adds the schema this reads. 

### Why

The default option of a reference picker is labelled with the block the backend resolves the field to when it is left unset. That label came from the config schema's `default_block_reference_labels`, keyed by **reference type** — which cannot express two fields of the same type that mean different things.

The clearest case is Brian2: an untargeted stimulus drives the `sugar` node set, while the simulation itself runs every point neuron. Both fields are `PointNeuronSetReference`, so the schema could only carry one of those answers. A comment in the backend recorded which one had to be sacrificed, and `Initialize.node_set` was marked `ui_hidden` partly to keep the remaining label honest.

### What changed

A reference field now carries a `reference_tag` naming its **role** (`stimulus_target`, `simulation_target`, …), and a scan config publishes `reference_tag_defaults` mapping each role to the block it resolves to. The label lookup prefers that, falling back to the by-type labels:

```ts
export function findDefaultReferenceLabel(referenceSchema, schema): string | undefined {
  const byTag = referenceSchema.reference_tag
    ? schema.reference_tag_defaults?.[referenceSchema.reference_tag]
    : undefined;
  if (byTag) return byTag;

  return referenceSchema.reference_types
    .map((referenceType) => schema.default_block_reference_labels?.[referenceType])
    .find(Boolean);
}
```

**`default_block_reference_labels` is no longer required.** It previously did double duty: the label *and* the visibility gate — a reference was hidden unless one of its `reference_types` appeared there. A config naming its defaults by role had no way to make a field visible without also listing them by type. Both gates (`block.tsx`, `reference.tsx`) now ask the same question the label lookup answers: does the schema name a default for this field, from either source? The map becomes optional, and is purely a fallback for schemas published before the tags.

`findDefaultReferenceLabel` returns `undefined` rather than a generic label, so one call drives both the gate and the label and the two cannot disagree. The old generic `'Default'` was unreachable anyway — a field with no label was already hidden before it could be used.

The combined-neuron-set rows pass the tag through their synthetic reference schema, so each operand is labelled with the default for its own population type.

### Compatibility

A schema with no `reference_tag_defaults` behaves exactly as before: every field falls through to the by-type labels. Both new schema keys are optional in `ConfigSchema`.

### Tests

10 unit tests on the resolution rule: role beats type, each source sufficient on its own, a tag the schema does not name, a field with no tag, an empty label, the first labelled type wins, and nothing named at all. 124 pass across the scan-config suite; biome clean.

Verified against the real generated Brian2 schema with `default_block_reference_labels` absent: `Initialize.node_set` renders and labels as "Default: All Point Neurons", while the Poisson stimulus target labels as "Default: Sugar gustatory receptor neurons".