### PR TITLE
fix(circuit-nodes): migrate nodes grid off legacy AG Grid CSS

### DIFF
--- a/src/features/circuit-nodes/circuit-nodes-table.module.css
+++ b/src/features/circuit-nodes/circuit-nodes-table.module.css
@@ -114,6 +114,14 @@
   color: var(--color-dark);
 }
 
+/* Let antd Select/Dropdown popups (anchored inside the custom filter popover
+   via getPopupContainer) escape the ag-grid popup's clipping bounds. */
+.grid :global(.ag-popup-child),
+.grid :global(.ag-filter),
+.grid :global(.ag-filter-wrapper) {
+  overflow: visible;
+}
+
 .centered {
   flex: 1 1 auto;
   display: flex;

--- a/src/features/circuit-nodes/components/nodes-grid.css
+++ b/src/features/circuit-nodes/components/nodes-grid.css
@@ -1,7 +1,0 @@
-/* Let antd Select/Dropdown popups (anchored inside the custom filter popover
-   via getPopupContainer) escape the ag-grid popup's clipping bounds. */
-.ag-theme-quartz .ag-popup-child,
-.ag-theme-quartz .ag-filter,
-.ag-theme-quartz .ag-filter-wrapper {
-  overflow: visible;
-}

--- a/src/features/circuit-nodes/components/nodes-grid.tsx
+++ b/src/features/circuit-nodes/components/nodes-grid.tsx
@@ -28,10 +28,6 @@ const PREFERRED_NAME_SET = new Set(PREFERRED_COLUMNS.map((p) => p.name));
 
 const CATEGORICAL_SET_FILTER_MAX = 100;
 
-import 'ag-grid-community/styles/ag-grid.css';
-import 'ag-grid-community/styles/ag-theme-quartz.css';
-import '@/features/circuit-nodes/components/nodes-grid.css';
-
 import styles from '@/features/circuit-nodes/circuit-nodes-table.module.css';
 
 type Props = {
@@ -194,7 +190,7 @@ export function NodesGrid({
   }, [columns, visibleColumns]);
 
   return (
-    <div className={`ag-theme-quartz ${styles.gridWrapper}`}>
+    <div className={styles.gridWrapper}>
       <div className={styles.gridHeader}>
         <span className={styles.gridStat}>
           {filteredCount === null ? (
@@ -210,7 +206,6 @@ export function NodesGrid({
       <div className={styles.grid}>
         <AgGridReact
           ref={gridRef}
-          theme="legacy"
           columnDefs={columnDefs}
           rowModelType="infinite"
           cacheBlockSize={200}


### PR DESCRIPTION

the workflows activity table sometimes renders squashed because
the circuit nodes table imported AG Grid's legacy v32 CSS files
