### PR TITLE
feat(44): add `build > circuit synaptic physiology` workflow

### DIFF
--- a/src/__tests__/entity-routing/url-builder.test.ts
+++ b/src/__tests__/entity-routing/url-builder.test.ts
@@ -56,6 +56,12 @@ describe('resolveConcreteEntityPathParam', () => {
         resolveConcreteEntityPathParam(ExtendedEntitiesTypeDict.EmSynapseMappingCampaign)
       ).toBe('circuit');
     });
+
+    it('routes circuit synaptic physiology campaigns to the circuit listing (no browse page of their own)', () => {
+      expect(
+        resolveConcreteEntityPathParam(ExtendedEntitiesTypeDict.CircuitSynapticPhysiologyCampaign)
+      ).toBe('circuit');
+    });
   });
 
   describe('other entities map to themselves (kebab-cased)', () => {
@@ -94,6 +100,10 @@ describe('resolveConcreteEntityPathParam', () => {
       [ExtendedEntitiesTypeDict.Microcircuit, ExtendedEntitiesTypeDict.Circuit],
       [ExtendedEntitiesTypeDict.PairedNeuronCircuit, ExtendedEntitiesTypeDict.Circuit],
       [ExtendedEntitiesTypeDict.EmSynapseMappingCampaign, ExtendedEntitiesTypeDict.Circuit],
+      [
+        ExtendedEntitiesTypeDict.CircuitSynapticPhysiologyCampaign,
+        ExtendedEntitiesTypeDict.Circuit,
+      ],
       [ExtendedEntitiesTypeDict.SingleNeuronCircuit, ExtendedEntitiesTypeDict.SingleNeuronCircuit],
       [ExtendedEntitiesTypeDict.Emodel, ExtendedEntitiesTypeDict.Emodel],
       [ExtendedEntitiesTypeDict.Memodel, ExtendedEntitiesTypeDict.Memodel],

--- a/src/__tests__/workflows/entity-entry.test.ts
+++ b/src/__tests__/workflows/entity-entry.test.ts
@@ -181,10 +181,15 @@ const cases: TCase[] = [
     selects: { type: ExtendedEntitiesTypeDict.Circuit, id: ENTITY_ID },
   },
   {
-    name: 'scale-less circuit → circuit extraction when only extraction is enabled',
+    // with the recording-array flag off, the next circuit-consuming build workflow
+    // (circuit synaptic physiology, unflagged) wins over extract by activity order
+    name: 'scale-less circuit → circuit synaptic physiology build when recording array is off',
     fixture: { entity: { type: EntityTypeDict.Circuit } },
-    covers: { activity: extract, targetType: ExtendedEntitiesTypeDict.CircuitExtractionCampaign },
-    href: `${base}/extract/configure/circuit-extraction-campaign/{session}`,
+    covers: {
+      activity: build,
+      targetType: ExtendedEntitiesTypeDict.CircuitSynapticPhysiologyCampaign,
+    },
+    href: `${base}/build/configure/circuit-synaptic-physiology-campaign/{session}`,
     selects: { type: ExtendedEntitiesTypeDict.Circuit, id: ENTITY_ID },
     flags: { [extractionActivityFlag.key]: true } as FeatureFlags,
   },
@@ -297,6 +302,19 @@ const cases: TCase[] = [
     href: `${base}/build/configure/extracellular-recording-array-campaign/{session}?origin=${ENTITY_ID}`,
   },
   {
+    name: 'circuit synaptic physiology task config → build editor',
+    fixture: {
+      entity: { type: EntityTypeDict.TaskConfig },
+      input: { type: EntityTypeDict.Circuit },
+      taskConfigType: TaskConfigType.CircuitSynapticPhysiologyCampaign,
+    },
+    covers: {
+      activity: build,
+      targetType: ExtendedEntitiesTypeDict.CircuitSynapticPhysiologyCampaign,
+    },
+    href: `${base}/build/configure/circuit-synaptic-physiology-campaign/{session}?origin=${ENTITY_ID}`,
+  },
+  {
     name: 'circuit simulation task config picks the workflow matching its input scale',
     fixture: {
       entity: { type: EntityTypeDict.TaskConfig },
@@ -380,7 +398,13 @@ describe('resolveWorkflowConfigureHrefForEntity', () => {
   });
 
   it('skips workflows the user has no feature flag for', async () => {
-    applyFixture({ entity: { type: EntityTypeDict.Circuit } });
+    // a recording-array task config only matches the flag-gated recording-array build,
+    // so without flags no workflow accepts it
+    applyFixture({
+      entity: { type: EntityTypeDict.TaskConfig },
+      input: { type: EntityTypeDict.Circuit },
+      taskConfigType: TaskConfigType.ExtracellularRecordingWeightsCalculationCampaign,
+    });
 
     await expect(
       resolveWorkflowConfigureHrefForEntity({ entityId: ENTITY_ID, workspace })

--- a/src/api/entitycore/types/entities/task-activity.ts
+++ b/src/api/entitycore/types/entities/task-activity.ts
@@ -42,6 +42,9 @@ export const TaskActivityType = {
     'extracellular_recording_weights_calculation__config_generation',
   ExtracellularRecordingWeightsCalculationExecution:
     'extracellular_recording_weights_calculation__execution',
+  CircuitSynapticPhysiologyConfigGeneration:
+    'circuit_synaptic_physiology_assignment__config_generation',
+  CircuitSynapticPhysiologyExecution: 'circuit_synaptic_physiology_assignment__execution',
 } as const;
 
 export type TTaskActivityType = (typeof TaskActivityType)[keyof typeof TaskActivityType];

--- a/src/api/entitycore/types/entities/task-config.ts
+++ b/src/api/entitycore/types/entities/task-config.ts
@@ -39,6 +39,8 @@ export const TaskConfigType = {
     'extracellular_recording_weights_calculation__campaign',
   ExtracellularRecordingWeightsCalculationConfig:
     'extracellular_recording_weights_calculation__config',
+  CircuitSynapticPhysiologyCampaign: 'circuit_synaptic_physiology_assignment__campaign',
+  CircuitSynapticPhysiologyConfig: 'circuit_synaptic_physiology_assignment__config',
 } as const;
 
 export type TTaskConfigType = (typeof TaskConfigType)[keyof typeof TaskConfigType];

--- a/src/api/entitycore/types/extended-entity-type.ts
+++ b/src/api/entitycore/types/extended-entity-type.ts
@@ -24,6 +24,7 @@ export const ExtendedEntitiesTypeDict = {
   CircuitExtractionCampaign: 'circuit_extraction_campaign',
   SkeletonizationCampaign: 'skeletonization_campaign',
   ExtracellularRecordingArrayCampaign: 'extracellular_recording_array_campaign',
+  CircuitSynapticPhysiologyCampaign: 'circuit_synaptic_physiology_campaign',
   RegionCircuitSimulation: 'region_circuit_simulation',
   WholeBrainCircuitSimulation: 'whole_brain_circuit_simulation',
 } as const;

--- a/src/api/one/types/task.ts
+++ b/src/api/one/types/task.ts
@@ -7,6 +7,7 @@ export const ObiOneTaskTypeDict = {
   IonChannelModelSimulationExecution: 'ion_channel_model_simulation_execution',
   EmSynapseMapping: 'em_synapse_mapping',
   ExtracellularRecordingWeightsCalculation: 'extracellular_recording_weights_calculation',
+  CircuitSynapticPhysiology: 'circuit_synaptic_physiology_assignment',
 } as const;
 
 export type TObiOneTaskType = (typeof ObiOneTaskTypeDict)[keyof typeof ObiOneTaskTypeDict];

--- a/src/entity-configuration/domain/index.ts
+++ b/src/entity-configuration/domain/index.ts
@@ -11,6 +11,7 @@ import { UniversalCellMorphology } from '@/entity-configuration/domain/experimen
 import { CircuitExtractionCampaign } from '@/entity-configuration/domain/extraction/extraction-campaign';
 import { BrainRegion } from '@/entity-configuration/domain/model/brain-region';
 import { Circuit } from '@/entity-configuration/domain/model/circuit';
+import { CircuitSynapticPhysiologyCampaign } from '@/entity-configuration/domain/model/circuit-synaptic-physiology-campaign';
 import { Emodel } from '@/entity-configuration/domain/model/e-model';
 import { EmSynapseMappingCampaign } from '@/entity-configuration/domain/model/em-synapse-mapping-campaign';
 import { ExtracellularRecordingArray } from '@/entity-configuration/domain/model/extracellular-recording-array';
@@ -73,6 +74,7 @@ export const EntityCoreModelConfiguration = {
   EmSynapseMappingCampaign,
   ExtracellularRecordingArray,
   ExtracellularRecordingArrayCampaign,
+  CircuitSynapticPhysiologyCampaign,
   SingleNeuronCircuit,
   SynthesizedCellMorphology,
 } as const;

--- a/src/entity-configuration/domain/model/circuit-synaptic-physiology-campaign.ts
+++ b/src/entity-configuration/domain/model/circuit-synaptic-physiology-campaign.ts
@@ -1,0 +1,160 @@
+import { downloadAsset } from '@/api/entitycore/queries/assets';
+import { createTaskConfig, getTaskConfig } from '@/api/entitycore/queries/task';
+import { getAsset } from '@/api/entitycore/selectors/assets';
+import { discardBrainRegionQueryParams } from '@/api/entitycore/transformers';
+import { TaskConfigType } from '@/api/entitycore/types/entities/task-config';
+import { EntityTypeDict } from '@/api/entitycore/types/entity-type';
+import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
+import { AssetLabel } from '@/api/entitycore/types/shared/global';
+import { DetailViewSectionsDict } from '@/entity-configuration/definitions/types';
+import { EntityTypeGroup } from '@/entity-configuration/domain/group';
+import { EntitySlug } from '@/entity-configuration/domain/slug';
+import { Task, type TTaskFlowTypes } from '@/entity-configuration/domain/task-functions';
+
+import type { ITaskConfig, ITaskConfigFilter } from '@/api/entitycore/types/entities/task-config';
+import type { EntityCoreTypeConfig } from '@/entity-configuration/domain/types';
+import type { AwaitedType, WorkspaceContext } from '@/types/common';
+
+export type TCircuitSynapticPhysiologyCampaignMeta = {
+  scan_parameters?: Record<string, unknown>;
+};
+
+// The build campaign is tracked through the launchable synaptic-physiology-assignment task family.
+const TaskFlow: TTaskFlowTypes = {
+  campaignConfigType: TaskConfigType.CircuitSynapticPhysiologyCampaign,
+};
+
+async function list({
+  withFacets,
+  context,
+  filters,
+}: {
+  withFacets?: boolean;
+  context: WorkspaceContext | undefined;
+  filters?: Partial<ITaskConfigFilter>;
+}) {
+  return Task.many<TCircuitSynapticPhysiologyCampaignMeta>({
+    context,
+    withFacets,
+    ...TaskFlow,
+    filters: {
+      ...discardBrainRegionQueryParams(filters),
+    },
+  });
+}
+
+async function rows({
+  campaign,
+  id,
+  context,
+}: {
+  campaign?: ITaskConfig<TCircuitSynapticPhysiologyCampaignMeta>;
+  id: string;
+  context: WorkspaceContext | undefined;
+}) {
+  return Task.one<TCircuitSynapticPhysiologyCampaignMeta>({
+    campaign,
+    id,
+    context,
+    ...TaskFlow,
+  });
+}
+
+async function status({ id, context }: { id: string; context?: WorkspaceContext | null }) {
+  return Task.status({
+    campaignId: id,
+    context: context ?? undefined,
+  });
+}
+
+async function resolve({ id, context }: { id: string; context?: WorkspaceContext | null }) {
+  const resolvedContext = context ?? undefined;
+  const campaign = await getTaskConfig({ id, context: resolvedContext });
+
+  if (!campaign) {
+    throw new Error(`No circuit synaptic physiology campaign with id ${id} found`);
+  }
+
+  const taskRows = await Task.one<TCircuitSynapticPhysiologyCampaignMeta>({
+    id,
+    context: resolvedContext,
+    ...TaskFlow,
+  });
+  const firstConfig = taskRows.at(0)?.provenance.config;
+  const assets = campaign.assets ?? [];
+
+  const configAsset = getAsset({
+    assets,
+    label: AssetLabel.task_config,
+  }).getOneOrNull();
+
+  const sourceEntityId = firstConfig?.inputs.at(0)?.id ?? null;
+  if (!configAsset) {
+    return {
+      campaign,
+      config: null,
+      sourceEntityId,
+    };
+  }
+
+  const rawConfig = await downloadAsset({
+    entityId: campaign.id,
+    entityType: EntityTypeDict.TaskConfig,
+    id: configAsset.id,
+    ctx: resolvedContext,
+    asRawResponse: true,
+  });
+  const config = await rawConfig.json();
+
+  return {
+    campaign,
+    config,
+    sourceEntityId,
+  };
+}
+
+export type TExtendedCircuitSynapticPhysiologyCampaignsType = AwaitedType<ReturnType<typeof list>>;
+
+export type TResolvedCircuitSynapticPhysiologyByCampaign = Awaited<ReturnType<typeof resolve>>;
+export type TResolvedCircuitSynapticPhysiologyByCampaigns = Awaited<ReturnType<typeof list>>;
+
+export const CircuitSynapticPhysiologyCampaign: EntityCoreTypeConfig<
+  ITaskConfig<TCircuitSynapticPhysiologyCampaignMeta>,
+  TResolvedCircuitSynapticPhysiologyByCampaign,
+  TResolvedCircuitSynapticPhysiologyByCampaigns
+> = {
+  group: EntityTypeGroup.Models,
+  title: 'Circuit synaptic physiology',
+  extendedType: ExtendedEntitiesTypeDict.CircuitSynapticPhysiologyCampaign,
+  type: EntityTypeDict.TaskConfig,
+  slug: EntitySlug.CircuitSynapticPhysiologyCampaign,
+  api: {
+    config: {
+      allowedFacets: true,
+      ilikeSearchEnabled: true,
+    },
+    query: {
+      list,
+      status,
+      resolve,
+      count: (params) => Task.count({ ...params, ...TaskFlow }),
+      one: (params) => getTaskConfig({ id: params.id, context: params.context }),
+      create: (data) => createTaskConfig({ data, context: data.context }),
+    },
+    expandRow: async (record, context) =>
+      rows({
+        campaign: record as ITaskConfig<TCircuitSynapticPhysiologyCampaignMeta>,
+        id: record.id,
+        context,
+      }),
+  },
+  asset: {
+    extension: 'application/json',
+  },
+  detailViewSections: [DetailViewSectionsDict.Overview],
+  isBookmarkable: false,
+  isDownloadable: false,
+  isCopyable: true,
+  isSimulatable: false,
+  isDeletable: false,
+} as const;

--- a/src/entity-configuration/domain/slug.ts
+++ b/src/entity-configuration/domain/slug.ts
@@ -25,6 +25,7 @@ export const ModelEntitySlug = {
   EmSynapseMappingCampaign: 'em-synapse-mapping-campaign',
   ExtracellularRecordingArray: 'extracellular-recording-array',
   ExtracellularRecordingArrayCampaign: 'extracellular-recording-array-campaign',
+  CircuitSynapticPhysiologyCampaign: 'circuit-synaptic-physiology-campaign',
 } as const;
 
 const SimulationEntitySlug = {

--- a/src/features/scan-config/types.ts
+++ b/src/features/scan-config/types.ts
@@ -118,6 +118,7 @@ export const SchemaNameDict = {
   // build
   EMSynapseMappingScanConfig: 'EMSynapseMappingScanConfig',
   ExtracellularRecordingArrayScanConfig: 'CreateExtracellularRecordingArrayScanConfig',
+  SynapseParameterizationScanConfig: 'SynapseParameterizationScanConfig',
   // processing
   SkeletonizationScanConfig: 'SkeletonizationScanConfig',
 } as const;

--- a/src/features/scan-config/workflow/definitions/build-circuit-synaptic-physiology.ts
+++ b/src/features/scan-config/workflow/definitions/build-circuit-synaptic-physiology.ts
@@ -1,0 +1,36 @@
+import { TaskActivityType } from '@/api/entitycore/types/entities/task-activity';
+import { TaskConfigType } from '@/api/entitycore/types/entities/task-config';
+import { ObiOneTaskTypeDict } from '@/api/one/types/task';
+import { CircuitSynapticPhysiologyCampaign } from '@/entity-configuration/domain/model/circuit-synaptic-physiology-campaign';
+import { ScanConfigCampaignOriginActionDict } from '@/features/scan-config/helpers';
+import { BuildScanConfigTabs, ScanConfigActivity } from '@/features/scan-config/types';
+import { defineScanConfigWorkflow } from '@/features/scan-config/workflow/define';
+import { ScanConfigEntitySourceMode } from '@/features/scan-config/workflow/types';
+
+export const buildCircuitSynapticPhysiologyWorkflow = defineScanConfigWorkflow({
+  id: 'build-circuit-synaptic-physiology',
+  activity: ScanConfigActivity.Build,
+  entity: {
+    mode: ScanConfigEntitySourceMode.Session,
+  },
+  campaign: {
+    resolve: async ({ id, context }) => {
+      // biome-ignore lint/style/noNonNullAssertion: resolve is defined on the campaign config
+      return await CircuitSynapticPhysiologyCampaign.api.query.resolve!({ id, context });
+    },
+  },
+  taskTypeBindings: {
+    obiOne: ObiOneTaskTypeDict.CircuitSynapticPhysiology,
+    configGeneration: TaskActivityType.CircuitSynapticPhysiologyConfigGeneration,
+    execution: TaskActivityType.CircuitSynapticPhysiologyExecution,
+    config: TaskConfigType.CircuitSynapticPhysiologyConfig,
+  },
+  editor: {
+    className: 'px-4',
+    campaignOriginAction: ScanConfigCampaignOriginActionDict.Task,
+    defaultTab: {
+      __activity: ScanConfigActivity.Build,
+      id: BuildScanConfigTabs.configuration,
+    },
+  },
+});

--- a/src/features/scan-config/workflow/definitions/index.ts
+++ b/src/features/scan-config/workflow/definitions/index.ts
@@ -38,6 +38,7 @@ export function defineSimulateCircuitScanConfigWorkflow({
   });
 }
 
+export { buildCircuitSynapticPhysiologyWorkflow } from '@/features/scan-config/workflow/definitions/build-circuit-synaptic-physiology';
 export { buildEmSynapseMappingWorkflow } from '@/features/scan-config/workflow/definitions/build-em-synapse-mapping';
 export { createExtracellularRecordingArrayWorkflow } from '@/features/scan-config/workflow/definitions/create-extracellular-recording-array';
 export { extractCircuitWorkflow } from '@/features/scan-config/workflow/definitions/extract-circuit';

--- a/src/ui/segments/workflows/config/activities/build.ts
+++ b/src/ui/segments/workflows/config/activities/build.ts
@@ -3,6 +3,7 @@ import { CircuitScaleDictionary } from '@/api/entitycore/types/entities/circuit'
 import { ExtendedEntitiesTypeDict } from '@/api/entitycore/types/extended-entity-type';
 import { extracellularRecordingArrayBuildFlag } from '@/features/feature-flags/flags';
 import { SchemaNameDict } from '@/features/scan-config/types';
+import { buildCircuitSynapticPhysiologyWorkflow } from '@/features/scan-config/workflow/definitions/build-circuit-synaptic-physiology';
 import { buildEmSynapseMappingWorkflow } from '@/features/scan-config/workflow/definitions/build-em-synapse-mapping';
 import { createExtracellularRecordingArrayWorkflow } from '@/features/scan-config/workflow/definitions/create-extracellular-recording-array';
 import {
@@ -13,12 +14,16 @@ import { EM_DENSE_RECONSTRUCTION_DATASET_TYPE } from '@/ui/segments/workflows/br
 import { EmSynapseMappingDatasetPrerequisiteCards } from '@/ui/segments/workflows/browse/prerequisite/em-synapse-mapping-dataset-cards';
 
 import {
+  buildCircuitSynapticPhysiologyConfigureBinding,
   buildEmSynapseMappingConfigureBinding,
   createExtracellularRecordingArrayConfigureBinding,
 } from '../scan-config-binding';
 import { WorkflowBrowseDefaults, WorkflowStagePresets } from '../types';
 
-import type { TBrowsePrerequisite } from '@/ui/segments/workflows/browse/browse-config';
+import type {
+  TBrowsePrerequisite,
+  TWorkflowBrowseConfig,
+} from '@/ui/segments/workflows/browse/browse-config';
 import type { IWorkflowDescriptor } from '../types';
 
 const emSynapseMappingPrerequisite: TBrowsePrerequisite = {
@@ -30,30 +35,59 @@ const emSynapseMappingPrerequisite: TBrowsePrerequisite = {
   presentation: { kind: 'custom', render: EmSynapseMappingDatasetPrerequisiteCards },
 };
 
-// circuit scales offered as the source of an extracellular recording array build.
-// limited to single-neuron up to microcircuit for now (22/06/2026).
-const EXTRACELLULAR_RECORDING_ARRAY_CIRCUIT_SCALES: string[] = [
+// circuit scales offered as the source of scale-capped circuit builds (extracellular recording
+// array, circuit synaptic physiology): limited to single-neuron up to small microcircuit.
+// stays aligned with the ScanConfigBuildWorkflow scale filter dropdown in
+// `entity-configuration/definitions/fields-defs/model.tsx`.
+const SMALL_SCALE_CIRCUIT_BUILD_SCALES: string[] = [
   CircuitScaleDictionary.Single,
   CircuitScaleDictionary.PairNeuron,
   CircuitScaleDictionary.SmallMicrocircuit,
 ];
 
 /**
- * resolves `scale__in` for the recording-array circuit browse: honour scales the user picked in the
+ * resolves `scale__in` for a scale-capped circuit browse: honour scales the user picked in the
  * filter panel but keep them within the allowed set; otherwise fall back to the full allowed set
  * keeps the workflow's scale ceiling while letting the user narrow within it
  */
-function resolveRecordingArrayCircuitScales(filters: Record<string, unknown>): string[] {
+function resolveSmallScaleCircuitBuildScales(filters: Record<string, unknown>): string[] {
   const requested = filters.scale__in;
   if (Array.isArray(requested)) {
     const within = requested.filter(
       (scale): scale is string =>
-        typeof scale === 'string' && EXTRACELLULAR_RECORDING_ARRAY_CIRCUIT_SCALES.includes(scale)
+        typeof scale === 'string' && SMALL_SCALE_CIRCUIT_BUILD_SCALES.includes(scale)
     );
     if (within.length > 0) return within;
   }
-  return EXTRACELLULAR_RECORDING_ARRAY_CIRCUIT_SCALES;
+  return SMALL_SCALE_CIRCUIT_BUILD_SCALES;
 }
+
+/** browse config for a circuit input capped to single → small-microcircuit scales */
+const smallScaleCircuitBrowseConfig = {
+  [ExtendedEntitiesTypeDict.Circuit]: {
+    loader: {
+      kind: 'custom' as const,
+      build:
+        () =>
+        ({ filters, withFacets, context }) =>
+          getCircuits({
+            context,
+            withFacets,
+            filters: { ...filters, scale__in: resolveSmallScaleCircuitBuildScales(filters) },
+          }),
+      facets: {
+        build:
+          () =>
+          ({ filters, context }) =>
+            getCircuits({
+              context,
+              withFacets: true,
+              filters: { ...filters, scale__in: resolveSmallScaleCircuitBuildScales(filters) },
+            }).then((response) => response?.facets),
+      },
+    },
+  },
+} satisfies TWorkflowBrowseConfig;
 
 export const BuildWorkflows: readonly IWorkflowDescriptor[] = [
   {
@@ -146,43 +180,44 @@ export const BuildWorkflows: readonly IWorkflowDescriptor[] = [
     },
     configurationInputs: [{ type: ExtendedEntitiesTypeDict.Circuit }],
     requireFilters: true,
-    // source circuits are limited to single-neuron up to microcircuit scale; a user scale filter is
-    // honoured but constrained to that allowed set (see resolveRecordingArrayCircuitScales)
-    browseConfig: {
-      [ExtendedEntitiesTypeDict.Circuit]: {
-        loader: {
-          kind: 'custom',
-          build:
-            () =>
-            ({ filters, withFacets, context }) =>
-              getCircuits({
-                context,
-                withFacets,
-                filters: { ...filters, scale__in: resolveRecordingArrayCircuitScales(filters) },
-              }),
-          facets: {
-            build:
-              () =>
-              ({ filters, context }) =>
-                getCircuits({
-                  context,
-                  withFacets: true,
-                  filters: { ...filters, scale__in: resolveRecordingArrayCircuitScales(filters) },
-                }).then((response) => response?.facets),
-          },
-        },
-      },
-    },
+    // source circuits are limited to single-neuron up to small-microcircuit scale; a user scale
+    // filter is honoured but constrained to that allowed set (see resolveSmallScaleCircuitBuildScales)
+    browseConfig: smallScaleCircuitBrowseConfig,
     order: 4,
     disabled: false,
     requiredFeatures: [extracellularRecordingArrayBuildFlag.key],
   },
   {
     ...WorkflowBrowseDefaults,
+    ...WorkflowStagePresets.ScanConfig,
+    sourceType: ExtendedEntitiesTypeDict.Circuit,
+    targetType: ExtendedEntitiesTypeDict.CircuitSynapticPhysiologyCampaign,
+    label: 'Circuit synaptic physiology',
+    breadcrumb: {
+      root: 'Circuit synaptic physiology build',
+      steps: {
+        selection: 'Select a circuit',
+      },
+    },
+    scanConfig: {
+      definition: buildCircuitSynapticPhysiologyWorkflow,
+      schemaName: SchemaNameDict.SynapseParameterizationScanConfig,
+      configureBinding: buildCircuitSynapticPhysiologyConfigureBinding(),
+    },
+    configurationInputs: [{ type: ExtendedEntitiesTypeDict.Circuit }],
+    requireFilters: true,
+    // source circuits are limited to single-neuron up to small-microcircuit scale; a user scale
+    // filter is honoured but constrained to that allowed set (see resolveSmallScaleCircuitBuildScales)
+    browseConfig: smallScaleCircuitBrowseConfig,
+    order: 5,
+    disabled: false,
+  },
+  {
+    ...WorkflowBrowseDefaults,
     ...WorkflowStagePresets.DirectConfigure,
     sourceType: ExtendedEntitiesTypeDict.SingleNeuronSynaptome,
     targetType: ExtendedEntitiesTypeDict.SingleNeuronSynaptome,
-    order: 5,
+    order: 6,
     disabled: false,
   },
   {
@@ -190,7 +225,7 @@ export const BuildWorkflows: readonly IWorkflowDescriptor[] = [
     ...WorkflowStagePresets.Disabled,
     sourceType: ExtendedEntitiesTypeDict.MemodelCircuit,
     targetType: ExtendedEntitiesTypeDict.MemodelCircuit,
-    order: 6,
+    order: 7,
     disabled: true,
   },
   {
@@ -198,7 +233,7 @@ export const BuildWorkflows: readonly IWorkflowDescriptor[] = [
     ...WorkflowStagePresets.Disabled,
     sourceType: ExtendedEntitiesTypeDict.PairedNeuronCircuit,
     targetType: ExtendedEntitiesTypeDict.PairedNeuronCircuit,
-    order: 7,
+    order: 8,
     disabled: true,
   },
   {
@@ -206,7 +241,7 @@ export const BuildWorkflows: readonly IWorkflowDescriptor[] = [
     ...WorkflowStagePresets.Disabled,
     sourceType: ExtendedEntitiesTypeDict.SmallMicrocircuit,
     targetType: ExtendedEntitiesTypeDict.SmallMicrocircuit,
-    order: 8,
+    order: 9,
     disabled: true,
   },
   {

--- a/src/ui/segments/workflows/config/entity-types.ts
+++ b/src/ui/segments/workflows/config/entity-types.ts
@@ -133,6 +133,13 @@ export const EntityTypeCatalog: Partial<Record<TExtendedEntitiesTypeDict, TEntit
     title: 'Electron Microscopy Circuit',
     description: 'Build a circuit campaign from an electron-microscopy cell morphology.',
   },
+  [ExtendedEntitiesTypeDict.CircuitSynapticPhysiologyCampaign]: {
+    value: ExtendedEntitiesTypeDict.CircuitSynapticPhysiologyCampaign,
+    group: EntityGroupDict.Circuit,
+    label: 'Circuit synaptic physiology',
+    title: 'Circuit synaptic physiology',
+    description: 'Generate or replace a physiological parameterization of an anatomical circuit.',
+  },
   [ExtendedEntitiesTypeDict.EMCellMesh]: {
     value: ExtendedEntitiesTypeDict.EMCellMesh,
     group: EntityGroupDict.Cellular,

--- a/src/ui/segments/workflows/config/scan-config-binding.ts
+++ b/src/ui/segments/workflows/config/scan-config-binding.ts
@@ -31,6 +31,7 @@ export const ScanConfigGeneratedApiPath = {
   EMSynapseMapping: 'em-synapse-mapping-scan-config-generate-grid',
   CreateExtracellularRecordingArray:
     'create-extracellular-recording-array-scan-config-generate-grid',
+  SynapseParameterization: 'synapse-parameterization-scan-config-generate-grid',
 } as const;
 
 /** Maps browse/session entity types to scan-config API, schema, and FromID wiring. */
@@ -205,6 +206,18 @@ export function createExtracellularRecordingArrayConfigureBinding(): TScanConfig
       [ExtendedEntitiesTypeDict.Circuit]: ScanConfigFromIdType.CircuitFromID,
     },
     generatedApiPath: ScanConfigGeneratedApiPath.CreateExtracellularRecordingArray,
+    schemaMappingKey: SchemaMappingKeyDict.Circuit,
+  };
+}
+
+export function buildCircuitSynapticPhysiologyConfigureBinding(): TScanConfigConfigureBinding {
+  return {
+    browseType: ExtendedEntitiesTypeDict.Circuit,
+    scanConfigEntityType: ExtendedEntitiesTypeDict.Circuit,
+    fromIdTypeByBrowseType: {
+      [ExtendedEntitiesTypeDict.Circuit]: ScanConfigFromIdType.CircuitFromID,
+    },
+    generatedApiPath: ScanConfigGeneratedApiPath.SynapseParameterization,
     schemaMappingKey: SchemaMappingKeyDict.Circuit,
   };
 }

--- a/src/ui/segments/workflows/config/workflow-labels.test.ts
+++ b/src/ui/segments/workflows/config/workflow-labels.test.ts
@@ -51,6 +51,7 @@ describe('workflow naming', () => {
       'Single neuron',
       'Electron microscopy circuit',
       'Extracellular recording array',
+      'Circuit synaptic physiology',
       'Synaptome (legacy)',
     ]);
   });

--- a/src/utils/url-builder.ts
+++ b/src/utils/url-builder.ts
@@ -116,6 +116,7 @@ const BASE_ENTITY_TYPE_FALLBACK: Partial<
   [ExtendedEntitiesTypeDict.BrainRegion]: ExtendedEntitiesTypeDict.Circuit,
   [ExtendedEntitiesTypeDict.IonChannelModelingCampaign]: ExtendedEntitiesTypeDict.IonChannelModel,
   [ExtendedEntitiesTypeDict.EmSynapseMappingCampaign]: ExtendedEntitiesTypeDict.Circuit,
+  [ExtendedEntitiesTypeDict.CircuitSynapticPhysiologyCampaign]: ExtendedEntitiesTypeDict.Circuit,
 };
 
 export function resolveConcreteEntityPathParam(extendedType?: TExtendedEntitiesTypeDict) {


### PR DESCRIPTION
configure and launch synaptic parameterization
for circuits of scale ≤ small microcircuit via the obi-one generate-grid and task launch endpoints.

related: https://github.com/openbraininstitute/prod-build-circuit/issues/44